### PR TITLE
Create an EngineData structure.

### DIFF
--- a/src/amber.cc
+++ b/src/amber.cc
@@ -74,8 +74,6 @@ amber::Result Amber::ExecuteWithShaderData(const std::string& input,
   if (!r.IsSuccess())
     return r;
 
-  engine->SetEngineData(script->GetEngineData());
-
   r = executor->Execute(engine.get(), script, shader_data);
   if (!r.IsSuccess())
     return r;

--- a/src/amber.cc
+++ b/src/amber.cc
@@ -68,9 +68,10 @@ amber::Result Amber::Execute(const std::string& input, const Options& opts) {
     r = engine->Initialize(script->RequiredFeatures(),
                            script->RequiredExtensions());
   }
-
   if (!r.IsSuccess())
     return r;
+
+  engine->SetEngineData(script->GetEngineData());
 
   r = executor->Execute(engine.get(), script);
   if (!r.IsSuccess())

--- a/src/amber.cc
+++ b/src/amber.cc
@@ -54,15 +54,25 @@ amber::Result Amber::Execute(const std::string& input, const Options& opts) {
   if (!engine)
     return Result("Failed to create engine");
 
-  if (opts.default_device)
+  const auto* script = parser->GetScript();
+
+  if (opts.default_device) {
+    // TODO(dsinclair): Should these be errors?
+    if (!script->RequiredFeatures().empty())
+      return Result("Required features provided with external device");
+    if (!script->RequiredFeatures().empty())
+      return Result("Required extensions provided with external device");
+
     r = engine->InitializeWithDevice(opts.default_device);
-  else
-    r = engine->Initialize();
+  } else {
+    r = engine->Initialize(script->RequiredFeatures(),
+                           script->RequiredExtensions());
+  }
 
   if (!r.IsSuccess())
     return r;
 
-  r = executor->Execute(engine.get(), parser->GetScript());
+  r = executor->Execute(engine.get(), script);
   if (!r.IsSuccess())
     return r;
 

--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -233,7 +233,7 @@ Result EngineDawn::CreatePipeline(PipelineType type) {
   return {};
 }
 
-Result EngineDawn::AddRequirement(Feature, const Format*, uint32_t) {
+Result EngineDawn::AddRequirement(Feature, const Format*) {
   return Result("Dawn:AddRequirement not implemented");
 }
 

--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -174,7 +174,8 @@ EngineDawn::EngineDawn() : Engine() {}
 
 EngineDawn::~EngineDawn() = default;
 
-Result EngineDawn::Initialize() {
+Result EngineDawn::Initialize(const std::vector<Feature>&,
+                              const std::vector<std::string>&) {
   if (device_)
     return Result("Dawn:Initialize device_ already exists");
 

--- a/src/dawn/engine_dawn.h
+++ b/src/dawn/engine_dawn.h
@@ -48,7 +48,7 @@ class EngineDawn : public Engine {
   // pipeline requires a compute shader.  A graphics pipeline requires a vertex
   // and a fragment shader.
   Result CreatePipeline(PipelineType) override;
-  Result AddRequirement(Feature feature, const Format*, uint32_t) override;
+  Result AddRequirement(Feature feature, const Format*) override;
   Result SetShader(ShaderType type, const std::vector<uint32_t>& data) override;
   Result SetBuffer(BufferType type,
                    uint8_t location,

--- a/src/dawn/engine_dawn.h
+++ b/src/dawn/engine_dawn.h
@@ -16,6 +16,7 @@
 #define SRC_DAWN_ENGINE_DAWN_H_
 
 #include <cstdint>
+#include <string>
 #include <unordered_map>
 #include <vector>
 

--- a/src/dawn/engine_dawn.h
+++ b/src/dawn/engine_dawn.h
@@ -36,7 +36,8 @@ class EngineDawn : public Engine {
 
   // Engine
   // Initialize with a default device.
-  Result Initialize() override;
+  Result Initialize(const std::vector<Feature>& features,
+                    const std::vector<std::string>& extensions) override;
   // Initialize with a given device, specified as a pointer-to-::dawn::Device
   // disguised as a pointer-to-void.
   Result InitializeWithDevice(void* default_device) override;

--- a/src/engine.h
+++ b/src/engine.h
@@ -99,8 +99,7 @@ class Engine {
   // Enable |feature|. If the feature requires a pixel format it will be
   // provided in |format|, otherwise |format| is a nullptr. If the feature
   // requires a uint32 value it will be set in the |uint32_t|.
-  virtual Result AddRequirement(Feature feature,
-                                const Format* format) = 0;
+  virtual Result AddRequirement(Feature feature, const Format* format) = 0;
 
   // Create graphics pipeline.
   virtual Result CreatePipeline(PipelineType type) = 0;

--- a/src/engine.h
+++ b/src/engine.h
@@ -70,8 +70,10 @@ class Engine {
 
   virtual ~Engine();
 
-  // Initialize the engine.
-  virtual Result Initialize() = 0;
+  // Initialize the engine. The |features| list is a set of required features
+  // for the device. The |extensions| list is a list of required extensions.
+  virtual Result Initialize(const std::vector<Feature>& features,
+                            const std::vector<std::string>& extensions) = 0;
 
   // Initialize the engine with the provided device. The device is _not_ owned
   // by the engine and should not be destroyed.

--- a/src/engine.h
+++ b/src/engine.h
@@ -16,6 +16,7 @@
 #define SRC_ENGINE_H_
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "amber/amber.h"

--- a/src/engine.h
+++ b/src/engine.h
@@ -39,6 +39,12 @@ enum class ResourceInfoType : uint8_t {
   kImage,
 };
 
+/// EngineData stores information used during engine execution.
+struct EngineData {
+  /// The timeout to use for fences, in milliseconds.
+  uint32_t fence_timeout_ms = 100;
+};
+
 struct ResourceInfo {
   ResourceInfoType type = ResourceInfoType::kBuffer;
 
@@ -87,8 +93,7 @@ class Engine {
   // provided in |format|, otherwise |format| is a nullptr. If the feature
   // requires a uint32 value it will be set in the |uint32_t|.
   virtual Result AddRequirement(Feature feature,
-                                const Format* format,
-                                uint32_t) = 0;
+                                const Format* format) = 0;
 
   // Create graphics pipeline.
   virtual Result CreatePipeline(PipelineType type) = 0;
@@ -157,8 +162,17 @@ class Engine {
                                    const uint32_t binding,
                                    ResourceInfo* info) = 0;
 
+  /// Sets the engine data to use.
+  void SetEngineData(const EngineData& data) { engine_data_ = data; }
+
  protected:
   Engine();
+
+  /// Retrieves the engine data.
+  const EngineData& GetEngineData() const { return engine_data_; }
+
+ private:
+  EngineData engine_data_;
 };
 
 }  // namespace amber

--- a/src/script.h
+++ b/src/script.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "amber/result.h"
+#include "src/engine.h"
 #include "src/feature.h"
 #include "src/shader.h"
 
@@ -71,6 +72,9 @@ class Script {
     return engine_info_.required_extensions;
   }
 
+  EngineData& GetEngineData() { return engine_data_; }
+  const EngineData& GetEngineData() const { return engine_data_; }
+
  protected:
   explicit Script(ScriptType);
 
@@ -83,6 +87,7 @@ class Script {
   ScriptType script_type_;
   std::map<std::string, Shader*> name_to_shader_;
   std::vector<std::unique_ptr<Shader>> shaders_;
+  EngineData engine_data_;
 };
 
 }  // namespace amber

--- a/src/script.h
+++ b/src/script.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "amber/result.h"
+#include "src/feature.h"
 #include "src/shader.h"
 
 namespace amber {
@@ -56,10 +57,29 @@ class Script {
     return shaders_;
   }
 
+  void AddRequiredFeature(Feature feature) {
+    engine_info_.required_features.push_back(feature);
+  }
+  const std::vector<Feature>& RequiredFeatures() const {
+    return engine_info_.required_features;
+  }
+
+  void AddRequiredExtension(const std::string& ext) {
+    engine_info_.required_extensions.push_back(ext);
+  }
+  const std::vector<std::string>& RequiredExtensions() const {
+    return engine_info_.required_extensions;
+  }
+
  protected:
   explicit Script(ScriptType);
 
  private:
+  struct {
+    std::vector<Feature> required_features;
+    std::vector<std::string> required_extensions;
+  } engine_info_;
+
   ScriptType script_type_;
   std::map<std::string, Shader*> name_to_shader_;
   std::vector<std::unique_ptr<Shader>> shaders_;

--- a/src/vkscript/executor.cc
+++ b/src/vkscript/executor.cc
@@ -41,8 +41,8 @@ Result Executor::Execute(Engine* engine, const amber::Script* src_script) {
       continue;
 
     for (const auto& require : node->AsRequire()->Requirements()) {
-      Result r = engine->AddRequirement(
-          require.GetFeature(), require.GetFormat(), require.GetUint32Value());
+      Result r = engine->AddRequirement(require.GetFeature(),
+                                        require.GetFormat());
       if (!r.IsSuccess())
         return r;
     }

--- a/src/vkscript/executor.cc
+++ b/src/vkscript/executor.cc
@@ -41,8 +41,8 @@ Result Executor::Execute(Engine* engine, const amber::Script* src_script) {
       continue;
 
     for (const auto& require : node->AsRequire()->Requirements()) {
-      Result r = engine->AddRequirement(require.GetFeature(),
-                                        require.GetFormat());
+      Result r =
+          engine->AddRequirement(require.GetFeature(), require.GetFormat());
       if (!r.IsSuccess())
         return r;
     }

--- a/src/vkscript/executor.cc
+++ b/src/vkscript/executor.cc
@@ -36,6 +36,7 @@ Result Executor::Execute(Engine* engine,
     return Result("VkScript Executor called with non-vkscript source");
 
   const Script* script = ToVkScript(src_script);
+  engine->SetEngineData(script->GetEngineData());
 
   // Process Requirement nodes
   for (const auto& node : script->Nodes()) {

--- a/src/vkscript/executor_test.cc
+++ b/src/vkscript/executor_test.cc
@@ -243,88 +243,14 @@ class EngineStub : public Engine {
   ClearColorCommand* last_clear_color_ = nullptr;
 };
 
-class EngineCountingStub : public Engine {
- public:
-  EngineCountingStub() : Engine() {}
-  ~EngineCountingStub() override = default;
-
-  // Engine
-  Result Initialize(const std::vector<Feature>&,
-                    const std::vector<std::string>&) override {
-    return {};
-  }
-
-  Result InitializeWithDevice(void*) override { return {}; }
-
-  Result Shutdown() override { return {}; }
-
-  int32_t GetRequireStageIdx() const { return require_stage_; }
-  uint32_t GetRequireCount() const { return require_stage_count_; }
-  Result AddRequirement(Feature, const Format*, uint32_t) override {
-    ++require_stage_count_;
-    require_stage_ = stage_count_++;
-    return {};
-  }
-  Result CreatePipeline(PipelineType) override { return {}; }
-
-  int32_t GetShaderStageIdx() const { return shader_stage_; }
-  uint32_t GetShaderCount() const { return shader_stage_count_; }
-  Result SetShader(ShaderType, const std::vector<uint32_t>&) override {
-    ++shader_stage_count_;
-    shader_stage_ = stage_count_++;
-    return {};
-  }
-  Result SetBuffer(BufferType,
-                   uint8_t,
-                   const Format&,
-                   const std::vector<Value>&) override {
-    return {};
-  }
-
-  Result DoClearColor(const ClearColorCommand*) override { return {}; }
-  Result DoClearStencil(const ClearStencilCommand*) override { return {}; }
-  Result DoClearDepth(const ClearDepthCommand*) override { return {}; }
-  Result DoClear(const ClearCommand*) override { return {}; }
-  Result DoDrawRect(const DrawRectCommand*) override { return {}; }
-  Result DoDrawArrays(const DrawArraysCommand*) override { return {}; }
-  Result DoCompute(const ComputeCommand*) override { return {}; }
-  Result DoEntryPoint(const EntryPointCommand*) override { return {}; }
-  Result DoPatchParameterVertices(
-      const PatchParameterVerticesCommand*) override {
-    return {};
-  }
-  Result DoBuffer(const BufferCommand*) override { return {}; }
-  Result DoProcessCommands() override { return {}; }
-  Result GetFrameBufferInfo(ResourceInfo*) override { return {}; }
-  Result GetDescriptorInfo(const uint32_t,
-                           const uint32_t,
-                           ResourceInfo*) override {
-    return {};
-  }
-
- private:
-  int32_t stage_count_ = 0;
-  int32_t require_stage_ = -1;
-  int32_t shader_stage_ = -1;
-  uint32_t require_stage_count_ = 0;
-  uint32_t shader_stage_count_ = 0;
-};
-
 class VkScriptExecutorTest : public testing::Test {
  public:
   VkScriptExecutorTest() = default;
   ~VkScriptExecutorTest() = default;
 
   std::unique_ptr<Engine> MakeEngine() { return MakeUnique<EngineStub>(); }
-  std::unique_ptr<Engine> MakeCountingEngine() {
-    return MakeUnique<EngineCountingStub>();
-  }
   EngineStub* ToStub(Engine* engine) {
     return static_cast<EngineStub*>(engine);
-  }
-
-  EngineCountingStub* ToCountingStub(Engine* engine) {
-    return static_cast<EngineCountingStub*>(engine);
   }
 };
 

--- a/src/vkscript/executor_test.cc
+++ b/src/vkscript/executor_test.cc
@@ -49,7 +49,7 @@ class EngineStub : public Engine {
   Result Shutdown() override { return {}; }
 
   void FailRequirements() { fail_requirements_ = true; }
-  Result AddRequirement(Feature feature, const Format* format) override {
+  Result AddRequirement(Feature feature, const Format* fmt) override {
     if (fail_requirements_)
       return Result("requirements failed");
 
@@ -74,7 +74,7 @@ class EngineStub : public Engine {
   const std::vector<std::string>& GetExtensions() const { return extensions_; }
   FormatType GetColorFrameFormat() const { return color_frame_format_; }
   FormatType GetDepthFrameFormat() const { return depth_frame_format_; }
-  uint32_t GetFenceTimeoutMs() { return EngineData().fence_timeout_ms; }
+  uint32_t GetFenceTimeoutMs() { return GetEngineData().fence_timeout_ms; }
 
   Result CreatePipeline(PipelineType) override { return {}; }
 
@@ -469,7 +469,7 @@ fence_timeout 12345)";
 
 TEST_F(VkScriptExecutorTest, EngineAddRequirementFailed) {
   auto engine = MakeEngine();
-  Result r = engine->AddRequirement(Feature::kRobustBufferAccess, nullptr, 0U);
+  Result r = engine->AddRequirement(Feature::kRobustBufferAccess, nullptr);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ(
       "Vulkan::AddRequirement features and extensions must be handled by "

--- a/src/vkscript/executor_test.cc
+++ b/src/vkscript/executor_test.cc
@@ -50,9 +50,7 @@ class EngineStub : public Engine {
 
   void FailRequirements() { fail_requirements_ = true; }
   const std::vector<Require>& GetRequirements() const { return requirements_; }
-  Result AddRequirement(Feature feature,
-                        const Format* format,
-                        uint32_t) override {
+  Result AddRequirement(Feature feature, const Format* format) override {
     if (fail_requirements_)
       return Result("requirements failed");
 

--- a/src/vkscript/nodes.cc
+++ b/src/vkscript/nodes.cc
@@ -57,10 +57,6 @@ RequireNode::Requirement::Requirement(Requirement&&) = default;
 
 RequireNode::Requirement::~Requirement() = default;
 
-void RequireNode::AddRequirement(Feature feature) {
-  requirements_.emplace_back(feature);
-}
-
 void RequireNode::AddRequirement(Feature feature,
                                  std::unique_ptr<Format> format) {
   requirements_.emplace_back(feature, std::move(format));

--- a/src/vkscript/nodes.cc
+++ b/src/vkscript/nodes.cc
@@ -50,9 +50,6 @@ RequireNode::Requirement::Requirement(Feature feature,
                                       std::unique_ptr<Format> format)
     : feature_(feature), format_(std::move(format)) {}
 
-RequireNode::Requirement::Requirement(Feature feature, uint32_t value)
-    : feature_(feature), uint32_value_(value) {}
-
 RequireNode::Requirement::Requirement(Requirement&&) = default;
 
 RequireNode::Requirement::~Requirement() = default;
@@ -60,10 +57,6 @@ RequireNode::Requirement::~Requirement() = default;
 void RequireNode::AddRequirement(Feature feature,
                                  std::unique_ptr<Format> format) {
   requirements_.emplace_back(feature, std::move(format));
-}
-
-void RequireNode::AddRequirement(Feature feature, uint32_t value) {
-  requirements_.emplace_back(feature, value);
 }
 
 IndicesNode::IndicesNode(std::unique_ptr<Buffer> buffer)

--- a/src/vkscript/nodes.h
+++ b/src/vkscript/nodes.h
@@ -79,18 +79,13 @@ class RequireNode : public Node {
   RequireNode();
   ~RequireNode() override;
 
-  void AddRequirement(Feature feature);
   void AddRequirement(Feature feature, std::unique_ptr<Format> format);
   void AddRequirement(Feature feature, uint32_t value);
 
   const std::vector<Requirement>& Requirements() const { return requirements_; }
 
-  void AddExtension(const std::string& ext) { extensions_.push_back(ext); }
-  const std::vector<std::string>& Extensions() const { return extensions_; }
-
  private:
   std::vector<Requirement> requirements_;
-  std::vector<std::string> extensions_;
 };
 
 class IndicesNode : public Node {

--- a/src/vkscript/nodes.h
+++ b/src/vkscript/nodes.h
@@ -62,25 +62,21 @@ class RequireNode : public Node {
    public:
     explicit Requirement(Feature feature);
     Requirement(Feature feature, std::unique_ptr<Format> format);
-    Requirement(Feature feature, uint32_t value);
     Requirement(Requirement&&);
     ~Requirement();
 
     Feature GetFeature() const { return feature_; }
     const Format* GetFormat() const { return format_.get(); }
-    uint32_t GetUint32Value() const { return uint32_value_; }
 
    private:
     Feature feature_;
     std::unique_ptr<Format> format_;
-    uint32_t uint32_value_;
   };
 
   RequireNode();
   ~RequireNode() override;
 
   void AddRequirement(Feature feature, std::unique_ptr<Format> format);
-  void AddRequirement(Feature feature, uint32_t value);
 
   const std::vector<Requirement>& Requirements() const { return requirements_; }
 

--- a/src/vkscript/parser.cc
+++ b/src/vkscript/parser.cc
@@ -228,7 +228,7 @@ Result Parser::ProcessRequireBlock(const std::string& data) {
       if (it != str.end())
         return Result("Unknown feature or extension: " + str);
 
-      node->AddExtension(str);
+      script_.AddRequiredExtension(str);
     } else if (feature == Feature::kFramebuffer) {
       token = tokenizer.NextToken();
       if (!token->IsString())
@@ -258,7 +258,7 @@ Result Parser::ProcessRequireBlock(const std::string& data) {
 
       node->AddRequirement(feature, token->AsUint32());
     } else {
-      node->AddRequirement(feature);
+      script_.AddRequiredFeature(feature);
     }
 
     token = tokenizer.NextToken();
@@ -266,7 +266,7 @@ Result Parser::ProcessRequireBlock(const std::string& data) {
       return Result("Failed to parser requirements block: invalid token");
   }
 
-  if (!node->Requirements().empty() || !node->Extensions().empty())
+  if (!node->Requirements().empty())
     script_.AddRequireNode(std::move(node));
 
   return {};

--- a/src/vkscript/parser.cc
+++ b/src/vkscript/parser.cc
@@ -256,7 +256,7 @@ Result Parser::ProcessRequireBlock(const std::string& data) {
       if (!token->IsInteger())
         return Result("Missing fence_timeout value");
 
-      node->AddRequirement(feature, token->AsUint32());
+      script_.GetEngineData().fence_timeout_ms = token->AsUint32();
     } else {
       script_.AddRequiredFeature(feature);
     }

--- a/src/vkscript/parser_test.cc
+++ b/src/vkscript/parser_test.cc
@@ -114,13 +114,9 @@ TEST_F(VkScriptParserTest, RequireBlockNoArgumentFeatures) {
     Result r = parser.ProcessRequireBlockForTesting(feature.name);
     ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-    auto& nodes = ToVkScript(parser.GetScript())->Nodes();
-    ASSERT_EQ(1U, nodes.size());
-    ASSERT_TRUE(nodes[0]->IsRequire());
-
-    auto req = nodes[0]->AsRequire();
-    ASSERT_EQ(1U, req->Requirements().size());
-    EXPECT_EQ(feature.feature, req->Requirements()[0].GetFeature());
+    auto& feats = ToVkScript(parser.GetScript())->RequiredFeatures();
+    ASSERT_EQ(1U, feats.size());
+    EXPECT_EQ(feature.feature, feats[0]);
   }
 }
 
@@ -132,14 +128,8 @@ VK_KHR_variable_pointers)";
   Result r = parser.ProcessRequireBlockForTesting(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& nodes = ToVkScript(parser.GetScript())->Nodes();
-  ASSERT_EQ(1U, nodes.size());
-  ASSERT_TRUE(nodes[0]->IsRequire());
-
-  auto req = nodes[0]->AsRequire();
-  ASSERT_EQ(2U, req->Extensions().size());
-
-  const auto& exts = req->Extensions();
+  auto& exts = parser.GetScript()->RequiredExtensions();
+  ASSERT_EQ(2U, exts.size());
   EXPECT_EQ("VK_KHR_storage_buffer_storage_class", exts[0]);
   EXPECT_EQ("VK_KHR_variable_pointers", exts[1]);
 }
@@ -210,19 +200,18 @@ inheritedQueries # line comment
   ASSERT_TRUE(nodes[0]->IsRequire());
 
   auto* req = nodes[0]->AsRequire();
-  ASSERT_EQ(4U, req->Requirements().size());
+  ASSERT_EQ(2U, req->Requirements().size());
   EXPECT_EQ(Feature::kDepthStencil, req->Requirements()[0].GetFeature());
   auto format = req->Requirements()[0].GetFormat();
   EXPECT_EQ(FormatType::kD24_UNORM_S8_UINT, format->GetFormatType());
 
-  EXPECT_EQ(Feature::kSparseResidency4Samples,
-            req->Requirements()[1].GetFeature());
-
-  EXPECT_EQ(Feature::kFramebuffer, req->Requirements()[2].GetFeature());
-  format = req->Requirements()[2].GetFormat();
+  EXPECT_EQ(Feature::kFramebuffer, req->Requirements()[1].GetFeature());
+  format = req->Requirements()[1].GetFormat();
   EXPECT_EQ(FormatType::kR32G32B32A32_SFLOAT, format->GetFormatType());
 
-  EXPECT_EQ(Feature::kInheritedQueries, req->Requirements()[3].GetFeature());
+  auto& feats = script->RequiredFeatures();
+  EXPECT_EQ(Feature::kSparseResidency4Samples, feats[0]);
+  EXPECT_EQ(Feature::kInheritedQueries, feats[1]);
 }
 
 TEST_F(VkScriptParserTest, IndicesBlock) {

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -106,9 +106,6 @@ Result EngineVulkan::Shutdown() {
 }
 
 Result EngineVulkan::AddRequirement(Feature feature, const Format* fmt) {
-Result EngineVulkan::AddRequirement(Feature feature,
-                                    const Format* fmt,
-                                    uint32_t val) {
   if (feature == Feature::kFramebuffer) {
     if (fmt != nullptr)
       color_frame_format_ = ToVkFormat(fmt->GetFormatType());

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -72,7 +72,8 @@ Result EngineVulkan::InitDeviceAndCreateCommand() {
   return {};
 }
 
-Result EngineVulkan::Initialize() {
+Result EngineVulkan::Initialize(const std::vector<Feature>&,
+                                const std::vector<std::string>&) {
   if (device_)
     return Result("Vulkan::Set device_ already exists");
 

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -105,8 +105,7 @@ Result EngineVulkan::Shutdown() {
   return {};
 }
 
-Result EngineVulkan::AddRequirement(Feature feature,
-                                    const Format* fmt) {
+Result EngineVulkan::AddRequirement(Feature feature, const Format* fmt) {
   auto it = std::find_if(requirements_.begin(), requirements_.end(),
                          [&feature](const EngineVulkan::Requirement& req) {
                            return req.feature == feature;

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -16,6 +16,7 @@
 #define SRC_VULKAN_ENGINE_VULKAN_H_
 
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <vector>
 

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -35,7 +35,8 @@ class EngineVulkan : public Engine {
   ~EngineVulkan() override;
 
   // Engine
-  Result Initialize() override;
+  Result Initialize(const std::vector<Feature>& features,
+                    const std::vector<std::string>& extensions) override;
   Result InitializeWithDevice(void* default_device) override;
   Result Shutdown() override;
   Result AddRequirement(Feature feature, const Format*, uint32_t) override;
@@ -80,6 +81,8 @@ class EngineVulkan : public Engine {
     const Format* format;
   };
 
+  std::vector<Feature> features_;
+  std::vector<std::string> extensions_;
   std::vector<Requirement> requirements_;
   std::vector<Requirement>::iterator FindFeature(Feature feature);
 };

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -40,7 +40,7 @@ class EngineVulkan : public Engine {
                     const std::vector<std::string>& extensions) override;
   Result InitializeWithDevice(void* default_device) override;
   Result Shutdown() override;
-  Result AddRequirement(Feature feature, const Format*, uint32_t) override;
+  Result AddRequirement(Feature feature, const Format*) override;
   Result CreatePipeline(PipelineType type) override;
   Result SetShader(ShaderType type, const std::vector<uint32_t>& data) override;
   Result SetBuffer(BufferType type,
@@ -68,8 +68,6 @@ class EngineVulkan : public Engine {
   Result InitDeviceAndCreateCommand();
 
   std::vector<VkPipelineShaderStageCreateInfo> GetShaderStageInfo();
-
-  uint32_t fence_timeout_ms_ = 100;
 
   std::unique_ptr<Device> device_;
   std::unique_ptr<CommandPool> pool_;


### PR DESCRIPTION
This CL adds the concept of EngineData which is information parsed from the file which is used
to configure the current engine. Currently only fence_timeout is supported. This removes the need
to provide an option to AddRequirement to pass in a uint32_t as only framebuffer and depth_stencil
are passed as requirements now.