### PR TITLE
Update image layout properly

### DIFF
--- a/src/vulkan/frame_buffer.h
+++ b/src/vulkan/frame_buffer.h
@@ -20,6 +20,12 @@
 namespace amber {
 namespace vulkan {
 
+enum class FrameImageState : uint8_t {
+  kInit = 0,
+  kClearOrDraw,
+  kProbe,
+};
+
 class FrameBuffer {
  public:
   FrameBuffer(VkDevice device, uint32_t width, uint32_t height);
@@ -31,12 +37,15 @@ class FrameBuffer {
                     const VkPhysicalDeviceMemoryProperties& properties);
   void Shutdown();
 
+  void ChangeFrameImageLayout(VkCommandBuffer command, FrameImageState layout);
+
   VkFramebuffer GetFrameBuffer() const { return frame_; }
   const void* GetColorBufferPtr() const {
     return color_image_->HostAccessibleMemoryPtr();
   }
   VkImage GetColorImage() const { return color_image_->GetVkImage(); }
   Result CopyColorImageToHost(VkCommandBuffer command) {
+    ChangeFrameImageLayout(command, FrameImageState::kProbe);
     return color_image_->CopyToHost(command);
   }
 
@@ -51,6 +60,7 @@ class FrameBuffer {
   uint32_t width_ = 0;
   uint32_t height_ = 0;
   uint32_t depth_ = 1;
+  FrameImageState frame_image_layout_ = FrameImageState::kInit;
 };
 
 }  // namespace vulkan

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -408,6 +408,9 @@ Result GraphicsPipeline::ClearBuffer(const VkClearValue& clear_value,
   if (!r.IsSuccess())
     return r;
 
+  frame_->ChangeFrameImageLayout(command_->GetCommandBuffer(),
+                                 FrameImageState::kClearOrDraw);
+
   // TODO(jaebaek): When multiple clear and draw commands exist, handle
   //                begin/end render pass properly.
   ActivateRenderPassIfNeeded();
@@ -443,6 +446,9 @@ Result GraphicsPipeline::Draw() {
   r = command_->BeginIfNotInRecording();
   if (!r.IsSuccess())
     return r;
+
+  frame_->ChangeFrameImageLayout(command_->GetCommandBuffer(),
+                                 FrameImageState::kClearOrDraw);
 
   ActivateRenderPassIfNeeded();
 

--- a/src/vulkan/image.cc
+++ b/src/vulkan/image.cc
@@ -187,6 +187,7 @@ void Image::ChangeLayout(VkCommandBuffer command,
                               VK_ACCESS_TRANSFER_WRITE_BIT;
       break;
     default:
+      barrier.srcAccessMask = 0;
       break;
   }
 
@@ -218,6 +219,7 @@ void Image::ChangeLayout(VkCommandBuffer command,
                               VK_ACCESS_TRANSFER_WRITE_BIT;
       break;
     default:
+      barrier.dstAccessMask = 0;
       break;
   }
 

--- a/src/vulkan/image.h
+++ b/src/vulkan/image.h
@@ -41,6 +41,12 @@ class Image : public Resource {
 
   // TODO(jaebaek): Implement CopyToDevice
 
+  void ChangeLayout(VkCommandBuffer command,
+                    VkImageLayout old_layout,
+                    VkImageLayout new_layout,
+                    VkPipelineStageFlags from,
+                    VkPipelineStageFlags to);
+
   // Resource
   VkDeviceMemory GetHostAccessMemory() const override {
     if (is_image_host_accessible_)


### PR DESCRIPTION
Image layout of FrameBuffer for color attachment should have its layout as
`VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL` when we clear
or draw something on it. The one of depth/stencil attachment should have
`VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL`.

When we probe it, its layout must be
`VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL`. Note that we do not
change its layout to `VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL`
explicitly because the render pass will do.

Issue #7 