### PR TITLE
Delay VkScript Shader Compilation.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,6 @@ set(AMBER_SOURCES
     amberscript/parser.cc
     amberscript/pipeline.cc
     amberscript/script.cc
-    amberscript/shader.cc
     buffer.cc
     command.cc
     command_data.cc
@@ -31,6 +30,7 @@ set(AMBER_SOURCES
     pipeline_data.cc
     result.cc
     script.cc
+    shader.cc
     shader_compiler.cc
     tokenizer.cc
     value.cc

--- a/src/amberscript/pipeline.h
+++ b/src/amberscript/pipeline.h
@@ -19,7 +19,7 @@
 #include <vector>
 
 #include "amber/result.h"
-#include "src/amberscript/shader.h"
+#include "src/shader.h"
 
 namespace amber {
 namespace amberscript {

--- a/src/amberscript/script.h
+++ b/src/amberscript/script.h
@@ -22,7 +22,6 @@
 #include <vector>
 
 #include "src/amberscript/pipeline.h"
-#include "src/amberscript/shader.h"
 #include "src/buffer.h"
 #include "src/script.h"
 
@@ -34,18 +33,6 @@ class Script : public amber::Script {
   Script();
   ~Script() override;
 
-  Result AddShader(std::unique_ptr<Shader> shader) {
-    if (name_to_shader_.count(shader->GetName()) > 0)
-      return Result("duplicate shader name provided");
-
-    shaders_.push_back(std::move(shader));
-    name_to_shader_[shaders_.back()->GetName()] = shaders_.back().get();
-    return {};
-  }
-  const std::vector<std::unique_ptr<Shader>>& GetShaders() const {
-    return shaders_;
-  }
-
   Result AddPipeline(std::unique_ptr<Pipeline> pipeline) {
     if (name_to_pipeline_.count(pipeline->GetName()) > 0)
       return Result("duplicate pipeline name provided");
@@ -54,6 +41,12 @@ class Script : public amber::Script {
     name_to_pipeline_[pipelines_.back()->GetName()] = pipelines_.back().get();
     return {};
   }
+
+  Pipeline* GetPipeline(const std::string& name) const {
+    auto it = name_to_pipeline_.find(name);
+    return it == name_to_pipeline_.end() ? nullptr : it->second;
+  }
+
   const std::vector<std::unique_ptr<Pipeline>>& GetPipelines() const {
     return pipelines_;
   }
@@ -67,30 +60,18 @@ class Script : public amber::Script {
     return {};
   }
 
-  const std::vector<std::unique_ptr<Buffer>>& GetBuffers() const {
-    return buffers_;
-  }
-
-  Shader* GetShader(const std::string& name) const {
-    auto it = name_to_shader_.find(name);
-    return it == name_to_shader_.end() ? nullptr : it->second;
-  }
-
-  Pipeline* GetPipeline(const std::string& name) const {
-    auto it = name_to_pipeline_.find(name);
-    return it == name_to_pipeline_.end() ? nullptr : it->second;
-  }
-
   Buffer* GetBuffer(const std::string& name) const {
     auto it = name_to_buffer_.find(name);
     return it == name_to_buffer_.end() ? nullptr : it->second;
   }
 
+  const std::vector<std::unique_ptr<Buffer>>& GetBuffers() const {
+    return buffers_;
+  }
+
  private:
-  std::map<std::string, Shader*> name_to_shader_;
   std::map<std::string, Pipeline*> name_to_pipeline_;
   std::map<std::string, Buffer*> name_to_buffer_;
-  std::vector<std::unique_ptr<Shader>> shaders_;
   std::vector<std::unique_ptr<Pipeline>> pipelines_;
   std::vector<std::unique_ptr<Buffer>> buffers_;
 };

--- a/src/amberscript/script_test.cc
+++ b/src/amberscript/script_test.cc
@@ -17,9 +17,9 @@
 #include "gtest/gtest.h"
 #include "src/amberscript/pipeline.h"
 #include "src/amberscript/script.h"
-#include "src/amberscript/shader.h"
 #include "src/buffer.h"
 #include "src/make_unique.h"
+#include "src/shader.h"
 
 namespace amber {
 namespace amberscript {

--- a/src/script.h
+++ b/src/script.h
@@ -16,6 +16,14 @@
 #define SRC_SCRIPT_H_
 
 #include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "amber/result.h"
+#include "src/shader.h"
 
 namespace amber {
 
@@ -30,11 +38,31 @@ class Script {
     return script_type_ == ScriptType::kAmberScript;
   }
 
+  Result AddShader(std::unique_ptr<Shader> shader) {
+    if (name_to_shader_.count(shader->GetName()) > 0)
+      return Result("duplicate shader name provided");
+
+    shaders_.push_back(std::move(shader));
+    name_to_shader_[shaders_.back()->GetName()] = shaders_.back().get();
+    return {};
+  }
+
+  Shader* GetShader(const std::string& name) const {
+    auto it = name_to_shader_.find(name);
+    return it == name_to_shader_.end() ? nullptr : it->second;
+  }
+
+  const std::vector<std::unique_ptr<Shader>>& GetShaders() const {
+    return shaders_;
+  }
+
  protected:
   explicit Script(ScriptType);
 
  private:
   ScriptType script_type_;
+  std::map<std::string, Shader*> name_to_shader_;
+  std::vector<std::unique_ptr<Shader>> shaders_;
 };
 
 }  // namespace amber

--- a/src/shader.cc
+++ b/src/shader.cc
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "src/amberscript/shader.h"
+#include "src/shader.h"
 
 namespace amber {
-namespace amberscript {
 
 Shader::Shader(ShaderType type) : shader_type_(type) {}
 
 Shader::~Shader() = default;
 
-}  // namespace amberscript
 }  // namespace amber

--- a/src/shader.h
+++ b/src/shader.h
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SRC_AMBERSCRIPT_SHADER_H_
-#define SRC_AMBERSCRIPT_SHADER_H_
+#ifndef SRC_SHADER_H_
+#define SRC_SHADER_H_
 
 #include <string>
 
 #include "src/shader_data.h"
 
 namespace amber {
-namespace amberscript {
 
 class Shader {
  public:
@@ -45,7 +44,6 @@ class Shader {
   std::string name_;
 };
 
-}  // namespace amberscript
 }  // namespace amber
 
-#endif  // SRC_AMBERSCRIPT_SHADER_H_
+#endif  // SRC_SHADER_H_

--- a/src/vkscript/executor_test.cc
+++ b/src/vkscript/executor_test.cc
@@ -418,12 +418,13 @@ void main() {}
 )";
 
   Parser parser;
-  ASSERT_TRUE(parser.Parse(input).IsSuccess());
+  Result r = parser.Parse(input);
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
   auto engine = MakeEngine();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  r = ex.Execute(engine.get(), parser.GetScript());
   ASSERT_TRUE(r.IsSuccess());
 
   auto shader_types = ToStub(engine.get())->GetShaderTypesSeen();

--- a/src/vkscript/nodes.cc
+++ b/src/vkscript/nodes.cc
@@ -28,10 +28,6 @@ IndicesNode* Node::AsIndices() {
   return static_cast<IndicesNode*>(this);
 }
 
-ShaderNode* Node::AsShader() {
-  return static_cast<ShaderNode*>(this);
-}
-
 RequireNode* Node::AsRequire() {
   return static_cast<RequireNode*>(this);
 }
@@ -43,11 +39,6 @@ TestNode* Node::AsTest() {
 VertexDataNode* Node::AsVertexData() {
   return static_cast<VertexDataNode*>(this);
 }
-
-ShaderNode::ShaderNode(ShaderType type, std::vector<uint32_t> shader)
-    : Node(NodeType::kShader), type_(type), shader_(std::move(shader)) {}
-
-ShaderNode::~ShaderNode() = default;
 
 RequireNode::RequireNode() : Node(NodeType::kRequire) {}
 

--- a/src/vkscript/nodes.h
+++ b/src/vkscript/nodes.h
@@ -32,7 +32,6 @@ namespace vkscript {
 
 class IndicesNode;
 class RequireNode;
-class ShaderNode;
 class TestNode;
 class VertexDataNode;
 
@@ -42,13 +41,11 @@ class Node {
 
   bool IsIndices() const { return node_type_ == NodeType::kIndices; }
   bool IsRequire() const { return node_type_ == NodeType::kRequire; }
-  bool IsShader() const { return node_type_ == NodeType::kShader; }
   bool IsTest() const { return node_type_ == NodeType::kTest; }
   bool IsVertexData() const { return node_type_ == NodeType::kVertexData; }
 
   IndicesNode* AsIndices();
   RequireNode* AsRequire();
-  ShaderNode* AsShader();
   TestNode* AsTest();
   VertexDataNode* AsVertexData();
 
@@ -57,19 +54,6 @@ class Node {
 
  private:
   NodeType node_type_;
-};
-
-class ShaderNode : public Node {
- public:
-  ShaderNode(ShaderType type, std::vector<uint32_t> shader);
-  ~ShaderNode() override;
-
-  ShaderType GetShaderType() const { return type_; }
-  const std::vector<uint32_t>& GetData() const { return shader_; }
-
- private:
-  ShaderType type_;
-  std::vector<uint32_t> shader_;
 };
 
 class RequireNode : public Node {

--- a/src/vkscript/parser.cc
+++ b/src/vkscript/parser.cc
@@ -22,7 +22,7 @@
 #include <vector>
 
 #include "src/make_unique.h"
-#include "src/shader_compiler.h"
+#include "src/shader.h"
 #include "src/tokenizer.h"
 #include "src/vkscript/command_parser.h"
 #include "src/vkscript/format_parser.h"
@@ -193,18 +193,17 @@ Result Parser::ProcessSection(const SectionParser::Section& section) {
 }
 
 Result Parser::ProcessShaderBlock(const SectionParser::Section& section) {
-  ShaderCompiler sc;
-
   assert(SectionParser::HasShader(section.section_type));
 
-  Result r;
-  std::vector<uint32_t> shader;
-  std::tie(r, shader) =
-      sc.Compile(section.shader_type, section.format, section.contents);
+  auto shader = MakeUnique<Shader>(section.shader_type);
+  // Generate a unique name for the shader.
+  shader->SetName("vk_shader_" + std::to_string(script_.GetShaders().size()));
+  shader->SetFormat(section.format);
+  shader->SetData(section.contents);
+
+  Result r = script_.AddShader(std::move(shader));
   if (!r.IsSuccess())
     return r;
-
-  script_.AddShader(section.shader_type, std::move(shader));
 
   return {};
 }

--- a/src/vkscript/script.cc
+++ b/src/vkscript/script.cc
@@ -36,10 +36,6 @@ void Script::AddRequireNode(std::unique_ptr<RequireNode> node) {
   test_nodes_.push_back(std::move(tn));
 }
 
-void Script::AddShader(ShaderType type, std::vector<uint32_t> shader) {
-  test_nodes_.push_back(MakeUnique<ShaderNode>(type, std::move(shader)));
-}
-
 void Script::AddIndexBuffer(std::unique_ptr<Buffer> buffer) {
   test_nodes_.push_back(MakeUnique<IndicesNode>(std::move(buffer)));
 }

--- a/src/vkscript/script.h
+++ b/src/vkscript/script.h
@@ -37,7 +37,6 @@ class Script : public amber::Script {
   ~Script() override;
 
   void AddRequireNode(std::unique_ptr<RequireNode> node);
-  void AddShader(ShaderType, std::vector<uint32_t>);
   void AddIndexBuffer(std::unique_ptr<Buffer> b);
   void AddVertexData(std::unique_ptr<VertexDataNode> node);
   void SetTestCommands(std::vector<std::unique_ptr<Command>> commands);


### PR DESCRIPTION
This CL changes VkScript to delay shader compilation until execution,
instead of at parse time. This allows VkScript to share the Script
object with AmberScript.