### PR TITLE
Vulkan: fix memory corruption for creating graphics pipeline

### DIFF
--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -182,7 +182,7 @@ Result GraphicsPipeline::CreateVkGraphicsPipeline() {
   VkVertexInputBindingDescription vertex_binding_desc = {};
   if (vertex_buffer_) {
     vertex_binding_desc = vertex_buffer_->GetVertexInputBinding();
-    auto vertex_attr_desc = vertex_buffer_->GetVertexInputAttr();
+    const auto& vertex_attr_desc = vertex_buffer_->GetVertexInputAttr();
 
     vertex_input_info.pVertexBindingDescriptions = &vertex_binding_desc;
     vertex_input_info.vertexAttributeDescriptionCount =


### PR DESCRIPTION
An address of an object passed to vkCreateGraphicsPipelines is in
stack and it disappears when we call the API. It results in memory
corruption.

Fixes #44