### PR TITLE
Provide features and extensions to engine initialization

### DIFF
--- a/src/amber.cc
+++ b/src/amber.cc
@@ -54,15 +54,25 @@ amber::Result Amber::Execute(const std::string& input, const Options& opts) {
   if (!engine)
     return Result("Failed to create engine");
 
-  if (opts.default_device)
+  const auto* script = parser->GetScript();
+
+  if (opts.default_device) {
+    // TODO(dsinclair): Should these be errors?
+    if (!script->RequiredFeatures().empty())
+      return Result("Required features provided with external device");
+    if (!script->RequiredFeatures().empty())
+      return Result("Required extensions provided with external device");
+
     r = engine->InitializeWithDevice(opts.default_device);
-  else
-    r = engine->Initialize();
+  } else {
+    r = engine->Initialize(script->RequiredFeatures(),
+                           script->RequiredExtensions());
+  }
 
   if (!r.IsSuccess())
     return r;
 
-  r = executor->Execute(engine.get(), parser->GetScript());
+  r = executor->Execute(engine.get(), script);
   if (!r.IsSuccess())
     return r;
 

--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -174,7 +174,8 @@ EngineDawn::EngineDawn() : Engine() {}
 
 EngineDawn::~EngineDawn() = default;
 
-Result EngineDawn::Initialize() {
+Result EngineDawn::Initialize(const std::vector<Feature>&,
+                              const std::vector<std::string>&) {
   if (device_)
     return Result("Dawn:Initialize device_ already exists");
 

--- a/src/dawn/engine_dawn.h
+++ b/src/dawn/engine_dawn.h
@@ -16,6 +16,7 @@
 #define SRC_DAWN_ENGINE_DAWN_H_
 
 #include <cstdint>
+#include <string>
 #include <unordered_map>
 #include <vector>
 

--- a/src/dawn/engine_dawn.h
+++ b/src/dawn/engine_dawn.h
@@ -36,7 +36,8 @@ class EngineDawn : public Engine {
 
   // Engine
   // Initialize with a default device.
-  Result Initialize() override;
+  Result Initialize(const std::vector<Feature>& features,
+                    const std::vector<std::string>& extensions) override;
   // Initialize with a given device, specified as a pointer-to-::dawn::Device
   // disguised as a pointer-to-void.
   Result InitializeWithDevice(void* default_device) override;

--- a/src/engine.h
+++ b/src/engine.h
@@ -70,8 +70,10 @@ class Engine {
 
   virtual ~Engine();
 
-  // Initialize the engine.
-  virtual Result Initialize() = 0;
+  // Initialize the engine. The |features| list is a set of required features
+  // for the device. The |extensions| list is a list of required extensions.
+  virtual Result Initialize(const std::vector<Feature>& features,
+                            const std::vector<std::string>& extensions) = 0;
 
   // Initialize the engine with the provided device. The device is _not_ owned
   // by the engine and should not be destroyed.

--- a/src/engine.h
+++ b/src/engine.h
@@ -16,6 +16,7 @@
 #define SRC_ENGINE_H_
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "amber/amber.h"

--- a/src/script.h
+++ b/src/script.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "amber/result.h"
+#include "src/feature.h"
 #include "src/shader.h"
 
 namespace amber {
@@ -56,10 +57,29 @@ class Script {
     return shaders_;
   }
 
+  void AddRequiredFeature(Feature feature) {
+    engine_info_.required_features.push_back(feature);
+  }
+  const std::vector<Feature>& RequiredFeatures() const {
+    return engine_info_.required_features;
+  }
+
+  void AddRequiredExtension(const std::string& ext) {
+    engine_info_.required_extensions.push_back(ext);
+  }
+  const std::vector<std::string>& RequiredExtensions() const {
+    return engine_info_.required_extensions;
+  }
+
  protected:
   explicit Script(ScriptType);
 
  private:
+  struct {
+    std::vector<Feature> required_features;
+    std::vector<std::string> required_extensions;
+  } engine_info_;
+
   ScriptType script_type_;
   std::map<std::string, Shader*> name_to_shader_;
   std::vector<std::unique_ptr<Shader>> shaders_;

--- a/src/vkscript/executor_test.cc
+++ b/src/vkscript/executor_test.cc
@@ -243,88 +243,14 @@ class EngineStub : public Engine {
   ClearColorCommand* last_clear_color_ = nullptr;
 };
 
-class EngineCountingStub : public Engine {
- public:
-  EngineCountingStub() : Engine() {}
-  ~EngineCountingStub() override = default;
-
-  // Engine
-  Result Initialize(const std::vector<Feature>&,
-                    const std::vector<std::string>&) override {
-    return {};
-  }
-
-  Result InitializeWithDevice(void*) override { return {}; }
-
-  Result Shutdown() override { return {}; }
-
-  int32_t GetRequireStageIdx() const { return require_stage_; }
-  uint32_t GetRequireCount() const { return require_stage_count_; }
-  Result AddRequirement(Feature, const Format*, uint32_t) override {
-    ++require_stage_count_;
-    require_stage_ = stage_count_++;
-    return {};
-  }
-  Result CreatePipeline(PipelineType) override { return {}; }
-
-  int32_t GetShaderStageIdx() const { return shader_stage_; }
-  uint32_t GetShaderCount() const { return shader_stage_count_; }
-  Result SetShader(ShaderType, const std::vector<uint32_t>&) override {
-    ++shader_stage_count_;
-    shader_stage_ = stage_count_++;
-    return {};
-  }
-  Result SetBuffer(BufferType,
-                   uint8_t,
-                   const Format&,
-                   const std::vector<Value>&) override {
-    return {};
-  }
-
-  Result DoClearColor(const ClearColorCommand*) override { return {}; }
-  Result DoClearStencil(const ClearStencilCommand*) override { return {}; }
-  Result DoClearDepth(const ClearDepthCommand*) override { return {}; }
-  Result DoClear(const ClearCommand*) override { return {}; }
-  Result DoDrawRect(const DrawRectCommand*) override { return {}; }
-  Result DoDrawArrays(const DrawArraysCommand*) override { return {}; }
-  Result DoCompute(const ComputeCommand*) override { return {}; }
-  Result DoEntryPoint(const EntryPointCommand*) override { return {}; }
-  Result DoPatchParameterVertices(
-      const PatchParameterVerticesCommand*) override {
-    return {};
-  }
-  Result DoBuffer(const BufferCommand*) override { return {}; }
-  Result DoProcessCommands() override { return {}; }
-  Result GetFrameBufferInfo(ResourceInfo*) override { return {}; }
-  Result GetDescriptorInfo(const uint32_t,
-                           const uint32_t,
-                           ResourceInfo*) override {
-    return {};
-  }
-
- private:
-  int32_t stage_count_ = 0;
-  int32_t require_stage_ = -1;
-  int32_t shader_stage_ = -1;
-  uint32_t require_stage_count_ = 0;
-  uint32_t shader_stage_count_ = 0;
-};
-
 class VkScriptExecutorTest : public testing::Test {
  public:
   VkScriptExecutorTest() = default;
   ~VkScriptExecutorTest() = default;
 
   std::unique_ptr<Engine> MakeEngine() { return MakeUnique<EngineStub>(); }
-  std::unique_ptr<Engine> MakeCountingEngine() {
-    return MakeUnique<EngineCountingStub>();
-  }
   EngineStub* ToStub(Engine* engine) {
     return static_cast<EngineStub*>(engine);
-  }
-
-  EngineCountingStub* ToCountingStub(Engine* engine) {
-    return static_cast<EngineCountingStub*>(engine);
   }
 };
 

--- a/src/vkscript/nodes.cc
+++ b/src/vkscript/nodes.cc
@@ -57,10 +57,6 @@ RequireNode::Requirement::Requirement(Requirement&&) = default;
 
 RequireNode::Requirement::~Requirement() = default;
 
-void RequireNode::AddRequirement(Feature feature) {
-  requirements_.emplace_back(feature);
-}
-
 void RequireNode::AddRequirement(Feature feature,
                                  std::unique_ptr<Format> format) {
   requirements_.emplace_back(feature, std::move(format));

--- a/src/vkscript/nodes.h
+++ b/src/vkscript/nodes.h
@@ -79,18 +79,13 @@ class RequireNode : public Node {
   RequireNode();
   ~RequireNode() override;
 
-  void AddRequirement(Feature feature);
   void AddRequirement(Feature feature, std::unique_ptr<Format> format);
   void AddRequirement(Feature feature, uint32_t value);
 
   const std::vector<Requirement>& Requirements() const { return requirements_; }
 
-  void AddExtension(const std::string& ext) { extensions_.push_back(ext); }
-  const std::vector<std::string>& Extensions() const { return extensions_; }
-
  private:
   std::vector<Requirement> requirements_;
-  std::vector<std::string> extensions_;
 };
 
 class IndicesNode : public Node {

--- a/src/vkscript/parser.cc
+++ b/src/vkscript/parser.cc
@@ -228,7 +228,7 @@ Result Parser::ProcessRequireBlock(const std::string& data) {
       if (it != str.end())
         return Result("Unknown feature or extension: " + str);
 
-      node->AddExtension(str);
+      script_.AddRequiredExtension(str);
     } else if (feature == Feature::kFramebuffer) {
       token = tokenizer.NextToken();
       if (!token->IsString())
@@ -258,7 +258,7 @@ Result Parser::ProcessRequireBlock(const std::string& data) {
 
       node->AddRequirement(feature, token->AsUint32());
     } else {
-      node->AddRequirement(feature);
+      script_.AddRequiredFeature(feature);
     }
 
     token = tokenizer.NextToken();
@@ -266,7 +266,7 @@ Result Parser::ProcessRequireBlock(const std::string& data) {
       return Result("Failed to parser requirements block: invalid token");
   }
 
-  if (!node->Requirements().empty() || !node->Extensions().empty())
+  if (!node->Requirements().empty())
     script_.AddRequireNode(std::move(node));
 
   return {};

--- a/src/vkscript/parser_test.cc
+++ b/src/vkscript/parser_test.cc
@@ -114,13 +114,9 @@ TEST_F(VkScriptParserTest, RequireBlockNoArgumentFeatures) {
     Result r = parser.ProcessRequireBlockForTesting(feature.name);
     ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-    auto& nodes = ToVkScript(parser.GetScript())->Nodes();
-    ASSERT_EQ(1U, nodes.size());
-    ASSERT_TRUE(nodes[0]->IsRequire());
-
-    auto req = nodes[0]->AsRequire();
-    ASSERT_EQ(1U, req->Requirements().size());
-    EXPECT_EQ(feature.feature, req->Requirements()[0].GetFeature());
+    auto& feats = ToVkScript(parser.GetScript())->RequiredFeatures();
+    ASSERT_EQ(1U, feats.size());
+    EXPECT_EQ(feature.feature, feats[0]);
   }
 }
 
@@ -132,14 +128,8 @@ VK_KHR_variable_pointers)";
   Result r = parser.ProcessRequireBlockForTesting(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& nodes = ToVkScript(parser.GetScript())->Nodes();
-  ASSERT_EQ(1U, nodes.size());
-  ASSERT_TRUE(nodes[0]->IsRequire());
-
-  auto req = nodes[0]->AsRequire();
-  ASSERT_EQ(2U, req->Extensions().size());
-
-  const auto& exts = req->Extensions();
+  auto& exts = parser.GetScript()->RequiredExtensions();
+  ASSERT_EQ(2U, exts.size());
   EXPECT_EQ("VK_KHR_storage_buffer_storage_class", exts[0]);
   EXPECT_EQ("VK_KHR_variable_pointers", exts[1]);
 }
@@ -210,19 +200,18 @@ inheritedQueries # line comment
   ASSERT_TRUE(nodes[0]->IsRequire());
 
   auto* req = nodes[0]->AsRequire();
-  ASSERT_EQ(4U, req->Requirements().size());
+  ASSERT_EQ(2U, req->Requirements().size());
   EXPECT_EQ(Feature::kDepthStencil, req->Requirements()[0].GetFeature());
   auto format = req->Requirements()[0].GetFormat();
   EXPECT_EQ(FormatType::kD24_UNORM_S8_UINT, format->GetFormatType());
 
-  EXPECT_EQ(Feature::kSparseResidency4Samples,
-            req->Requirements()[1].GetFeature());
-
-  EXPECT_EQ(Feature::kFramebuffer, req->Requirements()[2].GetFeature());
-  format = req->Requirements()[2].GetFormat();
+  EXPECT_EQ(Feature::kFramebuffer, req->Requirements()[1].GetFeature());
+  format = req->Requirements()[1].GetFormat();
   EXPECT_EQ(FormatType::kR32G32B32A32_SFLOAT, format->GetFormatType());
 
-  EXPECT_EQ(Feature::kInheritedQueries, req->Requirements()[3].GetFeature());
+  auto& feats = script->RequiredFeatures();
+  EXPECT_EQ(Feature::kSparseResidency4Samples, feats[0]);
+  EXPECT_EQ(Feature::kInheritedQueries, feats[1]);
 }
 
 TEST_F(VkScriptParserTest, IndicesBlock) {

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -72,7 +72,8 @@ Result EngineVulkan::InitDeviceAndCreateCommand() {
   return {};
 }
 
-Result EngineVulkan::Initialize() {
+Result EngineVulkan::Initialize(const std::vector<Feature>&,
+                                const std::vector<std::string>&) {
   if (device_)
     return Result("Vulkan::Set device_ already exists");
 

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -16,6 +16,7 @@
 #define SRC_VULKAN_ENGINE_VULKAN_H_
 
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <vector>
 

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -35,7 +35,8 @@ class EngineVulkan : public Engine {
   ~EngineVulkan() override;
 
   // Engine
-  Result Initialize() override;
+  Result Initialize(const std::vector<Feature>& features,
+                    const std::vector<std::string>& extensions) override;
   Result InitializeWithDevice(void* default_device) override;
   Result Shutdown() override;
   Result AddRequirement(Feature feature, const Format*, uint32_t) override;
@@ -80,6 +81,8 @@ class EngineVulkan : public Engine {
     const Format* format;
   };
 
+  std::vector<Feature> features_;
+  std::vector<std::string> extensions_;
   std::vector<Requirement> requirements_;
   std::vector<Requirement>::iterator FindFeature(Feature feature);
 };


### PR DESCRIPTION
This CL changes the requires data to pass a list of features and a
list of extensions into the initialize method of the engines instead
of using require nodes.

The framebuffer, depth_stencil and fence_timeout are still provided as
require nodes.