### PR TITLE
Vulkan: add memory barrier (#9)

### DIFF
--- a/src/vulkan/buffer.cc
+++ b/src/vulkan/buffer.cc
@@ -68,6 +68,7 @@ void Buffer::CopyToDevice(VkCommandBuffer command) {
   region.size = GetSize();
 
   vkCmdCopyBuffer(command, GetHostAccessibleBuffer(), buffer_, 1, &region);
+  MemoryBarrier(command);
 }
 
 void Buffer::Shutdown() {

--- a/src/vulkan/image.cc
+++ b/src/vulkan/image.cc
@@ -144,6 +144,7 @@ Result Image::CopyToHost(VkCommandBuffer command) {
   vkCmdCopyImageToBuffer(command, image_, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                          GetHostAccessibleBuffer(), 1, &copy_region);
 
+  MemoryBarrier(command);
   return {};
 }
 

--- a/src/vulkan/resource.cc
+++ b/src/vulkan/resource.cc
@@ -21,6 +21,30 @@
 
 namespace amber {
 namespace vulkan {
+namespace {
+
+VkMemoryBarrier kMemoryBarrierForAll = {
+    VK_STRUCTURE_TYPE_MEMORY_BARRIER, nullptr,
+    VK_ACCESS_INDIRECT_COMMAND_READ_BIT | VK_ACCESS_INDEX_READ_BIT |
+        VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | VK_ACCESS_UNIFORM_READ_BIT |
+        VK_ACCESS_INPUT_ATTACHMENT_READ_BIT | VK_ACCESS_SHADER_READ_BIT |
+        VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+        VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+        VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+        VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT |
+        VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT |
+        VK_ACCESS_HOST_READ_BIT | VK_ACCESS_HOST_WRITE_BIT,
+    VK_ACCESS_INDIRECT_COMMAND_READ_BIT | VK_ACCESS_INDEX_READ_BIT |
+        VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | VK_ACCESS_UNIFORM_READ_BIT |
+        VK_ACCESS_INPUT_ATTACHMENT_READ_BIT | VK_ACCESS_SHADER_READ_BIT |
+        VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+        VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+        VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+        VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT |
+        VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT |
+        VK_ACCESS_HOST_READ_BIT | VK_ACCESS_HOST_WRITE_BIT};
+
+}  // namespace
 
 Resource::Resource(VkDevice device,
                    size_t size,
@@ -203,6 +227,32 @@ Result Resource::MapMemory(VkDeviceMemory memory) {
 
 void Resource::UnMapMemory(VkDeviceMemory memory) {
   vkUnmapMemory(device_, memory);
+}
+
+void Resource::MemoryBarrier(VkCommandBuffer command) {
+  // TODO(jaebaek): Current memory barrier is natively implemented.
+  // Update it with the following access flags:
+  // (r = read, w = write)
+  //
+  //                                 Host           Device
+  // VertexBuffer                  host w         vertex r
+  //                           transfer w       transfer r
+  //
+  // IndexBuffer                   host w          index r
+  //                           transfer w       transfer r
+  //
+  // FrameBuffer                   host r          color w
+  //                                       depth/stencil w
+  //                           transfer r       transfer w
+  //
+  // ReadWrite Descriptors       host r/w       shader r/w
+  //                         transfer r/w     transfer r/w
+  //
+  // ReadOnly Descriptors          host w         shader r
+  //                           transfer w       transfer r
+  vkCmdPipelineBarrier(command, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                       VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 1,
+                       &kMemoryBarrierForAll, 0, nullptr, 0, nullptr);
 }
 
 }  // namespace vulkan

--- a/src/vulkan/resource.h
+++ b/src/vulkan/resource.h
@@ -71,6 +71,10 @@ class Resource {
   Result MapMemory(VkDeviceMemory memory);
   void UnMapMemory(VkDeviceMemory memory);
 
+  // Make all memory operations before calling this method effective i.e.,
+  // prevent hazards caused by out-of-order execution.
+  void MemoryBarrier(VkCommandBuffer command);
+
  private:
   uint32_t ChooseMemory(uint32_t memory_type_bits,
                         VkMemoryPropertyFlags flags,


### PR DESCRIPTION
Draw after sending vertex data is not guaranteed currently, as well
as probe after copying frame buffer to host accessible buffer.

This CL adds a memory barrier after copying to the device or to the host
to make sure that memory updates are complete when we access the
associated buffers.

Fixes #9 