### PR TITLE
Roll DEPS; Fixup build issues.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,6 @@ if (POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW)
 endif()
 
-if (POLICY CMP0048)
-  cmake_policy(SET CMP0048 NEW)
-endif()
-
 project(amber)
 enable_testing()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ if (POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW)
 endif()
 
+if (POLICY CMP0048)
+  cmake_policy(SET CMP0048 NEW)
+endif()
+
 project(amber)
 enable_testing()
 
@@ -43,7 +47,6 @@ include(src/vulkan/find_vulkan.cmake)
 add_definitions(-DAMBER_ENGINE_VULKAN=$<BOOL:${Vulkan_FOUND}>)
 add_definitions(-DAMBER_ENGINE_DAWN=$<BOOL:${Dawn_FOUND}>)
 
-
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
   message(STATUS "No build type selected, default to Debug")
   set(CMAKE_BUILD_TYPE "Debug")
@@ -57,29 +60,31 @@ endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set(CUSTOM_CXX_FLAGS
-      ${CUSTOM_CXX_FLAGS}
-      -std=c++11
-      -Wall
-      -Werror
-      -Weverything
-      -Wextra
-      -Wno-c++98-compat
-      -Wno-c++98-compat-pedantic
-      -Wno-padded
-      -Wno-switch-enum
-      -Wno-unknown-pragmas
-      -Wno-unknown-warning-option)
+    ${CUSTOM_CXX_FLAGS}
+    -std=c++11
+    -fvisibility=hidden
+    -Wall
+    -Werror
+    -Weverything
+    -Wextra
+    -Wno-c++98-compat
+    -Wno-c++98-compat-pedantic
+    -Wno-padded
+    -Wno-switch-enum
+    -Wno-unknown-pragmas
+    -Wno-unknown-warning-option)
 
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set(CUSTOM_CXX_FLAGS
-      ${CUSTOM_CXX_FLAGS}
-      -Wall
-      -std=c++11
-      -Werror
-      -Wextra
-      -Wno-unknown-pragmas
-      -Wpedantic
-      -pedantic-errors)
+    ${CUSTOM_CXX_FLAGS}
+    -std=c++11
+    -fvisibility=hidden
+    -Wall
+    -Werror
+    -Wextra
+    -Wno-unknown-pragmas
+    -Wpedantic
+    -pedantic-errors)
 elseif(MSVC)
   # We don't want to have to copy the C Runtime DLL everywhere the executable
   # goes.  So compile code to assume the CRT is statically linked, i.e. use
@@ -89,22 +94,23 @@ elseif(MSVC)
   else()
     set(CUSTOM_CXX_FLAGS ${CUSTOM_CXX_FLAGS} /MT)
   endif()
+
   set(CUSTOM_CXX_FLAGS
-      ${CUSTOM_CXX_FLAGS}
-      /bigobj
-      /EHsc
-      /W3
-      /WX
-      /wd4068
-      /wd4514
-      /wd4571
-      /wd4625
-      /wd4626
-      /wd4710
-      /wd4774
-      /wd4820
-      /wd5026
-      /wd5027
+    ${CUSTOM_CXX_FLAGS}
+    /bigobj
+    /EHsc
+    /W3
+    /WX
+    /wd4068
+    /wd4514
+    /wd4571
+    /wd4625
+    /wd4626
+    /wd4710
+    /wd4774
+    /wd4820
+    /wd5026
+    /wd5027
   )
 endif()
 
@@ -128,9 +134,9 @@ function(amber_default_compile_options TARGET)
   if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
       set_target_properties(${TARGET} PROPERTIES LINK_FLAGS
-          -static
-          -static-libgcc
-          -static-libstdc++)
+        -static
+        -static-libgcc
+        -static-libstdc++)
     endif()
   endif()
 endfunction()

--- a/DEPS
+++ b/DEPS
@@ -4,11 +4,11 @@ vars = {
   'google_git':  'https://github.com/google',
   'khronos_git': 'https://github.com/KhronosGroup',
 
-  'glslang_revision': '579ccece451292a402cd5410091197df3cd9e741',
+  'glslang_revision': 'd2a7b07a64811bb4a734bd66ef4e0b4c7d7fe1af',
   'googletest_revision': 'd5932506d6eed73ac80b9bcc47ed723c8c74eb1e',
-  'shaderc_revision': 'eb743ec9cb31303e0abefeeb74886ab134dced6f',
-  'spirv_headers_revision': 'a2c529b5dda18838ab4b52f816acfebd774eaab3',
-  'spirv_tools_revision': 'c37388f1addd697d3e67ee441d9dfe5c739f3979',
+  'shaderc_revision': '75441559fdb99856be9c02c0abd9c8e23b405033',
+  'spirv_headers_revision': '7cb43009d543e90698dd300eb26dfd6d9a9bb100',
+  'spirv_tools_revision': 'b0c143c8eb23ea68fc815882b891a13814e9663b',
 }
 
 deps = {


### PR DESCRIPTION
This CL updates the various DEPS entries for amber and fixes up the
cmake policy warning around VERSION information.

The -fvisiblity=hidden flag is set to remove warnings from shaderc and
glslang symbols.