### PR TITLE
Vulkan: Split Engine::DoProcessCommands

### DIFF
--- a/src/dawn/engine_dawn.h
+++ b/src/dawn/engine_dawn.h
@@ -63,10 +63,11 @@ class EngineDawn : public Engine {
   Result DoPatchParameterVertices(
       const PatchParameterVerticesCommand* cmd) override;
   Result DoBuffer(const BufferCommand* cmd) override;
-  Result DoProcessCommands(uint32_t* stride,
-                           uint32_t* width,
-                           uint32_t* height,
-                           const void** buf) override;
+  Result DoProcessCommands() override;
+  Result GetFrameBufferInfo(ResourceInfo* info) override;
+  Result GetDescriptorInfo(const uint32_t descriptor_set,
+                           const uint32_t binding,
+                           ResourceInfo* info) override;
 
  private:
   // Creates a command buffer builder if it doesn't already exist.

--- a/src/dawn/pipeline_info.h
+++ b/src/dawn/pipeline_info.h
@@ -49,7 +49,7 @@ struct RenderPipelineInfo {
   uint32_t fb_row_stride = 0;
   // The number of data bytes in the framebuffer host-side buffer.
   uint32_t fb_size = 0;
-  bool fb_is_mapped = false;
+  const void* fb_data = nullptr;
 
   // TODO(dneto): Record index data
   // TODO(dneto): Record buffer data

--- a/src/dawn/pipeline_info_test.cc
+++ b/src/dawn/pipeline_info_test.cc
@@ -49,7 +49,7 @@ TEST_F(DawnRenderPipelineInfoTest, DefaultValuesForMembers) {
   EXPECT_FALSE(static_cast<bool>(rpi.fb_buffer));
   EXPECT_EQ(0u, rpi.fb_row_stride);
   EXPECT_EQ(0u, rpi.fb_size);
-  EXPECT_FALSE(rpi.fb_is_mapped);
+  EXPECT_EQ(nullptr, rpi.fb_data);
 }
 
 }  // namespace

--- a/src/verifier.cc
+++ b/src/verifier.cc
@@ -113,7 +113,7 @@ Result Verifier::Probe(const ProbeCommand* command,
   return {};
 }
 
-Result Verifier::ProbeSSBO(const ProbeSSBOCommand*) {
+Result Verifier::ProbeSSBO(const ProbeSSBOCommand*, size_t, const void*) {
   return Result("Verifier::ProbeSSBO Not Implemented");
 }
 

--- a/src/verifier.h
+++ b/src/verifier.h
@@ -30,7 +30,7 @@ class Verifier {
                uint32_t frame_width,
                uint32_t frame_height,
                const void* buf);
-  Result ProbeSSBO(const ProbeSSBOCommand*);
+  Result ProbeSSBO(const ProbeSSBOCommand*, size_t, const void*);
 };
 
 }  // namespace amber

--- a/src/vkscript/executor_test.cc
+++ b/src/vkscript/executor_test.cc
@@ -195,10 +195,11 @@ class EngineStub : public Engine {
     return {};
   }
 
-  Result DoProcessCommands(uint32_t*,
-                           uint32_t*,
-                           uint32_t*,
-                           const void**) override {
+  Result DoProcessCommands() override { return {}; }
+  Result GetFrameBufferInfo(ResourceInfo*) override { return {}; }
+  Result GetDescriptorInfo(const uint32_t,
+                           const uint32_t,
+                           ResourceInfo*) override {
     return {};
   }
 
@@ -287,10 +288,11 @@ class EngineCountingStub : public Engine {
     return {};
   }
   Result DoBuffer(const BufferCommand*) override { return {}; }
-  Result DoProcessCommands(uint32_t*,
-                           uint32_t*,
-                           uint32_t*,
-                           const void**) override {
+  Result DoProcessCommands() override { return {}; }
+  Result GetFrameBufferInfo(ResourceInfo*) override { return {}; }
+  Result GetDescriptorInfo(const uint32_t,
+                           const uint32_t,
+                           ResourceInfo*) override {
     return {};
   }
 

--- a/src/vulkan/compute_pipeline.cc
+++ b/src/vulkan/compute_pipeline.cc
@@ -81,5 +81,17 @@ Result ComputePipeline::Compute(uint32_t x, uint32_t y, uint32_t z) {
   return {};
 }
 
+Result ComputePipeline::ProcessCommands() {
+  Result r = command_->BeginIfNotInRecording();
+  if (!r.IsSuccess())
+    return r;
+
+  r = command_->End();
+  if (!r.IsSuccess())
+    return r;
+
+  return command_->SubmitAndReset(GetFenceTimeout());
+}
+
 }  // namespace vulkan
 }  // namespace amber

--- a/src/vulkan/compute_pipeline.h
+++ b/src/vulkan/compute_pipeline.h
@@ -37,6 +37,9 @@ class ComputePipeline : public Pipeline {
 
   Result Compute(uint32_t x, uint32_t y, uint32_t z);
 
+  // Pipeline
+  Result ProcessCommands() override;
+
  private:
   Result CreateVkComputePipeline();
 };

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -56,10 +56,11 @@ class EngineVulkan : public Engine {
   Result DoPatchParameterVertices(
       const PatchParameterVerticesCommand* cmd) override;
   Result DoBuffer(const BufferCommand* cmd) override;
-  Result DoProcessCommands(uint32_t* stride,
-                           uint32_t* width,
-                           uint32_t* height,
-                           const void** buf) override;
+  Result DoProcessCommands() override;
+  Result GetFrameBufferInfo(ResourceInfo* info) override;
+  Result GetDescriptorInfo(const uint32_t descriptor_set,
+                           const uint32_t binding,
+                           ResourceInfo* info) override;
 
  private:
   Result InitDeviceAndCreateCommand();

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -528,10 +528,6 @@ Result GraphicsPipeline::ProcessCommands() {
 void GraphicsPipeline::Shutdown() {
   DeactivateRenderPassIfNeeded();
 
-  Result r = command_->End();
-  if (r.IsSuccess())
-    command_->SubmitAndReset(GetFenceTimeout());
-
   Pipeline::Shutdown();
   frame_->Shutdown();
   vkDestroyRenderPass(device_, render_pass_, nullptr);

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -58,7 +58,6 @@ class GraphicsPipeline : public Pipeline {
                      VkImageAspectFlags aspect);
   VkFormat GetColorFormat() const { return color_format_; }
   VkFormat GetDepthStencilFormat() const { return depth_stencil_format_; }
-  Result ProcessCommands();
 
   Result SetClearColor(float r, float g, float b, float a);
   Result SetClearStencil(uint32_t stencil);
@@ -70,6 +69,7 @@ class GraphicsPipeline : public Pipeline {
 
   // Pipeline
   void Shutdown() override;
+  Result ProcessCommands() override;
 
  private:
   enum class RenderPassState : uint8_t {

--- a/src/vulkan/pipeline.h
+++ b/src/vulkan/pipeline.h
@@ -46,6 +46,7 @@ class Pipeline {
   Result AddDescriptor(const BufferCommand*);
 
   virtual void Shutdown();
+  virtual Result ProcessCommands() = 0;
 
  protected:
   Pipeline(


### PR DESCRIPTION
Split Engine::DoProcessCommands() into DoProcessCommands() and
GetFrameBufferInfo() for probing FrameBuffer and split it into
DoProcessCommands() and GetDescriptorInfo() for probing SSBO

This commit is a part of PR #101