### PR TITLE
Destructor on abstract class should be virtual

### DIFF
--- a/src/vulkan/descriptor.h
+++ b/src/vulkan/descriptor.h
@@ -46,7 +46,7 @@ class Descriptor {
              uint32_t desc_set,
              uint32_t binding);
 
-  ~Descriptor();
+  virtual ~Descriptor();
 
   uint32_t GetDescriptorSet() const { return descriptor_set_; }
   uint32_t GetBinding() const { return binding_; }


### PR DESCRIPTION
Otherwise you get a warning from Clang on macOS. (For good reason)