### PR TITLE
Add kokoro build files.

### DIFF
--- a/kokoro/check-format/build.sh
+++ b/kokoro/check-format/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e  # fail on error
+set -x  # display commands
+
+BUILD_ROOT=$PWD
+SRC=$PWD/github/amber
+
+# Get clang-format-5.0.0.
+# Once kokoro upgrades the Ubuntu VMs, we can use 'apt-get install clang-format'
+curl -L http://releases.llvm.org/5.0.0/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04.tar.xz -o clang-llvm.tar.xz
+tar xf clang-llvm.tar.xz
+export PATH=$PWD/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04/bin:$PATH
+
+cd $SRC
+curl -L http://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format-diff.py -o tools/clang-format-diff.py;
+
+echo $(date): Check formatting...
+./tools/check_code_format.sh;
+echo $(date): check completed.

--- a/kokoro/check-format/presubmit_check_format.cfg
+++ b/kokoro/check-format/presubmit_check_format.cfg
@@ -1,0 +1,15 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "amber/kokoro/check-format/build.sh"

--- a/kokoro/linux-clang-debug/build.sh
+++ b/kokoro/linux-clang-debug/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e  # fail on error
+set -x  # display commands
+
+SCRIPT_DIR=`dirname "$BASH_SOURCE"`
+source $SCRIPT_DIR/../scripts/linux/build.sh DEBUG clang

--- a/kokoro/linux-clang-debug/continuous.cfg
+++ b/kokoro/linux-clang-debug/continuous.cfg
@@ -1,0 +1,15 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "amber/kokoro/linux-clang-debug/build.sh"

--- a/kokoro/linux-clang-debug/presubmit.cfg
+++ b/kokoro/linux-clang-debug/presubmit.cfg
@@ -1,0 +1,15 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "amber/kokoro/linux-clang-debug/build.sh"

--- a/kokoro/linux-clang-release/build.sh
+++ b/kokoro/linux-clang-release/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e  # fail on error
+set -x  # display commands
+
+SCRIPT_DIR=`dirname "$BASH_SOURCE"`
+source $SCRIPT_DIR/../scripts/linux/build.sh RELEASE clang

--- a/kokoro/linux-clang-release/continuous.cfg
+++ b/kokoro/linux-clang-release/continuous.cfg
@@ -1,0 +1,15 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "amber/kokoro/linux-clang-release/build.sh"

--- a/kokoro/linux-clang-release/presubmit.cfg
+++ b/kokoro/linux-clang-release/presubmit.cfg
@@ -1,0 +1,15 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "amber/kokoro/linux-clang-release/build.sh"

--- a/kokoro/linux-gcc-debug/build.sh
+++ b/kokoro/linux-gcc-debug/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e  # fail on error
+set -x  # display commands
+
+SCRIPT_DIR=`dirname "$BASH_SOURCE"`
+source $SCRIPT_DIR/../scripts/linux/build.sh DEBUG gcc

--- a/kokoro/linux-gcc-debug/continuous.cfg
+++ b/kokoro/linux-gcc-debug/continuous.cfg
@@ -1,0 +1,15 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "amber/kokoro/linux-gcc-debug/build.sh"

--- a/kokoro/linux-gcc-debug/presubmit.cfg
+++ b/kokoro/linux-gcc-debug/presubmit.cfg
@@ -1,0 +1,15 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "amber/kokoro/linux-gcc-debug/build.sh"

--- a/kokoro/linux-gcc-release/build.sh
+++ b/kokoro/linux-gcc-release/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e  # fail on error
+set -x  # display commands
+
+SCRIPT_DIR=`dirname "$BASH_SOURCE"`
+source $SCRIPT_DIR/../scripts/linux/build.sh RELEASE gcc

--- a/kokoro/linux-gcc-release/continuous.cfg
+++ b/kokoro/linux-gcc-release/continuous.cfg
@@ -1,0 +1,15 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "amber/kokoro/linux-gcc-release/build.sh"

--- a/kokoro/linux-gcc-release/presubmit.cfg
+++ b/kokoro/linux-gcc-release/presubmit.cfg
@@ -1,0 +1,15 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "amber/kokoro/linux-gcc-release/build.sh"

--- a/kokoro/macos-clang-debug/build.sh
+++ b/kokoro/macos-clang-debug/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e  # fail on error
+set -x  # display commands
+
+SCRIPT_DIR=`dirname "$BASH_SOURCE"`
+source $SCRIPT_DIR/../scripts/macos/build.sh DEBUG clang

--- a/kokoro/macos-clang-debug/continuous.cfg
+++ b/kokoro/macos-clang-debug/continuous.cfg
@@ -1,0 +1,15 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "amber/kokoro/macos-clang-debug/build.sh"

--- a/kokoro/macos-clang-debug/presubmit.cfg
+++ b/kokoro/macos-clang-debug/presubmit.cfg
@@ -1,0 +1,15 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "amber/kokoro/macos-clang-debug/build.sh"

--- a/kokoro/macos-clang-release/build.sh
+++ b/kokoro/macos-clang-release/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e  # fail on error
+set -x  # display commands
+
+SCRIPT_DIR=`dirname "$BASH_SOURCE"`
+source $SCRIPT_DIR/../scripts/macos/build.sh RELEASE clang

--- a/kokoro/macos-clang-release/continuous.cfg
+++ b/kokoro/macos-clang-release/continuous.cfg
@@ -1,0 +1,15 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "amber/kokoro/macos-clang-release/build.sh"

--- a/kokoro/macos-clang-release/presubmit.cfg
+++ b/kokoro/macos-clang-release/presubmit.cfg
@@ -1,0 +1,15 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "amber/kokoro/macos-clang-release/build.sh"

--- a/tools/check_code_format.sh
+++ b/tools/check_code_format.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2018 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Script to determine if source code in Pull Request is properly formatted.
+# Exits with non 0 exit code if formatting is needed.
+#
+# This script assumes to be invoked at the project root directory.
+
+FILES_TO_CHECK=$(git diff --name-only master | grep -E ".*\.(cpp|cc|c\+\+|cxx|c|h|hpp)$")
+
+if [ -z "${FILES_TO_CHECK}" ]; then
+  echo "No source code to check for formatting."
+  exit 0
+fi
+
+FORMAT_DIFF=$(git diff -U0 master -- ${FILES_TO_CHECK} | python ./tools/clang-format-diff.py -p1 -style=file)
+
+if [ -z "${FORMAT_DIFF}" ]; then
+  echo "All source code in PR properly formatted."
+  exit 0
+else
+  echo "Found formatting errors!"
+  echo "${FORMAT_DIFF}"
+  exit 1
+fi


### PR DESCRIPTION
This CL adds the build files for Linux {gcc|clang} and Mac clang builds
in both Debug and Release mode.

Issue #3