### PR TITLE
Make the Buffer code common

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,12 +15,12 @@
 set(AMBER_SOURCES
     amber.cc
     amber_impl.cc
-    amberscript/buffer.cc
     amberscript/executor.cc
     amberscript/parser.cc
     amberscript/pipeline.cc
     amberscript/script.cc
     amberscript/shader.cc
+    buffer.cc
     command.cc
     command_data.cc
     datum_type.cc
@@ -65,10 +65,10 @@ if (${Dawn_FOUND})
 endif()
 
 set(TEST_SRCS
-    amberscript/buffer_test.cc
     amberscript/parser_test.cc
     amberscript/pipeline_test.cc
     amberscript/script_test.cc
+    buffer_test.cc
     command_data_test.cc
     result_test.cc
     shader_compiler_test.cc

--- a/src/amberscript/script.h
+++ b/src/amberscript/script.h
@@ -19,9 +19,9 @@
 #include <memory>
 #include <vector>
 
-#include "src/amberscript/buffer.h"
 #include "src/amberscript/pipeline.h"
 #include "src/amberscript/shader.h"
+#include "src/buffer.h"
 #include "src/script.h"
 
 namespace amber {

--- a/src/amberscript/script_test.cc
+++ b/src/amberscript/script_test.cc
@@ -14,9 +14,9 @@
 
 #include "src/amberscript/script.h"
 #include "gtest/gtest.h"
-#include "src/amberscript/buffer.h"
 #include "src/amberscript/pipeline.h"
 #include "src/amberscript/shader.h"
+#include "src/buffer.h"
 #include "src/make_unique.h"
 
 namespace amber {

--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "src/amberscript/buffer.h"
+#include "src/buffer.h"
 
 namespace amber {
-namespace amberscript {
 
 Buffer::Buffer(BufferType type) : buffer_type_(type) {}
 
 Buffer::~Buffer() = default;
 
-}  // namespace amberscript
 }  // namespace amber

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -12,29 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SRC_AMBERSCRIPT_BUFFER_H_
-#define SRC_AMBERSCRIPT_BUFFER_H_
+#ifndef SRC_BUFFER_H_
+#define SRC_BUFFER_H_
 
 #include <cstdint>
 #include <string>
 #include <vector>
 
+#include "src/buffer_data.h"
 #include "src/datum_type.h"
 #include "src/value.h"
 
 namespace amber {
-namespace amberscript {
-
-enum class BufferType : uint8_t {
-  kColor = 0,
-  kDepth,
-  kFramebuffer,
-  kIndex,
-  kSampled,
-  kStorage,
-  kUniform,
-  kVertex
-};
 
 class Buffer {
  public:
@@ -64,7 +53,6 @@ class Buffer {
   size_t size_ = 0;
 };
 
-}  // namespace amberscript
 }  // namespace amber
 
 #endif  // SRC_AMBERSCRIPT_BUFFER_H_

--- a/src/buffer_data.h
+++ b/src/buffer_data.h
@@ -17,7 +17,16 @@
 
 namespace amber {
 
-enum class BufferType { kFramebuffer = 0, kVertexData, kIndices };
+enum class BufferType : uint8_t {
+  kColor = 0,
+  kDepth,
+  kFramebuffer,
+  kIndex,
+  kSampled,
+  kStorage,
+  kUniform,
+  kVertex
+};
 
 }  // namespace amber
 

--- a/src/buffer_test.cc
+++ b/src/buffer_test.cc
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "src/amberscript/buffer.h"
+#include "src/buffer.h"
 #include "gtest/gtest.h"
 
 namespace amber {
-namespace amberscript {
 
 using BufferTest = testing::Test;
 
@@ -50,5 +49,4 @@ TEST_F(BufferTest, BufferSizeMatrix) {
   EXPECT_EQ(2 * 10 * 3 * 2, b.GetSizeInBytes());
 }
 
-}  // namespace amberscript
 }  // namespace amber

--- a/src/vkscript/executor.cc
+++ b/src/vkscript/executor.cc
@@ -83,7 +83,7 @@ Result Executor::Execute(Engine* engine, const amber::Script* src_script) {
           values.push_back(cell.GetValue(z));
       }
 
-      r = engine->SetBuffer(BufferType::kVertexData, headers[i].location,
+      r = engine->SetBuffer(BufferType::kVertex, headers[i].location,
                             *(headers[i].format), values);
       if (!r.IsSuccess())
         return r;
@@ -95,13 +95,8 @@ Result Executor::Execute(Engine* engine, const amber::Script* src_script) {
     if (!node->IsIndices())
       continue;
 
-    std::vector<Value> values;
-    for (uint16_t index : node->AsIndices()->Indices()) {
-      values.push_back(Value());
-      values.back().SetIntValue(index);
-    }
-
-    r = engine->SetBuffer(BufferType::kIndices, 0, Format(), values);
+    r = engine->SetBuffer(BufferType::kIndex, 0, Format(),
+                          node->AsIndices()->Indices());
     if (!r.IsSuccess())
       return r;
   }

--- a/src/vkscript/executor_test.cc
+++ b/src/vkscript/executor_test.cc
@@ -931,7 +931,7 @@ TEST_F(VkScriptExecutorTest, VertexData) {
 
   EXPECT_EQ(FormatType::kR32G32B32_SFLOAT,
             stub->GetBufferFormat(0)->GetFormatType());
-  EXPECT_EQ(BufferType::kVertexData, stub->GetBufferType(0));
+  EXPECT_EQ(BufferType::kVertex, stub->GetBufferType(0));
   EXPECT_EQ(9U, stub->GetBufferLocation(0));
 
   const auto& data1 = stub->GetBufferValues(0);
@@ -944,7 +944,7 @@ TEST_F(VkScriptExecutorTest, VertexData) {
 
   EXPECT_EQ(FormatType::kR8G8B8_UNORM,
             stub->GetBufferFormat(1)->GetFormatType());
-  EXPECT_EQ(BufferType::kVertexData, stub->GetBufferType(1));
+  EXPECT_EQ(BufferType::kVertex, stub->GetBufferType(1));
   EXPECT_EQ(1U, stub->GetBufferLocation(1));
 
   const auto& data2 = stub->GetBufferValues(1);
@@ -973,7 +973,7 @@ TEST_F(VkScriptExecutorTest, IndexBuffer) {
   auto stub = ToStub(engine.get());
   ASSERT_EQ(1U, stub->GetBufferCallCount());
 
-  EXPECT_EQ(BufferType::kIndices, stub->GetBufferType(0));
+  EXPECT_EQ(BufferType::kIndex, stub->GetBufferType(0));
 
   const auto& data = stub->GetBufferValues(0);
   std::vector<uint8_t> results = {1, 2, 3, 4, 5, 6};

--- a/src/vkscript/nodes.cc
+++ b/src/vkscript/nodes.cc
@@ -71,8 +71,8 @@ void RequireNode::AddRequirement(Feature feature,
   requirements_.emplace_back(feature, std::move(format));
 }
 
-IndicesNode::IndicesNode(const std::vector<uint16_t>& indices)
-    : Node(NodeType::kIndices), indices_(indices) {}
+IndicesNode::IndicesNode(std::unique_ptr<Buffer> buffer)
+    : Node(NodeType::kIndices), buffer_(std::move(buffer)) {}
 
 IndicesNode::~IndicesNode() = default;
 

--- a/src/vkscript/nodes.h
+++ b/src/vkscript/nodes.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <vector>
 
+#include "src/buffer.h"
 #include "src/command.h"
 #include "src/feature.h"
 #include "src/format.h"
@@ -105,13 +106,13 @@ class RequireNode : public Node {
 
 class IndicesNode : public Node {
  public:
-  IndicesNode(const std::vector<uint16_t>& indices);
+  IndicesNode(std::unique_ptr<Buffer> buffer);
   ~IndicesNode() override;
 
-  const std::vector<uint16_t>& Indices() const { return indices_; }
+  const std::vector<Value>& Indices() const { return buffer_->GetData(); }
 
  private:
-  std::vector<uint16_t> indices_;
+  std::unique_ptr<Buffer> buffer_;
 };
 
 class VertexDataNode : public Node {

--- a/src/vkscript/parser.cc
+++ b/src/vkscript/parser.cc
@@ -286,7 +286,6 @@ Result Parser::ProcessIndicesBlock(const std::string& data) {
     auto b = MakeUnique<Buffer>(BufferType::kIndex);
     b->SetData(std::move(indices));
     script_.AddIndexBuffer(std::move(b));
-    ;
   }
 
   return {};

--- a/src/vkscript/parser.cc
+++ b/src/vkscript/parser.cc
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <limits>
 
+#include "src/make_unique.h"
 #include "src/shader_compiler.h"
 #include "src/tokenizer.h"
 #include "src/vkscript/command_parser.h"
@@ -262,7 +263,7 @@ Result Parser::ProcessRequireBlock(const std::string& data) {
 }
 
 Result Parser::ProcessIndicesBlock(const std::string& data) {
-  std::vector<uint16_t> indices;
+  std::vector<Value> indices;
 
   Tokenizer tokenizer(data);
   for (auto token = tokenizer.NextToken(); !token->IsEOS();
@@ -277,11 +278,16 @@ Result Parser::ProcessIndicesBlock(const std::string& data) {
       return Result("Value too large in indices block");
     }
 
-    indices.push_back(token->AsUint16());
+    indices.push_back(Value());
+    indices.back().SetIntValue(token->AsUint16());
   }
 
-  if (!indices.empty())
-    script_.AddIndices(indices);
+  if (!indices.empty()) {
+    auto b = MakeUnique<Buffer>(BufferType::kIndex);
+    b->SetData(std::move(indices));
+    script_.AddIndexBuffer(std::move(b));
+    ;
+  }
 
   return {};
 }

--- a/src/vkscript/parser_test.cc
+++ b/src/vkscript/parser_test.cc
@@ -237,9 +237,12 @@ TEST_F(VkScriptParserTest, IndicesBlock) {
   auto& indices = nodes[0]->AsIndices()->Indices();
   ASSERT_EQ(3U, indices.size());
 
-  EXPECT_EQ(1, indices[0]);
-  EXPECT_EQ(2, indices[1]);
-  EXPECT_EQ(3, indices[2]);
+  EXPECT_TRUE(indices[0].IsInteger());
+  EXPECT_EQ(1, indices[0].AsUint16());
+  EXPECT_TRUE(indices[1].IsInteger());
+  EXPECT_EQ(2, indices[1].AsUint16());
+  EXPECT_TRUE(indices[2].IsInteger());
+  EXPECT_EQ(3, indices[2].AsUint16());
 }
 
 TEST_F(VkScriptParserTest, IndicesBlockMultipleLines) {
@@ -263,7 +266,8 @@ TEST_F(VkScriptParserTest, IndicesBlockMultipleLines) {
   auto& indices = nodes[0]->AsIndices()->Indices();
   ASSERT_EQ(results.size(), indices.size());
   for (size_t i = 0; i < results.size(); ++i) {
-    EXPECT_EQ(results[i], indices[i]);
+    EXPECT_TRUE(indices[i].IsInteger());
+    EXPECT_EQ(results[i], indices[i].AsUint16());
   }
 }
 

--- a/src/vkscript/script.cc
+++ b/src/vkscript/script.cc
@@ -38,8 +38,8 @@ void Script::AddShader(ShaderType type, std::vector<uint32_t> shader) {
   test_nodes_.push_back(MakeUnique<ShaderNode>(type, std::move(shader)));
 }
 
-void Script::AddIndices(const std::vector<uint16_t>& indices) {
-  test_nodes_.push_back(MakeUnique<IndicesNode>(indices));
+void Script::AddIndexBuffer(std::unique_ptr<Buffer> buffer) {
+  test_nodes_.push_back(MakeUnique<IndicesNode>(std::move(buffer)));
 }
 
 void Script::AddVertexData(std::unique_ptr<VertexDataNode> node) {

--- a/src/vkscript/script.h
+++ b/src/vkscript/script.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <vector>
 
+#include "src/buffer.h"
 #include "src/command.h"
 #include "src/make_unique.h"
 #include "src/script.h"
@@ -37,7 +38,7 @@ class Script : public amber::Script {
 
   void AddRequireNode(std::unique_ptr<RequireNode> node);
   void AddShader(ShaderType, std::vector<uint32_t>);
-  void AddIndices(const std::vector<uint16_t>& indices);
+  void AddIndexBuffer(std::unique_ptr<Buffer> b);
   void AddVertexData(std::unique_ptr<VertexDataNode> node);
   void SetTestCommands(std::vector<std::unique_ptr<Command>> commands);
 

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -326,7 +326,7 @@ void GraphicsPipeline::SetBuffer(BufferType type,
                                  const Format& format,
                                  const std::vector<Value>& values) {
   // TODO(jaebaek): Handle indices data.
-  if (type != BufferType::kVertexData)
+  if (type != BufferType::kVertex)
     return;
 
   if (!vertex_buffer_)


### PR DESCRIPTION
This CL moves the AmberScript Buffer to be shared with VkScript. The
Indices data is moved to be stored in a Buffer and passed as needed.