### PR TITLE
AmberScript: Parse BUFFER commands.

### DIFF
--- a/docs/amber_script.md
+++ b/docs/amber_script.md
@@ -15,12 +15,12 @@ TODO(dneto): What characters are valid in a name?
 ### Number literals
 
 Literal numbers are normally presented in decimal form.  They are interpreted
-as integers or floating point depending on context: a command parameter is predefined
-as either integral or floating point, or the data type is user-specified (such
-as for buffer data).
+as integers or floating point depending on context: a command parameter is
+predefined as either integral or floating point, or the data type is
+user-specified (such as for buffer data).
 
-Hex values: Whenever an integer is expected, you may use a hexadecimal number, which
-is the characters `0x` followed by hexadecimal digits.
+Hex values: Whenever an integer is expected, you may use a hexadecimal number,
+which is the characters `0x` followed by hexadecimal digits.
 
 ### Shaders
 
@@ -65,7 +65,7 @@ END
  * float
  * double
  * vec[2,3,4]\<type>
- * mat[2,3,4]\<type>    -- useful?
+ * mat[2,3,4]x[2,3,4]\<type>    -- useful?
 
 TODO(dneto): Support half-precision floating point.
 
@@ -77,7 +77,6 @@ Sized arrays and structures are not currently representable.
  * vertex
  * index
  * sampled
- * storage
  * color
  * depth
 
@@ -90,10 +89,12 @@ BUFFER <buffer_type> <name> DATA_TYPE <type> DATA
 <value>+
 END
 
-BUFFER <buffer_type> <name> DATA_TYPE <type> SIZE <size_in_bytes> <initializer>
+BUFFER <buffer_type> <name> DATA_TYPE <type> SIZE <size_in_items> <initializer>
 
 BUFFER framebuffer <name> DIMS <width_in_pixels> <height_in_pixels>
 ```
+
+TODO(dsinclair): Does framebuffer need a format attached to it?
 
 #### Buffer Initializers
 Fill the buffer with a single value.
@@ -177,7 +178,7 @@ Bind a provided framebuffer.
 Descriptor sets can be bound as:
 
 ```
-  DESCRIPTOR_SET <id> BINDING <id> IDX <0> TO <buffer_name>
+  DESCRIPTOR_SET <id> BINDING <id> IDX <val> TO <buffer_name>
 ```
 
 ### Run a pipeline.
@@ -330,7 +331,7 @@ PIPELINE graphics kGreenPipeline
   ENTRY_POINT kFragmentShader green
 END  # pipeline
 
-RUN kRedPipeline DRAW_RECT POS 0 0  SIZE 256 256
+RUN kRedPipeline DRAW_RECT POS 0 0 SIZE 256 256
 RUN kGreenPipeline DRAW_RECT POS 128 128 SIZE 256 256
 
 EXPECT kFrameBuffer IDX 0 0 SIZE 127 127 EQ_RGB 255 0 0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@
 set(AMBER_SOURCES
     amber.cc
     amber_impl.cc
+    amberscript/buffer.cc
     amberscript/executor.cc
     amberscript/parser.cc
     amberscript/pipeline.cc
@@ -64,8 +65,10 @@ if (${Dawn_FOUND})
 endif()
 
 set(TEST_SRCS
+    amberscript/buffer_test.cc
     amberscript/parser_test.cc
     amberscript/pipeline_test.cc
+    amberscript/script_test.cc
     command_data_test.cc
     result_test.cc
     shader_compiler_test.cc

--- a/src/amberscript/buffer.cc
+++ b/src/amberscript/buffer.cc
@@ -1,0 +1,25 @@
+// Copyright 2018 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/amberscript/buffer.h"
+
+namespace amber {
+namespace amberscript {
+
+Buffer::Buffer(BufferType type) : buffer_type_(type) {}
+
+Buffer::~Buffer() = default;
+
+}  // namespace amberscript
+}  // namespace amber

--- a/src/amberscript/buffer.h
+++ b/src/amberscript/buffer.h
@@ -1,0 +1,70 @@
+// Copyright 2018 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SRC_AMBERSCRIPT_BUFFER_H_
+#define SRC_AMBERSCRIPT_BUFFER_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "src/datum_type.h"
+#include "src/value.h"
+
+namespace amber {
+namespace amberscript {
+
+enum class BufferType : uint8_t {
+  kColor = 0,
+  kDepth,
+  kFramebuffer,
+  kIndex,
+  kSampled,
+  kStorage,
+  kUniform,
+  kVertex
+};
+
+class Buffer {
+ public:
+  explicit Buffer(BufferType type);
+  ~Buffer();
+
+  BufferType GetBufferType() const { return buffer_type_; }
+
+  void SetName(const std::string& name) { name_ = name; }
+  std::string GetName() const { return name_; }
+
+  void SetDatumType(const DatumType& type) { datum_type_ = type; }
+  const DatumType& GetDatumType() const { return datum_type_; }
+
+  void SetSize(size_t size) { size_ = size; }
+  size_t GetSize() const { return size_; }
+  size_t GetSizeInBytes() const { return size_ * datum_type_.SizeInBytes(); }
+
+  void SetData(std::vector<Value>&& data) { data_ = std::move(data); }
+  const std::vector<Value>& GetData() const { return data_; }
+
+ private:
+  BufferType buffer_type_;
+  DatumType datum_type_;
+  std::vector<Value> data_;
+  std::string name_;
+  size_t size_ = 0;
+};
+
+}  // namespace amberscript
+}  // namespace amber
+
+#endif  // SRC_AMBERSCRIPT_BUFFER_H_

--- a/src/amberscript/buffer_test.cc
+++ b/src/amberscript/buffer_test.cc
@@ -1,0 +1,54 @@
+// Copyright 2018 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/amberscript/buffer.h"
+#include "gtest/gtest.h"
+
+namespace amber {
+namespace amberscript {
+
+using BufferTest = testing::Test;
+
+TEST_F(BufferTest, BufferEmptyByDefault) {
+  Buffer b(BufferType::kColor);
+  EXPECT_EQ(static_cast<size_t>(0U), b.GetSize());
+  EXPECT_EQ(static_cast<size_t>(0U), b.GetSizeInBytes());
+}
+
+TEST_F(BufferTest, BufferSize) {
+  DatumType type;
+  type.SetType(DataType::kInt16);
+
+  Buffer b(BufferType::kColor);
+  b.SetDatumType(type);
+  b.SetSize(10);
+  EXPECT_EQ(10, b.GetSize());
+  EXPECT_EQ(2 * 10, b.GetSizeInBytes());
+}
+
+TEST_F(BufferTest, BufferSizeMatrix) {
+  DatumType type;
+  type.SetType(DataType::kInt16);
+  type.SetRowCount(2);
+  type.SetColumnCount(3);
+
+  Buffer b(BufferType::kColor);
+  b.SetDatumType(type);
+  b.SetSize(10);
+  EXPECT_EQ(10, b.GetSize());
+  EXPECT_EQ(2 * 10 * 3 * 2, b.GetSizeInBytes());
+}
+
+}  // namespace amberscript
+}  // namespace amber

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -15,6 +15,7 @@
 #include "src/amberscript/parser.h"
 
 #include <cassert>
+#include <limits>
 
 #include "src/make_unique.h"
 #include "src/tokenizer.h"
@@ -42,10 +43,12 @@ Result Parser::Parse(const std::string& data) {
 
     Result r;
     std::string tok = token->AsString();
-    if (tok == "SHADER") {
-      r = ParseShaderBlock();
+    if (tok == "BUFFER") {
+      r = ParseBuffer();
     } else if (tok == "PIPELINE") {
       r = ParsePipelineBlock();
+    } else if (tok == "SHADER") {
+      r = ParseShaderBlock();
     } else {
       r = Result("unknown token: " + tok);
     }
@@ -98,6 +101,90 @@ Result Parser::ToPipelineType(const std::string& str, PipelineType* type) {
     *type = PipelineType::kGraphics;
   else
     return Result("unknown pipeline type: " + str);
+  return {};
+}
+
+Result Parser::ToDatumType(const std::string& str, DatumType* type) {
+  assert(type);
+
+  if (str == "int8") {
+    type->SetType(DataType::kInt8);
+  } else if (str == "int16") {
+    type->SetType(DataType::kInt16);
+  } else if (str == "int32") {
+    type->SetType(DataType::kInt32);
+  } else if (str == "int64") {
+    type->SetType(DataType::kInt64);
+  } else if (str == "uint8") {
+    type->SetType(DataType::kUint8);
+  } else if (str == "uint16") {
+    type->SetType(DataType::kUint16);
+  } else if (str == "uint32") {
+    type->SetType(DataType::kUint32);
+  } else if (str == "uint64") {
+    type->SetType(DataType::kUint64);
+  } else if (str == "float") {
+    type->SetType(DataType::kFloat);
+  } else if (str == "double") {
+    type->SetType(DataType::kDouble);
+  } else if (str.length() > 7 && str.substr(0, 3) == "vec") {
+    if (str[4] != '<' || str[str.length() - 1] != '>')
+      return Result("invalid data_type provided");
+
+    if (str[3] == '2')
+      type->SetRowCount(2);
+    else if (str[3] == '3')
+      type->SetRowCount(3);
+    else if (str[3] == '4')
+      type->SetRowCount(4);
+    else
+      return Result("invalid data_type provided");
+
+    DatumType subtype;
+    Result r = ToDatumType(str.substr(5, str.length() - 6), &subtype);
+    if (!r.IsSuccess())
+      return r;
+
+    if (subtype.RowCount() > 1 || subtype.ColumnCount() > 1)
+      return Result("invalid data_type provided");
+
+    type->SetType(subtype.GetType());
+
+  } else if (str.length() > 9 && str.substr(0, 3) == "mat") {
+    if (str[4] != 'x' || str[6] != '<' || str[str.length() - 1] != '>')
+      return Result("invalid data_type provided");
+
+    if (str[3] == '2')
+      type->SetRowCount(2);
+    else if (str[3] == '3')
+      type->SetRowCount(3);
+    else if (str[3] == '4')
+      type->SetRowCount(4);
+    else
+      return Result("invalid data_type provided");
+
+    if (str[5] == '2')
+      type->SetColumnCount(2);
+    else if (str[5] == '3')
+      type->SetColumnCount(3);
+    else if (str[5] == '4')
+      type->SetColumnCount(4);
+    else
+      return Result("invalid data_type provided");
+
+    DatumType subtype;
+    Result r = ToDatumType(str.substr(7, str.length() - 8), &subtype);
+    if (!r.IsSuccess())
+      return r;
+
+    if (subtype.RowCount() > 1 || subtype.ColumnCount() > 1)
+      return Result("invalid data_type provided");
+
+    type->SetType(subtype.GetType());
+  } else {
+    return Result("invalid data_type provided");
+  }
+
   return {};
 }
 
@@ -303,6 +390,278 @@ Result Parser::ParsePipelineShaderOptimizations(Pipeline* pipeline) {
     return r;
 
   return ValidateEndOfStatement("SHADER_OPTIMIZATION command");
+}
+
+Result Parser::ToBufferType(const std::string& str, BufferType* type) {
+  assert(type);
+
+  if (str == "color")
+    *type = BufferType::kColor;
+  else if (str == "depth")
+    *type = BufferType::kDepth;
+  else if (str == "framebuffer")
+    *type = BufferType::kFramebuffer;
+  else if (str == "index")
+    *type = BufferType::kIndex;
+  else if (str == "sampled")
+    *type = BufferType::kSampled;
+  else if (str == "storage")
+    *type = BufferType::kStorage;
+  else if (str == "uniform")
+    *type = BufferType::kUniform;
+  else if (str == "vertex")
+    *type = BufferType::kVertex;
+  else
+    return Result("unknown BUFFER type provided: " + str);
+
+  return {};
+}
+
+Result Parser::ParseBuffer() {
+  auto token = tokenizer_->NextToken();
+  if (!token->IsString())
+    return Result("invalid BUFFER type provided");
+
+  BufferType type;
+  Result r = ToBufferType(token->AsString(), &type);
+  if (!r.IsSuccess())
+    return r;
+
+  auto buffer = MakeUnique<Buffer>(type);
+
+  token = tokenizer_->NextToken();
+  if (!token->IsString())
+    return Result("invalid BUFFER name provided");
+
+  auto& name = token->AsString();
+  if (name == "DATA_TYPE" || name == "DIMS")
+    return Result("missing BUFFER name");
+
+  buffer->SetName(token->AsString());
+
+  token = tokenizer_->NextToken();
+  if (!token->IsString())
+    return Result("invalid BUFFER command provided");
+
+  auto& cmd = token->AsString();
+  if (cmd == "DATA_TYPE") {
+    if (type == BufferType::kFramebuffer)
+      return Result("BUFFER framebuffer must be used with DIMS");
+
+    r = ParseBufferInitializer(buffer.get());
+    if (!r.IsSuccess())
+      return r;
+  } else if (cmd == "DIMS") {
+    if (type != BufferType::kFramebuffer)
+      return Result("BUFFER DIMS can only be used with a framebuffer");
+
+    r = ParseBufferFramebuffer(buffer.get());
+    if (!r.IsSuccess())
+      return r;
+  } else {
+    return Result("unknown BUFFER command provided: " + cmd);
+  }
+
+  r = script_.AddBuffer(std::move(buffer));
+  if (!r.IsSuccess())
+    return r;
+
+  return {};
+}
+
+Result Parser::ParseBufferFramebuffer(Buffer* buffer) {
+  auto token = tokenizer_->NextToken();
+  if (token->IsEOL() || token->IsEOS())
+    return Result("BUFFER framebuffer missing DIMS values");
+  if (!token->IsInteger())
+    return Result("BUFFER framebuffer invalid width value");
+
+  // TODO(dsinclair): Is uint32 rgba the right format to use here?
+  DatumType datum;
+  datum.SetType(DataType::kUint32);
+  datum.SetColumnCount(4);
+  buffer->SetDatumType(datum);
+
+  auto w = token->AsUint32();
+
+  token = tokenizer_->NextToken();
+  if (token->IsEOS() || token->IsEOL())
+    return Result("BUFFER framebuffer missing height value");
+  if (!token->IsInteger())
+    return Result("BUFFER framebuffer invalid height value");
+
+  auto h = token->AsUint32();
+
+  // TODO(dsinclair): Should this be a smaller maximum size?
+  uint64_t size = static_cast<uint64_t>(w) * static_cast<uint64_t>(h);
+  if (size >= std::numeric_limits<uint32_t>::max())
+    return Result("BUFFER framebuffer size too large");
+
+  buffer->SetSize(static_cast<size_t>(size));
+  return ValidateEndOfStatement("BUFFER framebuffer command");
+}
+
+Result Parser::ParseBufferInitializer(Buffer* buffer) {
+  auto token = tokenizer_->NextToken();
+  if (!token->IsString())
+    return Result("BUFFER invalid data type");
+
+  DatumType type;
+  Result r = ToDatumType(token->AsString(), &type);
+  if (!r.IsSuccess())
+    return r;
+
+  buffer->SetDatumType(type);
+
+  token = tokenizer_->NextToken();
+  if (!token->IsString())
+    return Result("BUFFER missing initializer");
+
+  if (token->AsString() == "SIZE")
+    return ParseBufferInitializerSize(buffer);
+  if (token->AsString() == "DATA")
+    return ParseBufferInitializerData(buffer);
+
+  return Result("unknown initializer for BUFFER");
+}
+
+Result Parser::ParseBufferInitializerSize(Buffer* buffer) {
+  auto token = tokenizer_->NextToken();
+  if (token->IsEOS() || token->IsEOL())
+    return Result("BUFFER size missing");
+  if (!token->IsInteger())
+    return Result("BUFFER size invalid");
+
+  uint32_t size_in_items = token->AsUint32();
+  buffer->SetSize(size_in_items);
+
+  token = tokenizer_->NextToken();
+  if (!token->IsString())
+    return Result("BUFFER invalid initializer");
+
+  if (token->AsString() == "FILL")
+    return ParseBufferInitializerFill(buffer, size_in_items);
+  if (token->AsString() == "SERIES_FROM")
+    return ParseBufferInitializerSeries(buffer, size_in_items);
+
+  return Result("invalid BUFFER initializer provided");
+}
+
+Result Parser::ParseBufferInitializerFill(Buffer* buffer,
+                                          uint32_t size_in_items) {
+  auto token = tokenizer_->NextToken();
+  if (token->IsEOS() || token->IsEOL())
+    return Result("missing BUFFER fill value");
+  if (!token->IsInteger() && !token->IsDouble())
+    return Result("invalid BUFFER fill value");
+
+  auto& type = buffer->GetDatumType();
+  bool is_double_data = type.IsFloat() || type.IsDouble();
+
+  // Inflate the size because our items are multi-dimensional.
+  size_in_items = size_in_items * type.RowCount() * type.ColumnCount();
+
+  std::vector<Value> values;
+  values.resize(size_in_items);
+  for (size_t i = 0; i < size_in_items; ++i) {
+    if (is_double_data)
+      values[i].SetDoubleValue(token->AsDouble());
+    else
+      values[i].SetIntValue(token->AsUint64());
+  }
+  buffer->SetData(std::move(values));
+  return ValidateEndOfStatement("BUFFER fill command");
+}
+
+Result Parser::ParseBufferInitializerSeries(Buffer* buffer,
+                                            uint32_t size_in_items) {
+  auto token = tokenizer_->NextToken();
+  if (token->IsEOS() || token->IsEOL())
+    return Result("missing BUFFER series_from value");
+  if (!token->IsInteger() && !token->IsDouble())
+    return Result("invalid BUFFER series_from value");
+
+  auto& type = buffer->GetDatumType();
+  if (type.RowCount() > 1 || type.ColumnCount() > 1)
+    return Result("BUFFER series_from must not be multi-row/column types");
+
+  bool is_double_data = type.IsFloat() || type.IsDouble();
+
+  Value counter;
+  if (is_double_data)
+    counter.SetDoubleValue(token->AsDouble());
+  else
+    counter.SetIntValue(token->AsUint64());
+
+  token = tokenizer_->NextToken();
+  if (!token->IsString())
+    return Result("missing BUFFER series_from inc_by");
+  if (token->AsString() != "INC_BY")
+    return Result("BUFFER series_from invalid command");
+
+  token = tokenizer_->NextToken();
+  if (token->IsEOS() || token->IsEOL())
+    return Result("missing BUFFER series_from inc_by value");
+  if (!token->IsInteger() && !token->IsDouble())
+    return Result("invalid BUFFER series_from inc_by value");
+
+  std::vector<Value> values;
+  values.resize(size_in_items);
+  for (size_t i = 0; i < size_in_items; ++i) {
+    if (is_double_data) {
+      double value = counter.AsDouble();
+      values[i].SetDoubleValue(value);
+      counter.SetDoubleValue(value + token->AsDouble());
+    } else {
+      uint64_t value = counter.AsUint64();
+      values[i].SetIntValue(value);
+      counter.SetIntValue(value + token->AsUint64());
+    }
+  }
+  buffer->SetData(std::move(values));
+  return ValidateEndOfStatement("BUFFER series_from command");
+}
+
+Result Parser::ParseBufferInitializerData(Buffer* buffer) {
+  auto token = tokenizer_->NextToken();
+  if (!token->IsEOL())
+    return Result("extra parameters after BUFFER data command");
+
+  auto& type = buffer->GetDatumType();
+  bool is_double_type = type.IsFloat() || type.IsDouble();
+
+  std::vector<Value> values;
+  for (token = tokenizer_->NextToken();; token = tokenizer_->NextToken()) {
+    if (token->IsEOL())
+      continue;
+    if (token->IsEOS())
+      return Result("missing BUFFER END command");
+    if (token->IsString() && token->AsString() == "END")
+      break;
+    if (!token->IsInteger() && !token->IsDouble() && !token->IsHex())
+      return Result("invalid BUFFER data value");
+
+    if (!is_double_type && token->IsDouble())
+      return Result("invalid BUFFER data value");
+
+    Value v;
+    if (is_double_type) {
+      double val = token->IsHex() ? static_cast<double>(token->AsHex())
+                                  : token->AsDouble();
+      v.SetDoubleValue(val);
+    } else {
+      uint64_t val = token->IsHex() ? token->AsHex() : token->AsUint64();
+      v.SetIntValue(val);
+    }
+
+    values.emplace_back(v);
+  }
+
+  size_t size_in_items = values.size() / type.RowCount() / type.ColumnCount();
+  buffer->SetSize(size_in_items);
+
+  buffer->SetData(std::move(values));
+  return ValidateEndOfStatement("BUFFER data command");
 }
 
 }  // namespace amberscript

--- a/src/amberscript/parser.h
+++ b/src/amberscript/parser.h
@@ -41,10 +41,19 @@ class Parser : public amber::Parser {
  private:
   std::string make_error(const std::string& err);
   Result ToShaderType(const std::string& str, ShaderType* type);
+  Result ToBufferType(const std::string& str, BufferType* type);
   Result ToShaderFormat(const std::string& str, ShaderFormat* fmt);
+  Result ToDatumType(const std::string& str, DatumType* type);
   Result ToPipelineType(const std::string& str, PipelineType* type);
   Result ValidateEndOfStatement(const std::string& name);
 
+  Result ParseBuffer();
+  Result ParseBufferInitializer(Buffer*);
+  Result ParseBufferInitializerSize(Buffer*);
+  Result ParseBufferInitializerFill(Buffer*, uint32_t);
+  Result ParseBufferInitializerSeries(Buffer*, uint32_t);
+  Result ParseBufferInitializerData(Buffer*);
+  Result ParseBufferFramebuffer(Buffer*);
   Result ParseShaderBlock();
   Result ParsePipelineBlock();
   Result ParsePipelineAttach(Pipeline*);

--- a/src/amberscript/script.h
+++ b/src/amberscript/script.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <vector>
 
+#include "src/amberscript/buffer.h"
 #include "src/amberscript/pipeline.h"
 #include "src/amberscript/shader.h"
 #include "src/script.h"
@@ -55,6 +56,19 @@ class Script : public amber::Script {
     return pipelines_;
   }
 
+  Result AddBuffer(std::unique_ptr<Buffer> buffer) {
+    if (name_to_buffer_.count(buffer->GetName()) > 0)
+      return Result("duplicate buffer name provided");
+
+    buffers_.push_back(std::move(buffer));
+    name_to_buffer_[buffers_.back()->GetName()] = buffers_.back().get();
+    return {};
+  }
+
+  const std::vector<std::unique_ptr<Buffer>>& GetBuffers() const {
+    return buffers_;
+  }
+
   Shader* GetShader(const std::string& name) const {
     auto it = name_to_shader_.find(name);
     return it == name_to_shader_.end() ? nullptr : it->second;
@@ -65,11 +79,18 @@ class Script : public amber::Script {
     return it == name_to_pipeline_.end() ? nullptr : it->second;
   }
 
+  Buffer* GetBuffer(const std::string& name) const {
+    auto it = name_to_buffer_.find(name);
+    return it == name_to_buffer_.end() ? nullptr : it->second;
+  }
+
  private:
   std::map<std::string, Shader*> name_to_shader_;
   std::map<std::string, Pipeline*> name_to_pipeline_;
+  std::map<std::string, Buffer*> name_to_buffer_;
   std::vector<std::unique_ptr<Shader>> shaders_;
   std::vector<std::unique_ptr<Pipeline>> pipelines_;
+  std::vector<std::unique_ptr<Buffer>> buffers_;
 };
 
 }  // namespace amberscript

--- a/src/amberscript/script_test.cc
+++ b/src/amberscript/script_test.cc
@@ -1,0 +1,246 @@
+// Copyright 2018 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/amberscript/script.h"
+#include "gtest/gtest.h"
+#include "src/amberscript/buffer.h"
+#include "src/amberscript/pipeline.h"
+#include "src/amberscript/shader.h"
+#include "src/make_unique.h"
+
+namespace amber {
+namespace amberscript {
+
+using ScriptTest = testing::Test;
+
+TEST_F(ScriptTest, AddShader) {
+  auto shader = MakeUnique<Shader>(ShaderType::kVertex);
+  shader->SetName("My Shader");
+
+  Script s;
+  Result r = s.AddShader(std::move(shader));
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+}
+
+TEST_F(ScriptTest, AddDuplicateShader) {
+  auto shader1 = MakeUnique<Shader>(ShaderType::kVertex);
+  shader1->SetName("My Shader");
+
+  Script s;
+  Result r = s.AddShader(std::move(shader1));
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto shader2 = MakeUnique<Shader>(ShaderType::kFragment);
+  shader2->SetName("My Shader");
+
+  r = s.AddShader(std::move(shader2));
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("duplicate shader name provided", r.Error());
+}
+
+TEST_F(ScriptTest, GetShader) {
+  auto shader = MakeUnique<Shader>(ShaderType::kVertex);
+  shader->SetName("My Shader");
+
+  auto* ptr = shader.get();
+
+  Script s;
+  Result r = s.AddShader(std::move(shader));
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  EXPECT_EQ(ptr, s.GetShader("My Shader"));
+}
+
+TEST_F(ScriptTest, GetMissingShader) {
+  Script s;
+  EXPECT_TRUE(s.GetShader("My Shader") == nullptr);
+}
+
+TEST_F(ScriptTest, GetShadersEmpty) {
+  Script s;
+  const auto& shaders = s.GetShaders();
+  EXPECT_TRUE(shaders.empty());
+}
+
+TEST_F(ScriptTest, GetShaders) {
+  auto shader1 = MakeUnique<Shader>(ShaderType::kVertex);
+  shader1->SetName("My Shader");
+
+  const auto* ptr1 = shader1.get();
+
+  Script s;
+  Result r = s.AddShader(std::move(shader1));
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto shader2 = MakeUnique<Shader>(ShaderType::kFragment);
+  shader2->SetName("My Fragment");
+
+  const auto* ptr2 = shader2.get();
+
+  r = s.AddShader(std::move(shader2));
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  const auto& shaders = s.GetShaders();
+  ASSERT_EQ(2U, shaders.size());
+  EXPECT_EQ(ptr1, shaders[0].get());
+  EXPECT_EQ(ptr2, shaders[1].get());
+}
+
+TEST_F(ScriptTest, AddPipeline) {
+  auto pipeline = MakeUnique<Pipeline>(PipelineType::kCompute);
+  pipeline->SetName("my_pipeline");
+
+  Script s;
+  Result r = s.AddPipeline(std::move(pipeline));
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+}
+
+TEST_F(ScriptTest, AddDuplicatePipeline) {
+  auto pipeline1 = MakeUnique<Pipeline>(PipelineType::kCompute);
+  pipeline1->SetName("my_pipeline");
+
+  Script s;
+  Result r = s.AddPipeline(std::move(pipeline1));
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto pipeline2 = MakeUnique<Pipeline>(PipelineType::kGraphics);
+  pipeline2->SetName("my_pipeline");
+  r = s.AddPipeline(std::move(pipeline2));
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("duplicate pipeline name provided", r.Error());
+}
+
+TEST_F(ScriptTest, GetPipeline) {
+  auto pipeline = MakeUnique<Pipeline>(PipelineType::kCompute);
+  pipeline->SetName("my_pipeline");
+
+  const auto* ptr = pipeline.get();
+
+  Script s;
+  Result r = s.AddPipeline(std::move(pipeline));
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  EXPECT_EQ(ptr, s.GetPipeline("my_pipeline"));
+}
+
+TEST_F(ScriptTest, GetMissingPipeline) {
+  Script s;
+  EXPECT_TRUE(s.GetPipeline("my_pipeline") == nullptr);
+}
+
+TEST_F(ScriptTest, GetPipelinesEmpty) {
+  Script s;
+  const auto& pipelines = s.GetPipelines();
+  EXPECT_TRUE(pipelines.empty());
+}
+
+TEST_F(ScriptTest, GetPipelines) {
+  auto pipeline1 = MakeUnique<Pipeline>(PipelineType::kCompute);
+  pipeline1->SetName("my_pipeline1");
+
+  const auto* ptr1 = pipeline1.get();
+
+  Script s;
+  Result r = s.AddPipeline(std::move(pipeline1));
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto pipeline2 = MakeUnique<Pipeline>(PipelineType::kGraphics);
+  pipeline2->SetName("my_pipeline2");
+
+  const auto* ptr2 = pipeline2.get();
+
+  r = s.AddPipeline(std::move(pipeline2));
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  const auto& pipelines = s.GetPipelines();
+  ASSERT_EQ(2U, pipelines.size());
+  EXPECT_EQ(ptr1, pipelines[0].get());
+  EXPECT_EQ(ptr2, pipelines[1].get());
+}
+
+TEST_F(ScriptTest, AddBuffer) {
+  auto buffer = MakeUnique<Buffer>(BufferType::kStorage);
+  buffer->SetName("my_buffer");
+
+  Script s;
+  Result r = s.AddBuffer(std::move(buffer));
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+}
+
+TEST_F(ScriptTest, AddDuplicateBuffer) {
+  auto buffer1 = MakeUnique<Buffer>(BufferType::kStorage);
+  buffer1->SetName("my_buffer");
+
+  Script s;
+  Result r = s.AddBuffer(std::move(buffer1));
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto buffer2 = MakeUnique<Buffer>(BufferType::kUniform);
+  buffer2->SetName("my_buffer");
+
+  r = s.AddBuffer(std::move(buffer2));
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("duplicate buffer name provided", r.Error());
+}
+
+TEST_F(ScriptTest, GetBuffer) {
+  auto buffer = MakeUnique<Buffer>(BufferType::kStorage);
+  buffer->SetName("my_buffer");
+
+  const auto* ptr = buffer.get();
+
+  Script s;
+  Result r = s.AddBuffer(std::move(buffer));
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  EXPECT_EQ(ptr, s.GetBuffer("my_buffer"));
+}
+
+TEST_F(ScriptTest, GetMissingBuffer) {
+  Script s;
+  EXPECT_TRUE(s.GetBuffer("my_buffer") == nullptr);
+}
+
+TEST_F(ScriptTest, GetBuffersEmpty) {
+  Script s;
+  const auto& buffers = s.GetBuffers();
+  EXPECT_TRUE(buffers.empty());
+}
+
+TEST_F(ScriptTest, GetBuffers) {
+  auto buffer1 = MakeUnique<Buffer>(BufferType::kStorage);
+  buffer1->SetName("my_buffer1");
+
+  const auto* ptr1 = buffer1.get();
+
+  Script s;
+  Result r = s.AddBuffer(std::move(buffer1));
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto buffer2 = MakeUnique<Buffer>(BufferType::kUniform);
+  buffer2->SetName("my_buffer2");
+
+  const auto* ptr2 = buffer2.get();
+
+  r = s.AddBuffer(std::move(buffer2));
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  const auto& buffers = s.GetBuffers();
+  ASSERT_EQ(2U, buffers.size());
+  EXPECT_EQ(ptr1, buffers[0].get());
+  EXPECT_EQ(ptr2, buffers[1].get());
+}
+
+}  // namespace amberscript
+}  // namespace amber

--- a/src/datum_type.cc
+++ b/src/datum_type.cc
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include "src/datum_type.h"
 
 namespace amber {
@@ -20,5 +21,23 @@ DatumType::DatumType() = default;
 DatumType::~DatumType() = default;
 
 DatumType& DatumType::operator=(const DatumType&) = default;
+
+size_t DatumType::SizeInBytes() const {
+  size_t s;
+  if (type_ == DataType::kInt8 || type_ == DataType::kUint8)
+    s = 1;
+  else if (type_ == DataType::kInt16 || type_ == DataType::kUint16)
+    s = 2;
+  else if (type_ == DataType::kInt32 || type_ == DataType::kUint32)
+    s = 4;
+  else if (type_ == DataType::kInt64 || type_ == DataType::kUint64)
+    s = 8;
+  else if (type_ == DataType::kFloat)
+    s = sizeof(float);
+  else
+    s = sizeof(double);
+
+  return s * column_count_ * row_count_;
+}
 
 }  // namespace amber

--- a/src/datum_type.h
+++ b/src/datum_type.h
@@ -15,6 +15,7 @@
 #ifndef SRC_DATUM_TYPE_H_
 #define SRC_DATUM_TYPE_H_
 
+#include <cstddef>
 #include <cstdint>
 
 namespace amber {
@@ -58,6 +59,8 @@ class DatumType {
 
   void SetRowCount(uint32_t count) { row_count_ = count; }
   uint32_t RowCount() const { return row_count_; }
+
+  size_t SizeInBytes() const;
 
  private:
   DataType type_ = DataType::kUint8;


### PR DESCRIPTION
This CL adds parsing for the various buffer commands available in
AmberScript.
```
BUFFER vertex my_buf DATA_TYPE vec2<int32> SIZE 5 FILL 0
BUFFER index my_buf DATA_TYPE int32 SIZE 5 SERIES_FROM 2 INC_BY 1
BUFFER framebuffer my_frame DIMS 256 256
BUFFER storage my_store DATA_TYPE uint32 DATA
1 2 3 4 5
END
```
For each type, the internal buffer will be filled with the data before
it leaves the parser.

Fixes #5