### PR TITLE
Add a fence_timeout option for VkScript.

### DIFF
--- a/docs/vk_script.md
+++ b/docs/vk_script.md
@@ -42,6 +42,9 @@ The _framebuffer_ and _depthstencil_ commands allow setting the format for the
 given buffer. The valid values are listed below in the *Image Formats*
 section.
 
+The _fence\_timeout_ option allows setting an integer number of milliseconds
+for any fence timeouts.
+
 The last option is _extensions_. Any string which isn't a _feature_,
 _framebuffer_ or _depthstencil_ is assumed to be an _extension_. The extensions
 must be of the format [a-zA-Z0-9_]+. If the device extension is not available

--- a/src/engine.h
+++ b/src/engine.h
@@ -50,8 +50,11 @@ class Engine {
   virtual Result Shutdown() = 0;
 
   // Enable |feature|. If the feature requires a pixel format it will be
-  // provided in |format|, otherwise |format| is a nullptr.
-  virtual Result AddRequirement(Feature feature, const Format* format) = 0;
+  // provided in |format|, otherwise |format| is a nullptr. If the feature
+  // requires a uint32 value it will be set in the |uint32_t|.
+  virtual Result AddRequirement(Feature feature,
+                                const Format* format,
+                                uint32_t) = 0;
 
   // Create graphics pipeline.
   virtual Result CreatePipeline(PipelineType type) = 0;

--- a/src/feature.h
+++ b/src/feature.h
@@ -76,6 +76,7 @@ enum class Feature {
   kInheritedQueries,
   kFramebuffer,
   kDepthStencil,
+  kFenceTimeout,
 };
 
 }  // namespace amber

--- a/src/vkscript/executor.cc
+++ b/src/vkscript/executor.cc
@@ -40,8 +40,8 @@ Result Executor::Execute(Engine* engine, const amber::Script* src_script) {
       continue;
 
     for (const auto& require : node->AsRequire()->Requirements()) {
-      Result r =
-          engine->AddRequirement(require.GetFeature(), require.GetFormat());
+      Result r = engine->AddRequirement(
+          require.GetFeature(), require.GetFormat(), require.GetUint32Value());
       if (!r.IsSuccess())
         return r;
     }

--- a/src/vkscript/executor_test.cc
+++ b/src/vkscript/executor_test.cc
@@ -43,7 +43,9 @@ class EngineStub : public Engine {
 
   void FailRequirements() { fail_requirements_ = true; }
   const std::vector<Require>& GetRequirements() const { return requirements_; }
-  Result AddRequirement(Feature feature, const Format* format) override {
+  Result AddRequirement(Feature feature,
+                        const Format* format,
+                        uint32_t) override {
     if (fail_requirements_)
       return Result("requirements failed");
 
@@ -276,7 +278,7 @@ class EngineCountingStub : public Engine {
 
   int32_t GetRequireStageIdx() const { return require_stage_; }
   uint32_t GetRequireCount() const { return require_stage_count_; }
-  Result AddRequirement(Feature, const Format*) override {
+  Result AddRequirement(Feature, const Format*, uint32_t) override {
     ++require_stage_count_;
     require_stage_ = stage_count_++;
     return {};

--- a/src/vkscript/nodes.cc
+++ b/src/vkscript/nodes.cc
@@ -58,6 +58,9 @@ RequireNode::Requirement::Requirement(Feature feature,
                                       std::unique_ptr<Format> format)
     : feature_(feature), format_(std::move(format)) {}
 
+RequireNode::Requirement::Requirement(Feature feature, uint32_t value)
+    : feature_(feature), uint32_value_(value) {}
+
 RequireNode::Requirement::Requirement(Requirement&&) = default;
 
 RequireNode::Requirement::~Requirement() = default;
@@ -69,6 +72,10 @@ void RequireNode::AddRequirement(Feature feature) {
 void RequireNode::AddRequirement(Feature feature,
                                  std::unique_ptr<Format> format) {
   requirements_.emplace_back(feature, std::move(format));
+}
+
+void RequireNode::AddRequirement(Feature feature, uint32_t value) {
+  requirements_.emplace_back(feature, value);
 }
 
 IndicesNode::IndicesNode(std::unique_ptr<Buffer> buffer)

--- a/src/vkscript/nodes.h
+++ b/src/vkscript/nodes.h
@@ -77,15 +77,18 @@ class RequireNode : public Node {
    public:
     Requirement(Feature feature);
     Requirement(Feature feature, std::unique_ptr<Format> format);
+    Requirement(Feature feature, uint32_t value);
     Requirement(Requirement&&);
     ~Requirement();
 
     Feature GetFeature() const { return feature_; }
     const Format* GetFormat() const { return format_.get(); }
+    uint32_t GetUint32Value() const { return uint32_value_; }
 
    private:
     Feature feature_;
     std::unique_ptr<Format> format_;
+    uint32_t uint32_value_;
   };
 
   RequireNode();
@@ -93,6 +96,7 @@ class RequireNode : public Node {
 
   void AddRequirement(Feature feature);
   void AddRequirement(Feature feature, std::unique_ptr<Format> format);
+  void AddRequirement(Feature feature, uint32_t value);
 
   const std::vector<Requirement>& Requirements() const { return requirements_; }
 

--- a/src/vkscript/parser.cc
+++ b/src/vkscript/parser.cc
@@ -144,6 +144,8 @@ Feature NameToFeature(const std::string& name) {
     return Feature::kFramebuffer;
   if (name == "depthstencil")
     return Feature::kDepthStencil;
+  if (name == "fence_timeout")
+    return Feature::kFenceTimeout;
   return Feature::kUnknown;
 }
 
@@ -247,6 +249,12 @@ Result Parser::ProcessRequireBlock(const std::string& data) {
         return Result("Failed to parse depthstencil format");
 
       node->AddRequirement(feature, std::move(fmt));
+    } else if (feature == Feature::kFenceTimeout) {
+      token = tokenizer.NextToken();
+      if (!token->IsInteger())
+        return Result("Missing fence_timeout value");
+
+      node->AddRequirement(feature, token->AsUint32());
     } else {
       node->AddRequirement(feature);
     }

--- a/src/vulkan/command.cc
+++ b/src/vulkan/command.cc
@@ -93,7 +93,7 @@ Result CommandBuffer::End() {
   return {};
 }
 
-Result CommandBuffer::SubmitAndReset() {
+Result CommandBuffer::SubmitAndReset(uint32_t timeout_ms) {
   if (state_ != CommandBufferState::kExecutable)
     return Result("Vulkan::Submit CommandBuffer from Not Valid State");
 
@@ -107,8 +107,8 @@ Result CommandBuffer::SubmitAndReset() {
   if (vkQueueSubmit(queue_, 1, &submit_info, fence_) != VK_SUCCESS)
     return Result("Vulkan::Calling vkQueueSubmit Fail");
 
-  VkResult r =
-      vkWaitForFences(device_, 1, &fence_, VK_TRUE, 100000000 /* nanosecond */);
+  VkResult r = vkWaitForFences(device_, 1, &fence_, VK_TRUE,
+                               timeout_ms * 1000 * 1000 /* nanosecond */);
   if (r == VK_TIMEOUT)
     return Result("Vulkan::Calling vkWaitForFences Timeout");
   if (r != VK_SUCCESS)

--- a/src/vulkan/command.h
+++ b/src/vulkan/command.h
@@ -61,7 +61,7 @@ class CommandBuffer {
   Result BeginIfNotInRecording();
 
   Result End();
-  Result SubmitAndReset();
+  Result SubmitAndReset(uint32_t timeout_ms);
 
  private:
   VkDevice device_ = VK_NULL_HANDLE;

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -37,7 +37,7 @@ class EngineVulkan : public Engine {
   Result Initialize() override;
   Result InitializeWithDevice(void* default_device) override;
   Result Shutdown() override;
-  Result AddRequirement(Feature feature, const Format*) override;
+  Result AddRequirement(Feature feature, const Format*, uint32_t) override;
   Result CreatePipeline(PipelineType type) override;
   Result SetShader(ShaderType type, const std::vector<uint32_t>& data) override;
   Result SetBuffer(BufferType type,
@@ -63,6 +63,8 @@ class EngineVulkan : public Engine {
   Result InitDeviceAndCreateCommand();
 
   std::vector<VkPipelineShaderStageCreateInfo> GetShaderStageInfo();
+
+  uint32_t fence_timeout_ms_ = 100;
 
   std::unique_ptr<Device> device_;
   std::unique_ptr<CommandPool> pool_;

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -115,11 +115,13 @@ GraphicsPipeline::GraphicsPipeline(
     const VkPhysicalDeviceMemoryProperties& properties,
     VkFormat color_format,
     VkFormat depth_stencil_format,
+    uint32_t fence_timeout_ms,
     std::vector<VkPipelineShaderStageCreateInfo> shader_stage_info)
     : Pipeline(type, device, properties),
       color_format_(color_format),
       depth_stencil_format_(depth_stencil_format),
-      shader_stage_info_(shader_stage_info) {}
+      shader_stage_info_(shader_stage_info),
+      fence_timeout_ms_(fence_timeout_ms) {}
 
 GraphicsPipeline::~GraphicsPipeline() = default;
 
@@ -518,7 +520,7 @@ Result GraphicsPipeline::SubmitProbeCommand() {
   if (!r.IsSuccess())
     return r;
 
-  return command_->SubmitAndReset();
+  return command_->SubmitAndReset(fence_timeout_ms_);
 }
 
 Result GraphicsPipeline::VerifyPixels(const uint32_t x,
@@ -619,7 +621,7 @@ void GraphicsPipeline::Shutdown() {
 
   Result r = command_->End();
   if (r.IsSuccess())
-    command_->SubmitAndReset();
+    command_->SubmitAndReset(fence_timeout_ms_);
 
   Pipeline::Shutdown();
   frame_->Shutdown();

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -40,6 +40,7 @@ class GraphicsPipeline : public Pipeline {
                    const VkPhysicalDeviceMemoryProperties& properties,
                    VkFormat color_format,
                    VkFormat depth_stencil_format,
+                   uint32_t fence_timeout_ms,
                    std::vector<VkPipelineShaderStageCreateInfo>);
   ~GraphicsPipeline() override;
 
@@ -102,6 +103,7 @@ class GraphicsPipeline : public Pipeline {
 
   std::vector<VkPipelineShaderStageCreateInfo> shader_stage_info_;
 
+  uint32_t fence_timeout_ms_ = 100;
   uint32_t frame_width_ = 0;
   uint32_t frame_height_ = 0;
 


### PR DESCRIPTION
This CL adds the `fence_timeout` option to VkScript to control the value
passed for fence timeouts. The value must be an integer and is
interpreted as number of milliseconds.

Fixes #69.