### PR TITLE
Vulkan: allow probe without draw or clear

### DIFF
--- a/tests/cases/probe_without_clear_command.expect_fail.amber
+++ b/tests/cases/probe_without_clear_command.expect_fail.amber
@@ -1,0 +1,30 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[vertex shader passthrough]
+
+[fragment shader]
+#version 430
+
+layout(location = 0) in vec4 color_in;
+layout(location = 0) out vec4 color_out;
+
+void
+main()
+{
+  color_out = color_in;
+}
+
+[test]
+relative probe rect rgba (0.0, 0.0, 1.0, 1.0) (0.1, 0.2, 0.3, 0.4)

--- a/tests/cases/probe_without_clear_command.expect_fail.amber
+++ b/tests/cases/probe_without_clear_command.expect_fail.amber
@@ -28,3 +28,7 @@ main()
 
 [test]
 relative probe rect rgba (0.0, 0.0, 1.0, 1.0) (0.1, 0.2, 0.3, 0.4)
+
+# Expected result: assert failure with the following message
+# "FrameBuffer::ChangeFrameImageLayout new layout cannot be kProbe "
+# "from kInit"


### PR DESCRIPTION
See tests/cases/probe_without_clear_command.expect_fail.amber.
We must allow probe without clear or draw even though it may
result in test failures.