### PR TITLE
Fix Index buffer datum type.

### DIFF
--- a/src/vkscript/parser.cc
+++ b/src/vkscript/parser.cc
@@ -283,7 +283,11 @@ Result Parser::ProcessIndicesBlock(const std::string& data) {
   }
 
   if (!indices.empty()) {
+    DatumType type;
+    type.SetType(DataType::kUint16);
+
     auto b = MakeUnique<Buffer>(BufferType::kIndex);
+    b->SetDatumType(type);
     b->SetData(std::move(indices));
     script_.AddIndexBuffer(std::move(b));
   }


### PR DESCRIPTION
This CL updates the datum type for Index buffers from the default uint8
to the correct uint16.