### PR TITLE
Allow host to provide a shader map.

### DIFF
--- a/include/amber/amber.h
+++ b/include/amber/amber.h
@@ -57,7 +57,8 @@ class Amber {
   /// |shader_map| to lookup shader data before attempting to compile the
   /// shader if possible.
   amber::Result ExecuteWithShaderData(const std::string& data,
-      const Options& opts, const ShaderMap& shader_data);
+                                      const Options& opts,
+                                      const ShaderMap& shader_data);
 };
 
 }  // namespace amber

--- a/include/amber/amber.h
+++ b/include/amber/amber.h
@@ -23,6 +23,8 @@
 
 namespace amber {
 
+/// The shader map is a map from the name of a shader to the spirv-binary
+/// which is the compiled represntation of that named shader.
 using ShaderMap = std::map<std::string, std::vector<uint32_t>>;
 
 enum class EngineType : uint8_t {

--- a/include/amber/amber.h
+++ b/include/amber/amber.h
@@ -25,7 +25,7 @@
 namespace amber {
 
 /// The shader map is a map from the name of a shader to the spirv-binary
-/// which is the compiled represntation of that named shader.
+/// which is the compiled representation of that named shader.
 using ShaderMap = std::map<std::string, std::vector<uint32_t>>;
 
 enum class EngineType : uint8_t {
@@ -57,7 +57,7 @@ class Amber {
   /// |Result| which indicates if the execution succeded.
   amber::Result Execute(const std::string& data, const Options& opts);
 
-  /// Executes the given |data| script with the provided |opts. Will use
+  /// Executes the given |data| script with the provided |opts|. Will use
   /// |shader_map| to lookup shader data before attempting to compile the
   /// shader if possible.
   amber::Result ExecuteWithShaderData(const std::string& data,

--- a/include/amber/amber.h
+++ b/include/amber/amber.h
@@ -15,11 +15,15 @@
 #ifndef AMBER_AMBER_H_
 #define AMBER_AMBER_H_
 
+#include <map>
 #include <string>
+#include <vector>
 
 #include "amber/result.h"
 
 namespace amber {
+
+using ShaderMap = std::map<std::string, std::vector<uint32_t>>;
 
 enum class EngineType : uint8_t {
   /// Use the Vulkan backend, if available
@@ -48,6 +52,12 @@ class Amber {
   /// Executes the given |data| script with the provided |opts|. Returns a
   /// |Result| which indicates if the execution succeded.
   amber::Result Execute(const std::string& data, const Options& opts);
+
+  /// Executes the given |data| script with the provided |opts. Will use
+  /// |shader_map| to lookup shader data before attempting to compile the
+  /// shader if possible.
+  amber::Result ExecuteWithShaderData(const std::string& data,
+      const Options& opts, const ShaderMap& shader_data);
 };
 
 }  // namespace amber

--- a/src/amber.cc
+++ b/src/amber.cc
@@ -38,7 +38,8 @@ amber::Result Amber::Execute(const std::string& input, const Options& opts) {
 }
 
 amber::Result Amber::ExecuteWithShaderData(const std::string& input,
-      const Options& opts, const ShaderMap& shader_data) {
+                                           const Options& opts,
+                                           const ShaderMap& shader_data) {
   std::unique_ptr<Parser> parser;
   std::unique_ptr<Executor> executor;
   if (input.substr(0, 7) == "#!amber") {

--- a/src/amber.cc
+++ b/src/amber.cc
@@ -33,6 +33,12 @@ Amber::Amber() = default;
 Amber::~Amber() = default;
 
 amber::Result Amber::Execute(const std::string& input, const Options& opts) {
+  ShaderMap map;
+  return ExecuteWithShaderData(input, opts, map);
+}
+
+amber::Result Amber::ExecuteWithShaderData(const std::string& input,
+      const Options& opts, const ShaderMap& shader_data) {
   std::unique_ptr<Parser> parser;
   std::unique_ptr<Executor> executor;
   if (input.substr(0, 7) == "#!amber") {
@@ -72,7 +78,7 @@ amber::Result Amber::Execute(const std::string& input, const Options& opts) {
   if (!r.IsSuccess())
     return r;
 
-  r = executor->Execute(engine.get(), script);
+  r = executor->Execute(engine.get(), script, shader_data);
   if (!r.IsSuccess())
     return r;
 

--- a/src/amberscript/executor.cc
+++ b/src/amberscript/executor.cc
@@ -21,7 +21,8 @@ Executor::Executor() : amber::Executor() {}
 
 Executor::~Executor() = default;
 
-Result Executor::Execute(Engine*, const amber::Script* src_script) {
+Result Executor::Execute(Engine*, const amber::Script* src_script,
+    const ShaderMap&) {
   if (!src_script->IsAmberScript())
     return Result("AmberScript executor called with non-amber script source");
 

--- a/src/amberscript/executor.cc
+++ b/src/amberscript/executor.cc
@@ -21,8 +21,9 @@ Executor::Executor() : amber::Executor() {}
 
 Executor::~Executor() = default;
 
-Result Executor::Execute(Engine*, const amber::Script* src_script,
-    const ShaderMap&) {
+Result Executor::Execute(Engine*,
+                         const amber::Script* src_script,
+                         const ShaderMap&) {
   if (!src_script->IsAmberScript())
     return Result("AmberScript executor called with non-amber script source");
 

--- a/src/amberscript/executor.h
+++ b/src/amberscript/executor.h
@@ -28,7 +28,7 @@ class Executor : public amber::Executor {
   Executor();
   ~Executor() override;
 
-  Result Execute(Engine*, const amber::Script*) override;
+  Result Execute(Engine*, const amber::Script*, const ShaderMap&) override;
 };
 
 }  // namespace amberscript

--- a/src/executor.h
+++ b/src/executor.h
@@ -25,7 +25,7 @@ class Executor {
  public:
   virtual ~Executor();
 
-  virtual Result Execute(Engine*, const Script*) = 0;
+  virtual Result Execute(Engine*, const Script*, const ShaderMap&) = 0;
 
  protected:
   Executor();

--- a/src/shader_compiler.cc
+++ b/src/shader_compiler.cc
@@ -37,9 +37,11 @@ ShaderCompiler::ShaderCompiler() = default;
 ShaderCompiler::~ShaderCompiler() = default;
 
 std::pair<Result, std::vector<uint32_t>> ShaderCompiler::Compile(
-    ShaderType type,
-    ShaderFormat fmt,
-    const std::string& data) const {
+    Shader* shader, const ShaderMap& shader_map) const {
+  auto it = shader_map.find(shader->GetName());
+  if (it != shader_map.end())
+    return {{}, it->second};
+
   std::string spv_errors;
   // TODO(dsinclair): Vulkan env should be an option.
   spvtools::SpirvTools tools(SPV_ENV_UNIVERSAL_1_0);
@@ -67,17 +69,17 @@ std::pair<Result, std::vector<uint32_t>> ShaderCompiler::Compile(
   });
 
   std::vector<uint32_t> results;
-  if (fmt == ShaderFormat::kGlsl) {
-    Result r = CompileGlsl(type, data, &results);
+  if (shader->GetFormat() == ShaderFormat::kGlsl) {
+    Result r = CompileGlsl(shader, &results);
     if (!r.IsSuccess())
       return {r, {}};
-  } else if (fmt == ShaderFormat::kSpirvAsm) {
-    if (!tools.Assemble(data, &results,
+  } else if (shader->GetFormat() == ShaderFormat::kSpirvAsm) {
+    if (!tools.Assemble(shader->GetData(), &results,
                         spvtools::SpirvTools::kDefaultAssembleOption)) {
       return {Result("Shader assembly failed: " + spv_errors), {}};
     }
-  } else if (fmt == ShaderFormat::kSpirvHex) {
-    Result r = ParseHex(data, &results);
+  } else if (shader->GetFormat() == ShaderFormat::kSpirvHex) {
+    Result r = ParseHex(shader->GetData(), &results);
     if (!r.IsSuccess())
       return {Result("Unable to parse shader hex."), {}};
   } else {
@@ -117,30 +119,29 @@ Result ShaderCompiler::ParseHex(const std::string& data,
   return {};
 }
 
-Result ShaderCompiler::CompileGlsl(ShaderType shader_type,
-                                   const std::string& data,
+Result ShaderCompiler::CompileGlsl(Shader* shader,
                                    std::vector<uint32_t>* result) const {
   shaderc::Compiler compiler;
   shaderc::CompileOptions options;
 
   shaderc_shader_kind kind;
-  if (shader_type == ShaderType::kCompute)
+  if (shader->GetType() == ShaderType::kCompute)
     kind = shaderc_compute_shader;
-  else if (shader_type == ShaderType::kFragment)
+  else if (shader->GetType() == ShaderType::kFragment)
     kind = shaderc_fragment_shader;
-  else if (shader_type == ShaderType::kGeometry)
+  else if (shader->GetType() == ShaderType::kGeometry)
     kind = shaderc_geometry_shader;
-  else if (shader_type == ShaderType::kVertex)
+  else if (shader->GetType() == ShaderType::kVertex)
     kind = shaderc_vertex_shader;
-  else if (shader_type == ShaderType::kTessellationControl)
+  else if (shader->GetType() == ShaderType::kTessellationControl)
     kind = shaderc_tess_control_shader;
-  else if (shader_type == ShaderType::kTessellationEvaluation)
+  else if (shader->GetType() == ShaderType::kTessellationEvaluation)
     kind = shaderc_tess_evaluation_shader;
   else
     return Result("Unknown shader type");
 
   shaderc::SpvCompilationResult module =
-      compiler.CompileGlslToSpv(data, kind, "-", options);
+      compiler.CompileGlslToSpv(shader->GetData(), kind, "-", options);
 
   if (module.GetCompilationStatus() != shaderc_compilation_status_success)
     return Result(module.GetErrorMessage());

--- a/src/shader_compiler.cc
+++ b/src/shader_compiler.cc
@@ -37,7 +37,8 @@ ShaderCompiler::ShaderCompiler() = default;
 ShaderCompiler::~ShaderCompiler() = default;
 
 std::pair<Result, std::vector<uint32_t>> ShaderCompiler::Compile(
-    Shader* shader, const ShaderMap& shader_map) const {
+    Shader* shader,
+    const ShaderMap& shader_map) const {
   auto it = shader_map.find(shader->GetName());
   if (it != shader_map.end())
     return {{}, it->second};

--- a/src/shader_compiler.h
+++ b/src/shader_compiler.h
@@ -31,13 +31,13 @@ class ShaderCompiler {
   ShaderCompiler();
   ~ShaderCompiler();
 
-  std::pair<Result, std::vector<uint32_t>>
-  Compile(Shader* shader, const ShaderMap& shader_map) const;
+  std::pair<Result, std::vector<uint32_t>> Compile(
+      Shader* shader,
+      const ShaderMap& shader_map) const;
 
  private:
   Result ParseHex(const std::string& data, std::vector<uint32_t>* result) const;
-  Result CompileGlsl(Shader* shader,
-                     std::vector<uint32_t>* result) const;
+  Result CompileGlsl(Shader* shader, std::vector<uint32_t>* result) const;
 };
 
 }  // namespace amber

--- a/src/shader_compiler.h
+++ b/src/shader_compiler.h
@@ -19,7 +19,9 @@
 #include <utility>
 #include <vector>
 
+#include "amber/amber.h"
 #include "amber/result.h"
+#include "src/shader.h"
 #include "src/shader_data.h"
 
 namespace amber {
@@ -30,12 +32,11 @@ class ShaderCompiler {
   ~ShaderCompiler();
 
   std::pair<Result, std::vector<uint32_t>>
-  Compile(ShaderType type, ShaderFormat fmt, const std::string& data) const;
+  Compile(Shader* shader, const ShaderMap& shader_map) const;
 
  private:
   Result ParseHex(const std::string& data, std::vector<uint32_t>* result) const;
-  Result CompileGlsl(ShaderType shader_type,
-                     const std::string& data,
+  Result CompileGlsl(Shader* shader,
                      std::vector<uint32_t>* result) const;
 };
 

--- a/src/shader_compiler_test.cc
+++ b/src/shader_compiler_test.cc
@@ -188,7 +188,7 @@ TEST_F(ShaderCompilerTest, ReturnsCachedShader) {
   // we don't compile this so the test will pass.
   std::string contents = "Just Random\nText()\nThat doesn't work.";
 
-  static const std::string kShaderName = "CachedShader";
+  static const char kShaderName[] = "CachedShader";
   Shader shader(ShaderType::kVertex);
   shader.SetName(kShaderName);
   shader.SetFormat(ShaderFormat::kGlsl);

--- a/src/vkscript/executor.cc
+++ b/src/vkscript/executor.cc
@@ -29,7 +29,8 @@ Executor::Executor() : amber::Executor() {}
 
 Executor::~Executor() = default;
 
-Result Executor::Execute(Engine* engine, const amber::Script* src_script) {
+Result Executor::Execute(Engine* engine, const amber::Script* src_script,
+    const ShaderMap& shader_map) {
   if (!src_script->IsVkScript())
     return Result("VkScript Executor called with non-vkscript source");
 
@@ -55,8 +56,7 @@ Result Executor::Execute(Engine* engine, const amber::Script* src_script) {
 
     Result r;
     std::vector<uint32_t> data;
-    std::tie(r, data) =
-        sc.Compile(shader->GetType(), shader->GetFormat(), shader->GetData());
+    std::tie(r, data) = sc.Compile(shader.get(), shader_map);
     if (!r.IsSuccess())
       return r;
 

--- a/src/vkscript/executor.cc
+++ b/src/vkscript/executor.cc
@@ -29,8 +29,9 @@ Executor::Executor() : amber::Executor() {}
 
 Executor::~Executor() = default;
 
-Result Executor::Execute(Engine* engine, const amber::Script* src_script,
-    const ShaderMap& shader_map) {
+Result Executor::Execute(Engine* engine,
+                         const amber::Script* src_script,
+                         const ShaderMap& shader_map) {
   if (!src_script->IsVkScript())
     return Result("VkScript Executor called with non-vkscript source");
 

--- a/src/vkscript/executor.h
+++ b/src/vkscript/executor.h
@@ -27,7 +27,7 @@ class Executor : public amber::Executor {
   Executor();
   ~Executor() override;
 
-  Result Execute(Engine* engine, const amber::Script* script) override;
+  Result Execute(Engine*, const amber::Script*, const ShaderMap&) override;
 
  private:
   Verifier verifier_;

--- a/src/vkscript/executor_test.cc
+++ b/src/vkscript/executor_test.cc
@@ -268,7 +268,7 @@ framebuffer R32G32B32A32_SINT)";
   ToStub(engine.get())->FailRequirements();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("requirements failed", r.Error());
 }
@@ -284,7 +284,7 @@ framebuffer R32G32B32A32_SINT)";
   auto engine = MakeEngine();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
 
   auto requirements = ToStub(engine.get())->GetRequirements();
@@ -309,7 +309,7 @@ void main() {}
   auto engine = MakeEngine();
 
   Executor ex;
-  r = ex.Execute(engine.get(), parser.GetScript());
+  r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
 
   auto shader_types = ToStub(engine.get())->GetShaderTypesSeen();
@@ -333,7 +333,7 @@ void main() {}
   ToStub(engine.get())->FailShaderCommand();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("shader command failed", r.Error());
 }
@@ -349,7 +349,7 @@ clear)";
   auto engine = MakeEngine();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   EXPECT_TRUE(ToStub(engine.get())->DidClearCommand());
 }
@@ -366,7 +366,7 @@ clear)";
   ToStub(engine.get())->FailClearCommand();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("clear command failed", r.Error());
 }
@@ -382,7 +382,7 @@ clear color 244 123 123 13)";
   auto engine = MakeEngine();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidClearColorCommand());
 
@@ -408,7 +408,7 @@ clear color 123 123 123 123)";
   ToStub(engine.get())->FailClearColorCommand();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("clear color command failed", r.Error());
 }
@@ -424,7 +424,7 @@ clear depth 24)";
   auto engine = MakeEngine();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidClearDepthCommand());
 }
@@ -441,7 +441,7 @@ clear depth 24)";
   ToStub(engine.get())->FailClearDepthCommand();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("clear depth command failed", r.Error());
 }
@@ -457,7 +457,7 @@ clear stencil 24)";
   auto engine = MakeEngine();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidClearStencilCommand());
 }
@@ -474,7 +474,7 @@ clear stencil 24)";
   ToStub(engine.get())->FailClearStencilCommand();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("clear stencil command failed", r.Error());
 }
@@ -490,7 +490,7 @@ draw rect 2 4 10 20)";
   auto engine = MakeEngine();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidDrawRectCommand());
 }
@@ -507,7 +507,7 @@ draw rect 2 4 10 20)";
   ToStub(engine.get())->FailDrawRectCommand();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("draw rect command failed", r.Error());
 }
@@ -523,7 +523,7 @@ draw arrays TRIANGLE_LIST 0 0)";
   auto engine = MakeEngine();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidDrawArraysCommand());
 }
@@ -540,7 +540,7 @@ draw arrays TRIANGLE_LIST 0 0)";
   ToStub(engine.get())->FailDrawArraysCommand();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("draw arrays command failed", r.Error());
 }
@@ -556,7 +556,7 @@ compute 2 3 4)";
   auto engine = MakeEngine();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidComputeCommand());
 }
@@ -573,7 +573,7 @@ compute 2 3 4)";
   ToStub(engine.get())->FailComputeCommand();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("compute command failed", r.Error());
 }
@@ -589,7 +589,7 @@ vertex entrypoint main)";
   auto engine = MakeEngine();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidEntryPointCommand());
 }
@@ -606,7 +606,7 @@ vertex entrypoint main)";
   ToStub(engine.get())->FailEntryPointCommand();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("entrypoint command failed", r.Error());
 }
@@ -622,7 +622,7 @@ patch parameter vertices 10)";
   auto engine = MakeEngine();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidPatchParameterVerticesCommand());
 }
@@ -639,7 +639,7 @@ patch parameter vertices 10)";
   ToStub(engine.get())->FailPatchParameterVerticesCommand();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("patch command failed", r.Error());
 }
@@ -655,7 +655,7 @@ probe rect rgba 2 3 40 40 0.2 0.4 0.4 0.3)";
   auto engine = MakeEngine();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   // ASSERT_TRUE(ToStub(engine.get())->DidProbeCommand());
 }
@@ -672,7 +672,7 @@ probe rect rgba 2 3 40 40 0.2 0.4 0.4 0.3)";
   // ToStub(engine.get())->FailProbeCommand();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("probe command failed", r.Error());
 }
@@ -688,7 +688,7 @@ ssbo 0 24)";
   auto engine = MakeEngine();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidBufferCommand());
 }
@@ -705,7 +705,7 @@ ssbo 0 24)";
   ToStub(engine.get())->FailBufferCommand();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("buffer command failed", r.Error());
 }
@@ -721,7 +721,7 @@ probe ssbo vec3 0 2 <= 2 3 4)";
   auto engine = MakeEngine();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   // ASSERT_TRUE(ToStub(engine.get())->DidProbeSSBOCommand());
 }
@@ -738,7 +738,7 @@ probe ssbo vec3 0 2 <= 2 3 4)";
   // ToStub(engine.get())->FailProbeSSBOCommand();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("probe ssbo command failed", r.Error());
 }
@@ -756,7 +756,7 @@ TEST_F(VkScriptExecutorTest, VertexData) {
   auto engine = MakeEngine();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
 
   auto stub = ToStub(engine.get());
@@ -800,7 +800,7 @@ TEST_F(VkScriptExecutorTest, IndexBuffer) {
   auto engine = MakeEngine();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript());
+  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
 
   auto stub = ToStub(engine.get());


### PR DESCRIPTION
This CL extends the Amber interface to allow a Shader map to be
provided. This map allows the caller to pre-compile the shaders and
provide the name to data mapping. The ShaderCompiler will then pull from
the map before attempting to do a compile.