### PR TITLE
Add row_stride to key image metrics in ResourceInfo

### DIFF
--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -36,7 +36,7 @@ const uint32_t kFramebufferWidth = 250, kFramebufferHeight = 250;
 const uint32_t kFramebufferSlot = 0;
 // The minimum multiple row pitch observed on Dawn on Metal.  Increase this
 // as needed for other Dawn backends.
-const uint32_t kImageRowPitch = 256;
+const uint32_t kMinimumImageRowPitch = 256;
 const auto kFramebufferFormat = ::dawn::TextureFormat::R8G8B8A8Unorm;
 
 // Creates a device-side texture for the framebuffer, and returns it through
@@ -90,10 +90,10 @@ Result MakeFramebufferBuffer(const ::dawn::Device& device,
   uint32_t row_stride = default_texel_bytes * kFramebufferWidth;
   {
     // Round up the stride to the minimum image row pitch.
-    const uint32_t spillover = row_stride % kImageRowPitch;
+    const uint32_t spillover = row_stride % kMinimumImageRowPitch;
     if (spillover > 0)
-      row_stride += (kImageRowPitch - spillover);
-    assert(0 == (row_stride % kImageRowPitch));
+      row_stride += (kMinimumImageRowPitch - spillover);
+    assert(0 == (row_stride % kMinimumImageRowPitch));
   }
 
   descriptor.size = row_stride * kFramebufferHeight;
@@ -435,13 +435,13 @@ Result EngineDawn::GetFrameBufferInfo(ResourceInfo* info) {
   if (render_pipeline_info_.fb_data == nullptr)
     return Result("Dawn: FrameBuffer is not mapped");
 
-  // TODO(dneto): Need to pass back a row_stride.
   info->image_info.texel_stride = render_pipeline_info_.fb_texel_stride;
+  info->image_info.row_stride = render_pipeline_info_.fb_row_stride;
   info->image_info.width = kFramebufferWidth;
   info->image_info.height = kFramebufferHeight;
   info->image_info.depth = 1U;
-  info->size_in_bytes = render_pipeline_info_.fb_texel_stride *
-                        kFramebufferWidth * kFramebufferHeight;
+  info->size_in_bytes =
+      render_pipeline_info_.fb_row_stride * kFramebufferHeight;
   info->cpu_memory = render_pipeline_info_.fb_data;
   return {};
 }

--- a/src/dawn/pipeline_info.h
+++ b/src/dawn/pipeline_info.h
@@ -44,8 +44,8 @@ struct RenderPipelineInfo {
   // The number of bytes between successive texels in framebuffer host-side
   // buffer.
   uint32_t fb_texel_stride = 0;
-  // The number of bytes between each row of texels in framebuffer host-side
-  // buffer.
+  // The number of bytes between successive rows of texels in framebuffer
+  // host-side buffer.
   uint32_t fb_row_stride = 0;
   // The number of data bytes in the framebuffer host-side buffer.
   uint32_t fb_size = 0;

--- a/src/engine.h
+++ b/src/engine.h
@@ -41,8 +41,12 @@ enum class ResourceInfoType : uint8_t {
 struct ResourceInfo {
   ResourceInfoType type = ResourceInfoType::kBuffer;
 
+  // Key metrics of a 2D image.
+  // For higher dimensions or arrayed images, we would need more strides.
+  // For example, see VkSubresourceLayout.
   struct {
     uint32_t texel_stride = 0;  // Number of bytes for a single texel.
+    uint32_t row_stride = 0;  // Number of bytes between successive pixel rows.
     uint32_t width = 0;
     uint32_t height = 0;
     uint32_t depth = 0;
@@ -50,8 +54,7 @@ struct ResourceInfo {
 
   // The size in bytes of Vulkan memory pointed by |cpu_memory|.
   // For the case when it is an image resource, |size_in_bytes| must
-  // be |image_info.width * image_info.height * image_info.depth *
-  // image_info.texel_stride|.
+  // be |image_info.row_stride * image_info.height * image_info.depth|.
   size_t size_in_bytes = 0;
 
   // If the primitive type of resource is the same with the type

--- a/src/verifier.cc
+++ b/src/verifier.cc
@@ -250,10 +250,10 @@ Result Verifier::Probe(const ProbeCommand* command,
   }
 
   if (count_of_invalid_pixels) {
-    const uint8_t* p =
-        ptr + row_stride * (first_invalid_j + y) + texel_stride * x;
+    const uint8_t* p = ptr + row_stride * (first_invalid_j + y) +
+                       texel_stride * (x + first_invalid_i);
     return Result(
-        "Probe failed at: " + std::to_string(first_invalid_i + x) + ", " +
+        "Probe failed at: " + std::to_string(x + first_invalid_i) + ", " +
         std::to_string(first_invalid_j + y) + "\n" +
         "  Expected RGBA: " + std::to_string(command->GetR() * 255) + ", " +
         std::to_string(command->GetG() * 255) + ", " +
@@ -261,15 +261,10 @@ Result Verifier::Probe(const ProbeCommand* command,
         (command->IsRGBA() ? ", " + std::to_string(command->GetA() * 255) +
                                  "\n  Actual RGBA: "
                            : "\n  Actual RGB: ") +
-        std::to_string(static_cast<int>(p[texel_stride * first_invalid_i])) +
-        ", " +
-        std::to_string(
-            static_cast<int>(p[texel_stride * first_invalid_i + 1])) +
-        ", " +
-        std::to_string(
-            static_cast<int>(p[texel_stride * first_invalid_i + 2])) +
-        (command->IsRGBA() ? ", " + std::to_string(static_cast<int>(
-                                        p[texel_stride * first_invalid_i + 3]))
+        std::to_string(static_cast<int>(p[0])) + ", " +
+        std::to_string(static_cast<int>(p[1])) + ", " +
+        std::to_string(static_cast<int>(p[2])) +
+        (command->IsRGBA() ? ", " + std::to_string(static_cast<int>(p[3]))
                            : "") +
         "\n" + "Probe failed in " + std::to_string(count_of_invalid_pixels) +
         " pixels");

--- a/src/verifier.cc
+++ b/src/verifier.cc
@@ -172,7 +172,8 @@ Verifier::Verifier() = default;
 Verifier::~Verifier() = default;
 
 Result Verifier::Probe(const ProbeCommand* command,
-                       uint32_t stride,
+                       uint32_t texel_stride,
+                       uint32_t row_stride,
                        uint32_t frame_width,
                        uint32_t frame_height,
                        const void* buf) {
@@ -198,9 +199,15 @@ Result Verifier::Probe(const ProbeCommand* command,
 
   if (x + width > frame_width || y + height > frame_height) {
     return Result(
-        "Vulkan::Probe Position(" + std::to_string(x + width - 1) + ", " +
+        "Verifier::Probe Position(" + std::to_string(x + width - 1) + ", " +
         std::to_string(y + height - 1) + ") is out of framebuffer scope (" +
         std::to_string(frame_width) + "," + std::to_string(frame_height) + ")");
+  }
+  if (row_stride < frame_width * texel_stride) {
+    return Result("Verifier::Probe Row stride of " +
+                  std::to_string(row_stride) + " is too small for " +
+                  std::to_string(frame_width) + " texels of " +
+                  std::to_string(texel_stride) + " bytes each");
   }
 
   double tolerance[4] = {};
@@ -213,25 +220,25 @@ Result Verifier::Probe(const ProbeCommand* command,
   uint32_t first_invalid_i = 0;
   uint32_t first_invalid_j = 0;
   for (uint32_t j = 0; j < height; ++j) {
-    const uint8_t* p = ptr + stride * frame_width * (j + y) + stride * x;
+    const uint8_t* p = ptr + row_stride * (j + y) + texel_stride * x;
     for (uint32_t i = 0; i < width; ++i) {
       // TODO(jaebaek): Get actual pixel values based on frame buffer formats.
       if (!IsEqualWithTolerance(
               static_cast<const double>(command->GetR()),
-              static_cast<const double>(p[stride * i]) / 255.0, tolerance[0],
-              is_tolerance_percent[0]) ||
+              static_cast<const double>(p[texel_stride * i]) / 255.0,
+              tolerance[0], is_tolerance_percent[0]) ||
           !IsEqualWithTolerance(
               static_cast<const double>(command->GetG()),
-              static_cast<const double>(p[stride * i + 1]) / 255.0,
+              static_cast<const double>(p[texel_stride * i + 1]) / 255.0,
               tolerance[1], is_tolerance_percent[1]) ||
           !IsEqualWithTolerance(
               static_cast<const double>(command->GetB()),
-              static_cast<const double>(p[stride * i + 2]) / 255.0,
+              static_cast<const double>(p[texel_stride * i + 2]) / 255.0,
               tolerance[2], is_tolerance_percent[2]) ||
           (command->IsRGBA() &&
            !IsEqualWithTolerance(
                static_cast<const double>(command->GetA()),
-               static_cast<const double>(p[stride * i + 3]) / 255.0,
+               static_cast<const double>(p[texel_stride * i + 3]) / 255.0,
                tolerance[3], is_tolerance_percent[3]))) {
         if (!count_of_invalid_pixels) {
           first_invalid_i = i;
@@ -244,7 +251,7 @@ Result Verifier::Probe(const ProbeCommand* command,
 
   if (count_of_invalid_pixels) {
     const uint8_t* p =
-        ptr + stride * frame_width * (first_invalid_j + y) + stride * x;
+        ptr + row_stride * (first_invalid_j + y) + texel_stride * x;
     return Result(
         "Probe failed at: " + std::to_string(first_invalid_i + x) + ", " +
         std::to_string(first_invalid_j + y) + "\n" +
@@ -254,12 +261,15 @@ Result Verifier::Probe(const ProbeCommand* command,
         (command->IsRGBA() ? ", " + std::to_string(command->GetA() * 255) +
                                  "\n  Actual RGBA: "
                            : "\n  Actual RGB: ") +
-        std::to_string(static_cast<int>(p[stride * first_invalid_i])) + ", " +
-        std::to_string(static_cast<int>(p[stride * first_invalid_i + 1])) +
+        std::to_string(static_cast<int>(p[texel_stride * first_invalid_i])) +
         ", " +
-        std::to_string(static_cast<int>(p[stride * first_invalid_i + 2])) +
+        std::to_string(
+            static_cast<int>(p[texel_stride * first_invalid_i + 1])) +
+        ", " +
+        std::to_string(
+            static_cast<int>(p[texel_stride * first_invalid_i + 2])) +
         (command->IsRGBA() ? ", " + std::to_string(static_cast<int>(
-                                        p[stride * first_invalid_i + 3]))
+                                        p[texel_stride * first_invalid_i + 3]))
                            : "") +
         "\n" + "Probe failed in " + std::to_string(count_of_invalid_pixels) +
         " pixels");

--- a/src/verifier.h
+++ b/src/verifier.h
@@ -26,7 +26,8 @@ class Verifier {
   ~Verifier();
 
   Result Probe(const ProbeCommand*,
-               uint32_t stride,
+               uint32_t texel_stride,
+               uint32_t row_stride,
                uint32_t frame_width,
                uint32_t frame_height,
                const void* buf);

--- a/src/verifier_test.cc
+++ b/src/verifier_test.cc
@@ -62,8 +62,8 @@ TEST_F(VerifierTest, ProbeFrameBufferWholeWindow) {
   };
 
   Verifier verifier;
-  Result r =
-      verifier.Probe(&probe, 4, 3, 3, static_cast<const void*>(frame_buffer));
+  Result r = verifier.Probe(&probe, 4, 12, 3, 3,
+                            static_cast<const void*>(frame_buffer));
   EXPECT_TRUE(r.IsSuccess());
 }
 
@@ -103,8 +103,8 @@ TEST_F(VerifierTest, ProbeFrameBufferRelative) {
   }
 
   Verifier verifier;
-  Result r =
-      verifier.Probe(&probe, 4, 10, 10, static_cast<const void*>(frame_buffer));
+  Result r = verifier.Probe(&probe, 4, 40, 10, 10,
+                            static_cast<const void*>(frame_buffer));
   EXPECT_TRUE(r.IsSuccess());
 }
 
@@ -143,8 +143,8 @@ TEST_F(VerifierTest, ProbeFrameBuffer) {
   }
 
   Verifier verifier;
-  Result r =
-      verifier.Probe(&probe, 4, 10, 10, static_cast<const void*>(frame_buffer));
+  Result r = verifier.Probe(&probe, 4, 40, 10, 10,
+                            static_cast<const void*>(frame_buffer));
   EXPECT_TRUE(r.IsSuccess());
 }
 
@@ -182,9 +182,25 @@ TEST_F(VerifierTest, ProbeFrameBufferRGB) {
   };
 
   Verifier verifier;
-  Result r =
-      verifier.Probe(&probe, 4, 3, 3, static_cast<const void*>(frame_buffer));
+  Result r = verifier.Probe(&probe, 4, 12, 3, 3,
+                            static_cast<const void*>(frame_buffer));
   EXPECT_TRUE(r.IsSuccess());
+}
+
+TEST_F(VerifierTest, ProbeFrameBufferBadRowStride) {
+  ProbeCommand probe;
+  probe.SetWholeWindow();
+
+  const uint8_t frame_buffer[4] = {128, 64, 51, 255};
+
+  Verifier verifier;
+  Result r = verifier.Probe(&probe, 4, 3, 1, 1,
+                            static_cast<const void*>(frame_buffer));
+  EXPECT_FALSE(r.IsSuccess());
+  EXPECT_STREQ(
+      "Verifier::Probe Row stride of 3 is too small for 1 texels of 4 bytes "
+      "each",
+      r.Error().c_str());
 }
 
 TEST_F(VerifierTest, ProbeSSBOUint8Single) {

--- a/src/vkscript/executor.cc
+++ b/src/vkscript/executor.cc
@@ -121,8 +121,8 @@ Result Executor::Execute(Engine* engine, const amber::Script* src_script) {
         assert(info.cpu_memory != nullptr);
 
         r = verifier_.Probe(cmd->AsProbe(), info.image_info.texel_stride,
-                            info.image_info.width, info.image_info.height,
-                            info.cpu_memory);
+                            info.image_info.row_stride, info.image_info.width,
+                            info.image_info.height, info.cpu_memory);
       } else if (cmd->IsProbeSSBO()) {
         auto probe_ssbo = cmd->AsProbeSSBO();
         ResourceInfo info;

--- a/src/vulkan/image.cc
+++ b/src/vulkan/image.cc
@@ -124,6 +124,8 @@ void Image::Shutdown() {
 Result Image::CopyToHost(VkCommandBuffer command) {
   VkBufferImageCopy copy_region = {};
   copy_region.bufferOffset = 0;
+  // Row length of 0 results in tight packing of rows, so the row stride
+  // is the number of texels times the texel stride.
   copy_region.bufferRowLength = 0;
   copy_region.bufferImageHeight = 0;
   copy_region.imageSubresource = {


### PR DESCRIPTION
This is needed for Dawn on Metal, which enforces minimum a row pitch
of 256 bytes.