### PR TITLE
Move tolerance data into probe commands

### DIFF
--- a/src/command.cc
+++ b/src/command.cc
@@ -68,10 +68,6 @@ ProbeSSBOCommand* Command::AsProbeSSBO() {
   return static_cast<ProbeSSBOCommand*>(this);
 }
 
-ToleranceCommand* Command::AsTolerance() {
-  return static_cast<ToleranceCommand*>(this);
-}
-
 DrawRectCommand::DrawRectCommand(PipelineData data)
     : Command(Type::kDrawRect), data_(data) {}
 
@@ -87,7 +83,11 @@ ComputeCommand::ComputeCommand(PipelineData data)
 
 ComputeCommand::~ComputeCommand() = default;
 
-ProbeCommand::ProbeCommand() : Command(Type::kProbe) {}
+Probe::Probe(Type type) : Command(type) {}
+
+Probe::~Probe() = default;
+
+ProbeCommand::ProbeCommand() : Probe(Type::kProbe) {}
 
 ProbeCommand::~ProbeCommand() = default;
 
@@ -96,13 +96,9 @@ BufferCommand::BufferCommand(BufferType type)
 
 BufferCommand::~BufferCommand() = default;
 
-ProbeSSBOCommand::ProbeSSBOCommand() : Command(Type::kProbeSSBO) {}
+ProbeSSBOCommand::ProbeSSBOCommand() : Probe(Type::kProbeSSBO) {}
 
 ProbeSSBOCommand::~ProbeSSBOCommand() = default;
-
-ToleranceCommand::ToleranceCommand() : Command(Type::kTolerance) {}
-
-ToleranceCommand::~ToleranceCommand() = default;
 
 ClearCommand::ClearCommand() : Command(Type::kClear) {}
 

--- a/src/command.h
+++ b/src/command.h
@@ -40,7 +40,6 @@ class PatchParameterVerticesCommand;
 class ProbeCommand;
 class ProbeSSBOCommand;
 class BufferCommand;
-class ToleranceCommand;
 
 class Command {
  public:
@@ -57,8 +56,7 @@ class Command {
     kPipelineProperties,
     kProbe,
     kProbeSSBO,
-    kBuffer,
-    kTolerance,
+    kBuffer
   };
 
   virtual ~Command();
@@ -69,7 +67,6 @@ class Command {
   bool IsProbe() const { return command_type_ == Type::kProbe; }
   bool IsProbeSSBO() const { return command_type_ == Type::kProbeSSBO; }
   bool IsBuffer() const { return command_type_ == Type::kBuffer; }
-  bool IsTolerance() const { return command_type_ == Type::kTolerance; }
   bool IsClear() const { return command_type_ == Type::kClear; }
   bool IsClearColor() const { return command_type_ == Type::kClearColor; }
   bool IsClearDepth() const { return command_type_ == Type::kClearDepth; }
@@ -91,7 +88,6 @@ class Command {
   ProbeCommand* AsProbe();
   ProbeSSBOCommand* AsProbeSSBO();
   BufferCommand* AsBuffer();
-  ToleranceCommand* AsTolerance();
 
  protected:
   explicit Command(Type type);
@@ -193,7 +189,29 @@ class ComputeCommand : public Command {
   uint32_t z_ = 0;
 };
 
-class ProbeCommand : public Command {
+class Probe : public Command {
+ public:
+  struct Tolerance {
+    Tolerance(bool percent, double val) : is_percent(percent), value(val) {}
+
+    bool is_percent = false;
+    double value = 0.0;
+  };
+
+  ~Probe() override;
+
+  bool HasTolerances() const { return !tolerances_.empty(); }
+  void SetTolerances(std::vector<Tolerance> t) { tolerances_ = t; }
+  const std::vector<Tolerance>& GetTolerances() const { return tolerances_; }
+
+ protected:
+  Probe(Type type);
+
+ private:
+  std::vector<Tolerance> tolerances_;
+};
+
+class ProbeCommand : public Probe {
  public:
   ProbeCommand();
   ~ProbeCommand() override;
@@ -252,7 +270,7 @@ class ProbeCommand : public Command {
   float a_ = 0.0;
 };
 
-class ProbeSSBOCommand : public Command {
+class ProbeSSBOCommand : public Probe {
  public:
   enum class Comparator {
     kEqual,
@@ -341,31 +359,6 @@ class BufferCommand : public Command {
   uint32_t offset_ = 0;
   DatumType datum_type_;
   std::vector<Value> values_;
-};
-
-class ToleranceCommand : public Command {
- public:
-  struct Tolerance {
-    Tolerance(bool percent, double val) : is_percent(percent), value(val) {}
-
-    bool is_percent = false;
-    double value = 0.0;
-  };
-
-  ToleranceCommand();
-  ~ToleranceCommand() override;
-
-  void AddPercentTolerance(double value) {
-    tolerances_.emplace_back(Tolerance{true, value});
-  }
-  void AddValueTolerance(double value) {
-    tolerances_.emplace_back(Tolerance{false, value});
-  }
-
-  const std::vector<Tolerance>& GetTolerances() const { return tolerances_; }
-
- private:
-  std::vector<Tolerance> tolerances_;
 };
 
 class ClearCommand : public Command {

--- a/src/verifier.cc
+++ b/src/verifier.cc
@@ -117,8 +117,4 @@ Result Verifier::ProbeSSBO(const ProbeSSBOCommand*) {
   return Result("Verifier::ProbeSSBO Not Implemented");
 }
 
-Result Verifier::Tolerance(const ToleranceCommand*) {
-  return Result("Verifier::Tolerance Not Implemented");
-}
-
 }  // namespace amber

--- a/src/verifier.h
+++ b/src/verifier.h
@@ -31,7 +31,6 @@ class Verifier {
                uint32_t frame_height,
                const void* buf);
   Result ProbeSSBO(const ProbeSSBOCommand*);
-  Result Tolerance(const ToleranceCommand*);
 };
 
 }  // namespace amber

--- a/src/vkscript/command_parser.h
+++ b/src/vkscript/command_parser.h
@@ -74,6 +74,7 @@ class CommandParser {
                                    ProbeSSBOCommand::Comparator* op) {
     return ParseComparator(name, op);
   }
+  const std::vector<Probe::Tolerance>& TolerancesForTesting() const { return current_tolerances_; }
 
  private:
   Result TokenToFloat(Token* token, float* val) const;
@@ -153,6 +154,7 @@ class CommandParser {
   PipelineData pipeline_data_;
   std::unique_ptr<Tokenizer> tokenizer_;
   std::vector<std::unique_ptr<Command>> commands_;
+  std::vector<Probe::Tolerance> current_tolerances_;
 };
 
 }  // namespace vkscript

--- a/src/vkscript/command_parser_test.cc
+++ b/src/vkscript/command_parser_test.cc
@@ -2983,13 +2983,7 @@ TEST_F(CommandParserTest, ToleranceSingleFloatValue) {
   Result r = cp.Parse(data);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& cmds = cp.Commands();
-  ASSERT_EQ(1U, cmds.size());
-  ASSERT_TRUE(cmds[0]->IsTolerance());
-
-  auto* cmd = cmds[0]->AsTolerance();
-  const auto& tolerances = cmd->GetTolerances();
-
+  auto& tolerances = cp.TolerancesForTesting();
   ASSERT_EQ(1U, tolerances.size());
   EXPECT_FALSE(tolerances[0].is_percent);
   EXPECT_DOUBLE_EQ(0.5, tolerances[0].value);
@@ -3002,13 +2996,7 @@ TEST_F(CommandParserTest, ToleranceSingleFloatPercent) {
   Result r = cp.Parse(data);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& cmds = cp.Commands();
-  ASSERT_EQ(1U, cmds.size());
-  ASSERT_TRUE(cmds[0]->IsTolerance());
-
-  auto* cmd = cmds[0]->AsTolerance();
-  const auto& tolerances = cmd->GetTolerances();
-
+  auto& tolerances = cp.TolerancesForTesting();
   ASSERT_EQ(1U, tolerances.size());
   EXPECT_TRUE(tolerances[0].is_percent);
   EXPECT_DOUBLE_EQ(0.5, tolerances[0].value);
@@ -3021,13 +3009,7 @@ TEST_F(CommandParserTest, ToleranceSingleIntValue) {
   Result r = cp.Parse(data);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& cmds = cp.Commands();
-  ASSERT_EQ(1U, cmds.size());
-  ASSERT_TRUE(cmds[0]->IsTolerance());
-
-  auto* cmd = cmds[0]->AsTolerance();
-  const auto& tolerances = cmd->GetTolerances();
-
+  auto& tolerances = cp.TolerancesForTesting();
   ASSERT_EQ(1U, tolerances.size());
   EXPECT_FALSE(tolerances[0].is_percent);
   EXPECT_DOUBLE_EQ(5.0, tolerances[0].value);
@@ -3040,13 +3022,7 @@ TEST_F(CommandParserTest, ToleranceSingleIntPercent) {
   Result r = cp.Parse(data);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& cmds = cp.Commands();
-  ASSERT_EQ(1U, cmds.size());
-  ASSERT_TRUE(cmds[0]->IsTolerance());
-
-  auto* cmd = cmds[0]->AsTolerance();
-  const auto& tolerances = cmd->GetTolerances();
-
+  auto& tolerances = cp.TolerancesForTesting();
   ASSERT_EQ(1U, tolerances.size());
   EXPECT_TRUE(tolerances[0].is_percent);
   EXPECT_DOUBLE_EQ(5.0, tolerances[0].value);
@@ -3059,13 +3035,7 @@ TEST_F(CommandParserTest, ToleranceMultiFloatValue) {
   Result r = cp.Parse(data);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& cmds = cp.Commands();
-  ASSERT_EQ(1U, cmds.size());
-  ASSERT_TRUE(cmds[0]->IsTolerance());
-
-  auto* cmd = cmds[0]->AsTolerance();
-  const auto& tolerances = cmd->GetTolerances();
-
+  auto& tolerances = cp.TolerancesForTesting();
   std::vector<double> results = {0.5, 2.4, 3.9, 99.7};
   ASSERT_EQ(results.size(), tolerances.size());
   for (size_t i = 0; i < results.size(); ++i) {
@@ -3081,13 +3051,7 @@ TEST_F(CommandParserTest, ToleranceMultiFloatValueWithPercent) {
   Result r = cp.Parse(data);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& cmds = cp.Commands();
-  ASSERT_EQ(1U, cmds.size());
-  ASSERT_TRUE(cmds[0]->IsTolerance());
-
-  auto* cmd = cmds[0]->AsTolerance();
-  const auto& tolerances = cmd->GetTolerances();
-
+  auto& tolerances = cp.TolerancesForTesting();
   std::vector<double> results = {0.5, 2.4, 3.9, 99.7};
   ASSERT_EQ(results.size(), tolerances.size());
   for (size_t i = 0; i < results.size(); ++i) {
@@ -3107,13 +3071,7 @@ TEST_F(CommandParserTest, ToleranceMultiIntValue) {
   Result r = cp.Parse(data);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& cmds = cp.Commands();
-  ASSERT_EQ(1U, cmds.size());
-  ASSERT_TRUE(cmds[0]->IsTolerance());
-
-  auto* cmd = cmds[0]->AsTolerance();
-  const auto& tolerances = cmd->GetTolerances();
-
+  auto& tolerances = cp.TolerancesForTesting();
   std::vector<double> results = {5.0, 4.0, 3.0, 99.0};
   ASSERT_EQ(results.size(), tolerances.size());
   for (size_t i = 0; i < results.size(); ++i) {
@@ -3129,13 +3087,7 @@ TEST_F(CommandParserTest, ToleranceMultiIntValueWithPercent) {
   Result r = cp.Parse(data);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& cmds = cp.Commands();
-  ASSERT_EQ(1U, cmds.size());
-  ASSERT_TRUE(cmds[0]->IsTolerance());
-
-  auto* cmd = cmds[0]->AsTolerance();
-  const auto& tolerances = cmd->GetTolerances();
-
+  auto& tolerances = cp.TolerancesForTesting();
   std::vector<double> results = {5.0, 4.0, 3.0, 99.0};
   ASSERT_EQ(results.size(), tolerances.size());
   for (size_t i = 0; i < results.size(); ++i) {
@@ -3236,18 +3188,62 @@ TEST_F(CommandParserTest, ToleranceWithCommas) {
   Result r = cp.Parse(data);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& cmds = cp.Commands();
-  ASSERT_EQ(1U, cmds.size());
-  ASSERT_TRUE(cmds[0]->IsTolerance());
-
-  auto* cmd = cmds[0]->AsTolerance();
-  const auto& tolerances = cmd->GetTolerances();
-
+  auto& tolerances = cp.TolerancesForTesting();
   std::vector<double> results = {1.0, 2.0, 3.0, 4.0};
   ASSERT_EQ(results.size(), tolerances.size());
   for (size_t i = 0; i < results.size(); ++i) {
     EXPECT_FALSE(tolerances[0].is_percent);
     EXPECT_DOUBLE_EQ(results[i], tolerances[i].value);
+  }
+}
+
+TEST_F(CommandParserTest, ProbeSSBOWithTolerance) {
+  std::string data = R"(
+tolerance 2 3 4 5
+probe ssbo vec3 3:6 2 >= 2.3 4.2 1.2)";
+
+  CommandParser cp;
+  Result r = cp.Parse(data);
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto& cmds = cp.Commands();
+  ASSERT_EQ(1U, cmds.size());
+  ASSERT_TRUE(cmds[0]->IsProbeSSBO());
+
+  auto* cmd = cmds[0]->AsProbeSSBO();
+  ASSERT_TRUE(cmd->HasTolerances());
+
+  auto& tolerances = cmd->GetTolerances();
+  std::vector<double> vals = {2, 3, 4, 5};
+  ASSERT_EQ(vals.size(), tolerances.size());
+  for (size_t i = 0; i < vals.size(); ++i) {
+    EXPECT_FALSE(tolerances[i].is_percent);
+    EXPECT_FLOAT_EQ(vals[i], tolerances[i].value);
+  }
+}
+
+TEST_F(CommandParserTest, ProbeWithTolerance) {
+std::string data = R"(
+tolerance 2% 3% 4% 5%
+probe all rgba 0.2 0.3 0.4 0.5)";
+
+  CommandParser cp;
+  Result r = cp.Parse(data);
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto& cmds = cp.Commands();
+  ASSERT_EQ(1U, cmds.size());
+  ASSERT_TRUE(cmds[0]->IsProbe());
+
+  auto* cmd = cmds[0]->AsProbe();
+  ASSERT_TRUE(cmd->HasTolerances());
+
+  auto& tolerances = cmd->GetTolerances();
+  std::vector<double> vals = {2, 3, 4, 5};
+  ASSERT_EQ(vals.size(), tolerances.size());
+  for (size_t i = 0; i < vals.size(); ++i) {
+    EXPECT_TRUE(tolerances[i].is_percent);
+    EXPECT_FLOAT_EQ(vals[i], tolerances[i].value);
   }
 }
 

--- a/src/vkscript/executor.cc
+++ b/src/vkscript/executor.cc
@@ -111,8 +111,6 @@ Result Executor::Execute(Engine* engine, const amber::Script* src_script) {
         r = verifier_.Probe(cmd->AsProbe(), stride, width, height, buf);
       } else if (cmd->IsProbeSSBO()) {
         r = verifier_.ProbeSSBO(cmd->AsProbeSSBO());
-      } else if (cmd->IsTolerance()) {
-        r = verifier_.Tolerance(cmd->AsTolerance());
 
       } else if (cmd->IsClear()) {
         r = engine->DoClear(cmd->AsClear());

--- a/src/vkscript/executor_test.cc
+++ b/src/vkscript/executor_test.cc
@@ -824,39 +824,6 @@ ssbo 0 24)";
   EXPECT_EQ("buffer command failed", r.Error());
 }
 
-TEST_F(VkScriptExecutorTest, DISABLED_ToleranceCommand) {
-  std::string input = R"(
-[test]
-tolerance 2 4 5 8)";
-
-  Parser parser;
-  ASSERT_TRUE(parser.Parse(input).IsSuccess());
-
-  auto engine = MakeEngine();
-
-  Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
-  ASSERT_TRUE(r.IsSuccess());
-  // ASSERT_TRUE(ToStub(engine.get())->DidToleranceCommand());
-}
-
-TEST_F(VkScriptExecutorTest, DISABLED_ToleranceCommandFailure) {
-  std::string input = R"(
-[test]
-tolerance 2 3 4 5)";
-
-  Parser parser;
-  ASSERT_TRUE(parser.Parse(input).IsSuccess());
-
-  auto engine = MakeEngine();
-  // ToStub(engine.get())->FailToleranceCommand();
-
-  Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
-  ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("tolerance command failed", r.Error());
-}
-
 TEST_F(VkScriptExecutorTest, DISABLED_ProbeSSBOCommand) {
   std::string input = R"(
 [test]


### PR DESCRIPTION
This CL removes the Tolerance command and, instead, stores the tolerance
data in the command parser. For each probe command, the tolerance data
is attached to the probe itself.

This way, the tolerance data is always available when the probe is
accessed.