### PR TITLE
Vulkan: Always create secondary buffer for image (#8)

### DIFF
--- a/src/vulkan/image.cc
+++ b/src/vulkan/image.cc
@@ -75,11 +75,10 @@ Result Image::Initialize(VkImageUsageFlags usage) {
   if (!r.IsSuccess())
     return r;
 
-  if (CheckMemoryHostAccessible(allocate_result.memory_type_index)) {
-    is_image_host_accessible_ = true;
-    return MapMemory(memory_);
-  }
-
+  // For images, we always make a secondary buffer. When the tiling of an image
+  // is optimal, read/write data from CPU does not show correct values. We need
+  // a secondary buffer to convert the GPU-optimial data to CPU-readable data
+  // and vice versa.
   is_image_host_accessible_ = false;
   return Resource::Initialize();
 }


### PR DESCRIPTION
Image with tiling optimal may have data in a format that is not
readable by CPU. Since the default image tiling of Amber is optimal,
we must always create secondary buffer for backing image.