### PR TITLE
Framebuffer updates

### DIFF
--- a/docs/amber_script.md
+++ b/docs/amber_script.md
@@ -172,7 +172,9 @@ The following commands are all specified within the `PIPELINE` command.
  * storage
  * sampled
  * color
- * depth
+ * depth_stencil
+
+TODO(dsinclair): Reserve `input` as a buffer type for input attachments.
 
 TODO(dsinclair): Sync the BufferTypes with the list of Vulkan Descriptor types.
 
@@ -180,10 +182,10 @@ A `pipeline` can have buffers bound. This includes buffers to contain image
 attachment content, depth/stencil content, uniform buffers, etc.
 
 ```
-  # Attach |buffer_name| as an image attachment at slot |idx|. The provided
-  # buffer must be a `FORMAT` buffer. If no image attachments are provided
-  # a single attachment with format `R8G8B8A8_UINT` will be created.
-  BIND BUFFER <buffer_name> AS image IDX <idx>
+  # Attach |buffer_name| as an output colour attachment at location |idx|.
+  # The provided buffer must be a `FORMAT` buffer. If no colour attachments are
+  # provided a single attachment with format `R8G8B8A8_UINT` will be created.
+  BIND BUFFER <buffer_name> AS color LOCATION <idx>
 
   # Attach |buffer_name| as the depth/stencil buffer. The provided buffer must
   # be a `FORMAT` buffer. If no depth/stencil buffer is specified a default

--- a/tools/amber-syntax.vim
+++ b/tools/amber-syntax.vim
@@ -33,8 +33,8 @@ syn keyword amberBlockCmd DESCRIPTOR_SET BINDING IDX TO EXPECT PASSTHROUGH
 syn keyword amberBlockCmd DATA_TYPE DIMS DATA SERIES_FROM DRAW_ARRAY IN START_IDX
 syn keyword amberBlockCmd COUNT CLEAR CLEAR_COLOR AS POS DRAW_RECT INC_BY
 syn keyword amberBlockCmd FRAMEBUFFER ENTRY_POINT SHADER_OPTIMIZATION
-syn keyword amberBlockCmd FORMAT RENDER_SIZE BIND SAMPLER VERTEX_DATA INDEX_DATA
-syn keyword amberBlockCmd INDEXED
+syn keyword amberBlockCmd FORMAT FRAMEBUFFER_SIZE BIND SAMPLER VERTEX_DATA INDEX_DATA
+syn keyword amberBlockCmd INDEXED IMAGE_ATTACHMENT DEPTH_STENCIL_ATTACHMENT
 
 syn keyword amberComparator EQ NE LT LE GT GE EQ_RGB EQ_RGBA
 
@@ -49,7 +49,7 @@ syn keyword amberTopology triangle_list_with_adjacench triangle_strip
 syn keyword amberTopology triangle_strip_with_adjacency triangle_fan patch_list
 
 syn keyword amberBufferType uniform storage vertex index sampled storage color
-syn keyword amberBufferType framebuffer depth
+syn keyword amberBufferType framebuffer depth image depth_stencil
 
 let b:current_syntax = "amber"
 hi def link amberTodo Todo

--- a/tools/amber.sublime-syntax
+++ b/tools/amber.sublime-syntax
@@ -25,14 +25,16 @@ contexts:
       scope: keyword.control.amber
     - match: '\b(COUNT|CLEAR_COLOR|CLEAR|EXPECT|TYPE|FRAMEBUFFER|SHADER_OPTIMIZATION)\b'
       scope: keyword.control.amber
-    - match: '\b(FORMAT|RENDER_SIZE|BIND|SAMPLER|VERTEX_DATA|INDEX_DATA|INDEXED)\b'
+    - match: '\b(FORMAT|FRAMEBUFFER_SIZE|BIND|SAMPLER|VERTEX_DATA|INDEX_DATA|INDEXED)\b'
+      scope: keyword.control.amber
+    - match : '\b(IMAGE_ATTACHMENT|DEPTH_STENCIL_ATTACHMENT)\b'
       scope: keyword.control.amber
 
     - match: '\b(vertex|fragment|compute|geometry|tessellation_evaluation|tessellation_control)\b'
       scope: constant.character.escape.amber
     - match: '\b(framebuffer|graphics)\b'
       scope: constant.character.escape.amber
-    - match: '\b(uniform|storage|index|sampled|storage|color|depth)\b'
+    - match: '\b(uniform|storage|index|sampled|storage|color|depth|image|depth_stencil)\b'
       scope: constant.character.escape.amber
     - match: '\b(EQ|NE|LT|LE|GT|GE|EQ_RGB|EQ_RGBA)\b'
       scope: constant.character.esape.amber


### PR DESCRIPTION
This Cl removes the FRAMEBUFFER commands from AmberScript and converts
them into more generic buffer commands.