### PR TITLE
Fix: compiler errors

### DIFF
--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -20,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+#include "amber/amber_dawn.h"
 #include "dawn/dawncpp.h"
 #include "src/dawn/device_metal.h"
 #include "src/sleep.h"

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cassert>
 
+#include "amber/amber_vulkan.h"
 #include "src/make_unique.h"
 #include "src/vulkan/compute_pipeline.h"
 #include "src/vulkan/descriptor.h"


### PR DESCRIPTION
Missing header files related to configurations cause compiler errors.