### PR TITLE
 Break apart Amber::Execute method.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -18,6 +18,7 @@ LOCAL_SRC_FILES:= \
     src/format.cc \
     src/parser.cc \
     src/pipeline_data.cc \
+    src/recipe.cc \
     src/result.cc \
     src/script.cc \
     src/shader.cc \

--- a/include/amber/amber.h
+++ b/include/amber/amber.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "amber/recipe.h"
 #include "amber/result.h"
 
 namespace amber {
@@ -43,8 +44,6 @@ struct Options {
   EngineType engine = EngineType::kVulkan;
   /// Holds engine specific configuration.
   std::unique_ptr<EngineConfig> config;
-  /// Set true to only parse the given script, does not execute the engine.
-  bool parse_only = false;
 };
 
 /// Main interface to the Amber environment.
@@ -53,14 +52,17 @@ class Amber {
   Amber();
   ~Amber();
 
-  /// Executes the given |data| script with the provided |opts|. Returns a
-  /// |Result| which indicates if the execution succeded.
-  amber::Result Execute(const std::string& data, const Options& opts);
+  /// Parse the given |data| into the |recipe|.
+  amber::Result Parse(const std::string& data, amber::Recipe* recipe);
 
-  /// Executes the given |data| script with the provided |opts|. Will use
+  /// Executes the given |recipe| with the provided |opts|. Returns a
+  /// |Result| which indicates if the execution succeded.
+  amber::Result Execute(const amber::Recipe* recipe, const Options& opts);
+
+  /// Executes the given |recipe| with the provided |opts|. Will use
   /// |shader_map| to lookup shader data before attempting to compile the
   /// shader if possible.
-  amber::Result ExecuteWithShaderData(const std::string& data,
+  amber::Result ExecuteWithShaderData(const amber::Recipe* recipe,
                                       const Options& opts,
                                       const ShaderMap& shader_data);
 };

--- a/include/amber/recipe.h
+++ b/include/amber/recipe.h
@@ -1,0 +1,55 @@
+// Copyright 2018 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AMBER_RECIPE_H_
+#define AMBER_RECIPE_H_
+
+#include <memory>
+#include <vector>
+
+#include "amber/shader_info.h"
+
+namespace amber {
+
+/// Internal recipe implementation.
+class RecipeImpl {
+ public:
+  virtual ~RecipeImpl();
+
+  /// Retrieves information on all the shaders in the given recipe.
+  virtual std::vector<ShaderInfo> GetShaderInfo() const = 0;
+
+ protected:
+  RecipeImpl();
+};
+
+/// A recipe is the parsed representation of the input script.
+class Recipe {
+ public:
+  Recipe();
+  ~Recipe();
+
+  /// Retrieves information on all the shaders in the recipe.
+  std::vector<ShaderInfo> GetShaderInfo() const;
+
+  RecipeImpl* GetImpl() const { return impl_.get(); }
+  void SetImpl(std::unique_ptr<RecipeImpl> impl) { impl_ = std::move(impl); }
+
+ private:
+  std::unique_ptr<RecipeImpl> impl_;
+};
+
+}  // namespace amber
+
+#endif  // AMBER_RECIPE_H_

--- a/include/amber/shader_info.h
+++ b/include/amber/shader_info.h
@@ -12,33 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SRC_SHADER_COMPILER_H_
-#define SRC_SHADER_COMPILER_H_
+#ifndef AMBER_SHADER_INFO_H_
+#define AMBER_SHADER_INFO_H_
 
 #include <string>
-#include <utility>
-#include <vector>
-
-#include "amber/amber.h"
-#include "amber/result.h"
-#include "src/shader.h"
 
 namespace amber {
 
-class ShaderCompiler {
- public:
-  ShaderCompiler();
-  ~ShaderCompiler();
+enum class ShaderFormat : uint8_t {
+  kDefault = 0,
+  kText,
+  kGlsl,
+  kSpirvAsm,
+  kSpirvHex,
+};
 
-  std::pair<Result, std::vector<uint32_t>> Compile(
-      Shader* shader,
-      const ShaderMap& shader_map) const;
+enum class ShaderType : uint8_t {
+  kCompute = 0,
+  kGeometry,
+  kFragment,
+  kVertex,
+  kTessellationControl,
+  kTessellationEvaluation,
+};
 
- private:
-  Result ParseHex(const std::string& data, std::vector<uint32_t>* result) const;
-  Result CompileGlsl(Shader* shader, std::vector<uint32_t>* result) const;
+struct ShaderInfo {
+  ShaderFormat format;
+  ShaderType type;
+  std::string shader_name;
+  std::string shader_data;
 };
 
 }  // namespace amber
 
-#endif  // SRC_SHADER_COMPILER_H_
+#endif  // AMBER_SHADER_INFO_H_

--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "amber/amber.h"
-
 #include <cassert>
 #include <cstdlib>
 #include <iostream>
 #include <vector>
 
+#include "amber/amber.h"
+#include "amber/recipe.h"
 #include "src/build-versions.h"
 
 namespace {
@@ -183,11 +183,20 @@ int main(int argc, const char** argv) {
   if (data.empty())
     return 1;
 
-  amber::Amber vk;
+  amber::Amber am;
+  amber::Recipe recipe;
+  amber::Result result = am.Parse(data, &recipe);
+  if (!result.IsSuccess()) {
+    std::cerr << result.Error() << std::endl;
+    return 1;
+  }
+
+  if (options.parse_only)
+    return 0;
+
   amber::Options amber_options;
   amber_options.engine = options.engine;
-  amber_options.parse_only = options.parse_only;
-  amber::Result result = vk.Execute(data, amber_options);
+  result = am.Execute(&recipe, amber_options);
   if (!result.IsSuccess()) {
     std::cerr << result.Error() << std::endl;
     return 1;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ set(AMBER_SOURCES
     format.cc
     parser.cc
     pipeline_data.cc
+    recipe.cc
     result.cc
     sleep.cc
     script.cc

--- a/src/amber.cc
+++ b/src/amber.cc
@@ -32,37 +32,45 @@ Amber::Amber() = default;
 
 Amber::~Amber() = default;
 
-amber::Result Amber::Execute(const std::string& input, const Options& opts) {
-  ShaderMap map;
-  return ExecuteWithShaderData(input, opts, map);
-}
+amber::Result Amber::Parse(const std::string& input, amber::Recipe* recipe) {
+  if (!recipe)
+    return Result("Recipe must be provided to Parse.");
 
-amber::Result Amber::ExecuteWithShaderData(const std::string& input,
-                                           const Options& opts,
-                                           const ShaderMap& shader_data) {
   std::unique_ptr<Parser> parser;
-  std::unique_ptr<Executor> executor;
-  if (input.substr(0, 7) == "#!amber") {
+  if (input.substr(0, 7) == "#!amber")
     parser = MakeUnique<amberscript::Parser>();
-    executor = MakeUnique<amberscript::Executor>();
-  } else {
+  else
     parser = MakeUnique<vkscript::Parser>();
-    executor = MakeUnique<vkscript::Executor>();
-  }
 
   Result r = parser->Parse(input);
   if (!r.IsSuccess())
     return r;
 
-  if (opts.parse_only)
-    return {};
+  recipe->SetImpl(parser->GetScript());
+  return {};
+}
+
+
+amber::Result Amber::Execute(const amber::Recipe* recipe, const Options& opts) {
+  ShaderMap map;
+  return ExecuteWithShaderData(recipe, opts, map);
+}
+
+amber::Result Amber::ExecuteWithShaderData(const amber::Recipe* recipe,
+                                           const Options& opts,
+                                           const ShaderMap& shader_data) {
+  if (!recipe)
+    return Result("Attempting to execute and invalid recipe");
+
+  Script* script = static_cast<Script*>(recipe->GetImpl());
+  if (!script)
+    return Result("Recipe must contain a parsed script");
 
   auto engine = Engine::Create(opts.engine);
   if (!engine)
     return Result("Failed to create engine");
 
-  const auto* script = parser->GetScript();
-
+  Result r;
   if (opts.config) {
     r = engine->InitializeWithConfig(opts.config.get(),
                                      script->RequiredFeatures(),
@@ -73,6 +81,12 @@ amber::Result Amber::ExecuteWithShaderData(const std::string& input,
   }
   if (!r.IsSuccess())
     return r;
+
+  std::unique_ptr<Executor> executor;
+  if (script->IsVkScript())
+    executor = MakeUnique<vkscript::Executor>();
+  else
+    executor = MakeUnique<amberscript::Executor>();
 
   r = executor->Execute(engine.get(), script, shader_data);
   if (!r.IsSuccess())

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -21,12 +21,14 @@
 #include <vector>
 
 #include "src/make_unique.h"
+#include "src/shader_data.h"
 #include "src/tokenizer.h"
 
 namespace amber {
 namespace amberscript {
 
-Parser::Parser() : amber::Parser() {}
+Parser::Parser()
+    : amber::Parser(), script_(MakeUnique<amberscript::Script>()) {}
 
 Parser::~Parser() = default;
 
@@ -230,7 +232,7 @@ Result Parser::ParseShaderBlock() {
     shader->SetFormat(ShaderFormat::kSpirvAsm);
     shader->SetData(kPassThroughShader);
 
-    r = script_.AddShader(std::move(shader));
+    r = script_->AddShader(std::move(shader));
     if (!r.IsSuccess())
       return r;
 
@@ -258,7 +260,7 @@ Result Parser::ParseShaderBlock() {
   if (!token->IsString() || token->AsString() != "END")
     return Result("SHADER missing END command");
 
-  r = script_.AddShader(std::move(shader));
+  r = script_->AddShader(std::move(shader));
   if (!r.IsSuccess())
     return r;
 
@@ -317,7 +319,7 @@ Result Parser::ParsePipelineBlock() {
   if (!r.IsSuccess())
     return r;
 
-  r = script_.AddPipeline(std::move(pipeline));
+  r = script_->AddPipeline(std::move(pipeline));
   if (!r.IsSuccess())
     return r;
 
@@ -329,7 +331,7 @@ Result Parser::ParsePipelineAttach(Pipeline* pipeline) {
   if (!token->IsString())
     return Result("invalid token in ATTACH command");
 
-  auto* shader = script_.GetShader(token->AsString());
+  auto* shader = script_->GetShader(token->AsString());
   if (!shader)
     return Result("unknown shader in ATTACH command");
 
@@ -345,7 +347,7 @@ Result Parser::ParsePipelineEntryPoint(Pipeline* pipeline) {
   if (!token->IsString())
     return Result("missing shader name in ENTRY_POINT command");
 
-  auto* shader = script_.GetShader(token->AsString());
+  auto* shader = script_->GetShader(token->AsString());
   if (!shader)
     return Result("unknown shader in ENTRY_POINT command");
 
@@ -365,7 +367,7 @@ Result Parser::ParsePipelineShaderOptimizations(Pipeline* pipeline) {
   if (!token->IsString())
     return Result("missing shader name in SHADER_OPTIMIZATION command");
 
-  auto* shader = script_.GetShader(token->AsString());
+  auto* shader = script_->GetShader(token->AsString());
   if (!shader)
     return Result("unknown shader in SHADER_OPTIMIZATION command");
 
@@ -465,7 +467,7 @@ Result Parser::ParseBuffer() {
     return Result("unknown BUFFER command provided: " + cmd);
   }
 
-  r = script_.AddBuffer(std::move(buffer));
+  r = script_->AddBuffer(std::move(buffer));
   if (!r.IsSuccess())
     return r;
 

--- a/src/amberscript/parser.h
+++ b/src/amberscript/parser.h
@@ -36,7 +36,9 @@ class Parser : public amber::Parser {
 
   // amber::Parser
   Result Parse(const std::string& data) override;
-  const amber::Script* GetScript() const override { return &script_; }
+  std::unique_ptr<amber::Script> GetScript() override {
+    return std::move(script_);
+  }
 
  private:
   std::string make_error(const std::string& err);
@@ -60,7 +62,7 @@ class Parser : public amber::Parser {
   Result ParsePipelineEntryPoint(Pipeline*);
   Result ParsePipelineShaderOptimizations(Pipeline*);
 
-  amberscript::Script script_;
+  std::unique_ptr<amberscript::Script> script_;
   std::unique_ptr<Tokenizer> tokenizer_;
 };
 

--- a/src/amberscript/parser_test.cc
+++ b/src/amberscript/parser_test.cc
@@ -16,6 +16,7 @@
 
 #include "gtest/gtest.h"
 #include "src/amberscript/parser.h"
+#include "src/shader_data.h"
 
 namespace amber {
 namespace amberscript {
@@ -89,7 +90,8 @@ TEST_F(AmberScriptParserTest, ShaderPassThrough) {
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& shaders = script->GetShaders();
   ASSERT_EQ(1U, shaders.size());
 
@@ -195,7 +197,8 @@ SHADER geometry shader_name GLSL
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& shaders = script->GetShaders();
   ASSERT_EQ(1U, shaders.size());
 
@@ -309,7 +312,8 @@ void main() {
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& shaders = script->GetShaders();
   ASSERT_EQ(1U, shaders.size());
 
@@ -350,7 +354,8 @@ TEST_P(AmberScriptParserShaderFormatTest, ShaderFormats) {
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& shaders = script->GetShaders();
   ASSERT_EQ(1U, shaders.size());
 
@@ -402,7 +407,8 @@ END
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   EXPECT_EQ(2U, script->GetShaders().size());
 
   const auto& pipelines = script->GetPipelines();
@@ -666,7 +672,8 @@ END
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& pipelines = script->GetPipelines();
   ASSERT_EQ(1U, pipelines.size());
 
@@ -812,7 +819,8 @@ END
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& pipelines = script->GetPipelines();
   ASSERT_EQ(1U, pipelines.size());
 
@@ -941,7 +949,8 @@ END)";
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& buffers = script->GetBuffers();
   ASSERT_EQ(1U, buffers.size());
 
@@ -968,7 +977,8 @@ TEST_F(AmberScriptParserTest, BufferFill) {
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& buffers = script->GetBuffers();
   ASSERT_EQ(1U, buffers.size());
 
@@ -995,7 +1005,8 @@ TEST_F(AmberScriptParserTest, BufferFillFloat) {
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& buffers = script->GetBuffers();
   ASSERT_EQ(1U, buffers.size());
 
@@ -1023,7 +1034,8 @@ TEST_F(AmberScriptParserTest, BufferSeries) {
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& buffers = script->GetBuffers();
   ASSERT_EQ(1U, buffers.size());
 
@@ -1052,7 +1064,8 @@ TEST_F(AmberScriptParserTest, BufferSeriesFloat) {
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& buffers = script->GetBuffers();
   ASSERT_EQ(1U, buffers.size());
 
@@ -1079,7 +1092,8 @@ TEST_F(AmberScriptParserTest, BufferFramebuffer) {
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& buffers = script->GetBuffers();
   ASSERT_EQ(1U, buffers.size());
 
@@ -1104,7 +1118,8 @@ END)";
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& buffers = script->GetBuffers();
   ASSERT_EQ(2U, buffers.size());
 
@@ -1147,7 +1162,8 @@ BUFFER index my_index_buffer DATA_TYPE vec2<int32> SIZE 5 FILL 2)";
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& buffers = script->GetBuffers();
   ASSERT_EQ(1U, buffers.size());
 
@@ -1181,7 +1197,8 @@ END
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& buffers = script->GetBuffers();
   ASSERT_EQ(1U, buffers.size());
 
@@ -1215,7 +1232,8 @@ END
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& buffers = script->GetBuffers();
   ASSERT_EQ(1U, buffers.size());
 
@@ -1592,7 +1610,8 @@ TEST_P(AmberScriptParserBufferTypeTest, BufferTypes) {
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& buffers = script->GetBuffers();
   ASSERT_EQ(1U, buffers.size());
 
@@ -1623,7 +1642,8 @@ TEST_P(AmberScriptParserBufferDataTypeTest, BufferTypes) {
   Result r = parser.Parse(in);
   ASSERT_TRUE(r.IsSuccess()) << test_data.name << " :" << r.Error();
 
-  auto script = ToAmberScript(parser.GetScript());
+  auto parent_script = parser.GetScript();
+  auto script = ToAmberScript(parent_script.get());
   const auto& buffers = script->GetBuffers();
   ASSERT_EQ(1U, buffers.size());
 

--- a/src/command.h
+++ b/src/command.h
@@ -20,10 +20,10 @@
 #include <utility>
 #include <vector>
 
+#include "amber/shader_info.h"
 #include "src/command_data.h"
 #include "src/datum_type.h"
 #include "src/pipeline_data.h"
-#include "src/shader_data.h"
 #include "src/value.h"
 
 namespace amber {

--- a/src/dawn/engine_dawn.h
+++ b/src/dawn/engine_dawn.h
@@ -25,7 +25,6 @@
 #include "src/command.h"
 #include "src/dawn/pipeline_info.h"
 #include "src/engine.h"
-#include "src/shader_data.h"
 
 namespace amber {
 namespace dawn {

--- a/src/engine.h
+++ b/src/engine.h
@@ -25,7 +25,6 @@
 #include "src/command.h"
 #include "src/feature.h"
 #include "src/format.h"
-#include "src/shader_data.h"
 
 namespace amber {
 

--- a/src/recipe.cc
+++ b/src/recipe.cc
@@ -10,30 +10,23 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.
 
-#ifndef SRC_PARSER_H_
-#define SRC_PARSER_H_
-
-#include <memory>
-#include <string>
-
-#include "amber/result.h"
-#include "src/script.h"
+#include "amber/recipe.h"
 
 namespace amber {
 
-class Parser {
- public:
-  virtual ~Parser();
+RecipeImpl::RecipeImpl() = default;
 
-  virtual Result Parse(const std::string& data) = 0;
-  virtual std::unique_ptr<Script> GetScript() = 0;
+RecipeImpl::~RecipeImpl() = default;
 
- protected:
-  Parser();
-};
+Recipe::Recipe() = default;
+
+Recipe::~Recipe() = default;
+
+std::vector<ShaderInfo> Recipe::GetShaderInfo() const {
+  if (!impl_)
+    return {};
+  return impl_->GetShaderInfo();
+}
 
 }  // namespace amber
-
-#endif  // SRC_PARSER_H_

--- a/src/script.h
+++ b/src/script.h
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 
+#include "amber/recipe.h"
 #include "amber/result.h"
 #include "src/command.h"
 #include "src/engine.h"
@@ -32,13 +33,17 @@ namespace amber {
 
 enum class ScriptType : uint8_t { kVkScript = 0, kAmberScript };
 
-class Script {
+class Script : public RecipeImpl {
  public:
-  virtual ~Script();
+  ~Script() override;
 
   bool IsVkScript() const { return script_type_ == ScriptType::kVkScript; }
   bool IsAmberScript() const {
     return script_type_ == ScriptType::kAmberScript;
+  }
+
+  std::vector<ShaderInfo> GetShaderInfo() const override {
+    return {};
   }
 
   Result AddShader(std::unique_ptr<Shader> shader) {

--- a/src/shader.h
+++ b/src/shader.h
@@ -17,7 +17,7 @@
 
 #include <string>
 
-#include "src/shader_data.h"
+#include "amber/shader_info.h"
 
 namespace amber {
 

--- a/src/shader_compiler_test.cc
+++ b/src/shader_compiler_test.cc
@@ -16,7 +16,7 @@
 
 #include "gtest/gtest.h"
 #include "src/shader_compiler.h"
-#include "src/vkscript/section_parser.h"  // For the passthrough vertex shader
+#include "src/shader_data.h"
 
 namespace amber {
 namespace {

--- a/src/shader_data.h
+++ b/src/shader_data.h
@@ -19,23 +19,6 @@
 
 namespace amber {
 
-enum class ShaderFormat : uint8_t {
-  kDefault = 0,
-  kText,
-  kGlsl,
-  kSpirvAsm,
-  kSpirvHex,
-};
-
-enum class ShaderType : uint8_t {
-  kCompute = 0,
-  kGeometry,
-  kFragment,
-  kVertex,
-  kTessellationControl,
-  kTessellationEvaluation,
-};
-
 const char kPassThroughShader[] = R"(; SPIR-V
 ; Version: 1.0
 ; Generator: Khronos Glslang Reference Front End; 7

--- a/src/vkscript/executor_test.cc
+++ b/src/vkscript/executor_test.cc
@@ -293,9 +293,10 @@ framebuffer R32G32B32A32_SINT)";
 
   auto engine = MakeEngine();
   ToStub(engine.get())->FailRequirements();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("requirements failed", r.Error());
 }
@@ -309,12 +310,12 @@ logicOp)";
   Parser parser;
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
-  const auto* script = parser.GetScript();
+  auto script = parser.GetScript();
   auto engine = MakeAndInitializeEngine(script->RequiredFeatures(),
                                         script->RequiredExtensions());
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
 
   const auto& features = ToStub(engine.get())->GetFeatures();
@@ -342,12 +343,12 @@ VK_KHR_variable_pointers)";
   Parser parser;
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
-  const auto* script = parser.GetScript();
+  auto script = parser.GetScript();
   auto engine = MakeAndInitializeEngine(script->RequiredFeatures(),
                                         script->RequiredExtensions());
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
 
   const auto& features = ToStub(engine.get())->GetFeatures();
@@ -375,12 +376,12 @@ depthstencil D24_UNORM_S8_UINT)";
   Parser parser;
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
-  const auto* script = parser.GetScript();
+  auto script = parser.GetScript();
   auto engine = MakeAndInitializeEngine(script->RequiredFeatures(),
                                         script->RequiredExtensions());
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
 
   const auto& features = ToStub(engine.get())->GetFeatures();
@@ -405,12 +406,12 @@ fence_timeout 12345)";
   Parser parser;
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
-  const auto* script = parser.GetScript();
+  auto script = parser.GetScript();
   auto engine = MakeAndInitializeEngine(script->RequiredFeatures(),
                                         script->RequiredExtensions());
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
 
   const auto& features = ToStub(engine.get())->GetFeatures();
@@ -441,12 +442,12 @@ fence_timeout 12345)";
   Parser parser;
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
-  const auto* script = parser.GetScript();
+  auto script = parser.GetScript();
   auto engine = MakeAndInitializeEngine(script->RequiredFeatures(),
                                         script->RequiredExtensions());
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
 
   const auto& features = ToStub(engine.get())->GetFeatures();
@@ -490,9 +491,10 @@ void main() {}
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
   auto engine = MakeEngine();
+  auto script = parser.GetScript();
 
   Executor ex;
-  r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
 
   auto shader_types = ToStub(engine.get())->GetShaderTypesSeen();
@@ -514,9 +516,10 @@ void main() {}
 
   auto engine = MakeEngine();
   ToStub(engine.get())->FailShaderCommand();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("shader command failed", r.Error());
 }
@@ -530,9 +533,10 @@ clear)";
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   EXPECT_TRUE(ToStub(engine.get())->DidClearCommand());
 }
@@ -547,9 +551,10 @@ clear)";
 
   auto engine = MakeEngine();
   ToStub(engine.get())->FailClearCommand();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("clear command failed", r.Error());
 }
@@ -563,9 +568,10 @@ clear color 244 123 123 13)";
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidClearColorCommand());
 
@@ -589,9 +595,10 @@ clear color 123 123 123 123)";
 
   auto engine = MakeEngine();
   ToStub(engine.get())->FailClearColorCommand();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("clear color command failed", r.Error());
 }
@@ -605,9 +612,10 @@ clear depth 24)";
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidClearDepthCommand());
 }
@@ -622,9 +630,10 @@ clear depth 24)";
 
   auto engine = MakeEngine();
   ToStub(engine.get())->FailClearDepthCommand();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("clear depth command failed", r.Error());
 }
@@ -638,9 +647,10 @@ clear stencil 24)";
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidClearStencilCommand());
 }
@@ -655,9 +665,10 @@ clear stencil 24)";
 
   auto engine = MakeEngine();
   ToStub(engine.get())->FailClearStencilCommand();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("clear stencil command failed", r.Error());
 }
@@ -671,9 +682,10 @@ draw rect 2 4 10 20)";
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidDrawRectCommand());
 }
@@ -688,9 +700,10 @@ draw rect 2 4 10 20)";
 
   auto engine = MakeEngine();
   ToStub(engine.get())->FailDrawRectCommand();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("draw rect command failed", r.Error());
 }
@@ -704,9 +717,10 @@ draw arrays TRIANGLE_LIST 0 0)";
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidDrawArraysCommand());
 }
@@ -721,9 +735,10 @@ draw arrays TRIANGLE_LIST 0 0)";
 
   auto engine = MakeEngine();
   ToStub(engine.get())->FailDrawArraysCommand();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("draw arrays command failed", r.Error());
 }
@@ -737,9 +752,10 @@ compute 2 3 4)";
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidComputeCommand());
 }
@@ -754,9 +770,10 @@ compute 2 3 4)";
 
   auto engine = MakeEngine();
   ToStub(engine.get())->FailComputeCommand();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("compute command failed", r.Error());
 }
@@ -770,9 +787,10 @@ vertex entrypoint main)";
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidEntryPointCommand());
 }
@@ -787,9 +805,10 @@ vertex entrypoint main)";
 
   auto engine = MakeEngine();
   ToStub(engine.get())->FailEntryPointCommand();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("entrypoint command failed", r.Error());
 }
@@ -803,9 +822,10 @@ patch parameter vertices 10)";
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidPatchParameterVerticesCommand());
 }
@@ -820,9 +840,10 @@ patch parameter vertices 10)";
 
   auto engine = MakeEngine();
   ToStub(engine.get())->FailPatchParameterVerticesCommand();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("patch command failed", r.Error());
 }
@@ -836,9 +857,10 @@ probe rect rgba 2 3 40 40 0.2 0.4 0.4 0.3)";
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   // ASSERT_TRUE(ToStub(engine.get())->DidProbeCommand());
 }
@@ -853,9 +875,10 @@ probe rect rgba 2 3 40 40 0.2 0.4 0.4 0.3)";
 
   auto engine = MakeEngine();
   // ToStub(engine.get())->FailProbeCommand();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("probe command failed", r.Error());
 }
@@ -869,9 +892,10 @@ ssbo 0 24)";
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidBufferCommand());
 }
@@ -886,9 +910,10 @@ ssbo 0 24)";
 
   auto engine = MakeEngine();
   ToStub(engine.get())->FailBufferCommand();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("buffer command failed", r.Error());
 }
@@ -902,9 +927,10 @@ probe ssbo vec3 0 2 <= 2 3 4)";
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   // ASSERT_TRUE(ToStub(engine.get())->DidProbeSSBOCommand());
 }
@@ -919,9 +945,10 @@ probe ssbo vec3 0 2 <= 2 3 4)";
 
   auto engine = MakeEngine();
   // ToStub(engine.get())->FailProbeSSBOCommand();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("probe ssbo command failed", r.Error());
 }
@@ -937,9 +964,10 @@ TEST_F(VkScriptExecutorTest, VertexData) {
   Parser parser;
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
   auto engine = MakeEngine();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
 
   auto stub = ToStub(engine.get());
@@ -981,9 +1009,10 @@ TEST_F(VkScriptExecutorTest, IndexBuffer) {
   Parser parser;
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
   auto engine = MakeEngine();
+  auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), parser.GetScript(), ShaderMap());
+  Result r = ex.Execute(engine.get(), ToVkScript(script.get()), ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
 
   auto stub = ToStub(engine.get());

--- a/src/vkscript/parser.h
+++ b/src/vkscript/parser.h
@@ -15,6 +15,7 @@
 #ifndef SRC_VKSCRIPT_PARSER_H_
 #define SRC_VKSCRIPT_PARSER_H_
 
+#include <memory>
 #include <string>
 
 #include "amber/result.h"
@@ -32,7 +33,9 @@ class Parser : public amber::Parser {
 
   // amber::Parser
   Result Parse(const std::string& data) override;
-  const amber::Script* GetScript() const override { return &script_; }
+  std::unique_ptr<amber::Script> GetScript() override {
+    return std::move(script_);
+  }
 
   Result ProcessRequireBlockForTesting(const std::string& block) {
     return ProcessRequireBlock(block);
@@ -55,7 +58,7 @@ class Parser : public amber::Parser {
   Result ProcessVertexDataBlock(const std::string&);
   Result ProcessTestBlock(const std::string&);
 
-  vkscript::Script script_;
+  std::unique_ptr<vkscript::Script> script_;
 };
 
 }  // namespace vkscript

--- a/src/vkscript/parser_test.cc
+++ b/src/vkscript/parser_test.cc
@@ -34,7 +34,7 @@ TEST_F(VkScriptParserTest, EmptyRequireBlock) {
 
   auto script = parser.GetScript();
   ASSERT_TRUE(script->IsVkScript());
-  EXPECT_TRUE(ToVkScript(script)->Nodes().empty());
+  EXPECT_TRUE(ToVkScript(script.get())->Nodes().empty());
 }
 
 TEST_F(VkScriptParserTest, RequireBlockNoArgumentFeatures) {
@@ -114,7 +114,8 @@ TEST_F(VkScriptParserTest, RequireBlockNoArgumentFeatures) {
     Result r = parser.ProcessRequireBlockForTesting(feature.name);
     ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-    auto& feats = ToVkScript(parser.GetScript())->RequiredFeatures();
+    auto script = parser.GetScript();
+    auto& feats = ToVkScript(script.get())->RequiredFeatures();
     ASSERT_EQ(1U, feats.size());
     EXPECT_EQ(feature.feature, feats[0]);
   }
@@ -128,7 +129,8 @@ VK_KHR_variable_pointers)";
   Result r = parser.ProcessRequireBlockForTesting(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& exts = parser.GetScript()->RequiredExtensions();
+  auto script = parser.GetScript();
+  auto& exts = script->RequiredExtensions();
   ASSERT_EQ(2U, exts.size());
   EXPECT_EQ("VK_KHR_storage_buffer_storage_class", exts[0]);
   EXPECT_EQ("VK_KHR_variable_pointers", exts[1]);
@@ -141,7 +143,8 @@ TEST_F(VkScriptParserTest, RequireBlockFramebuffer) {
   Result r = parser.ProcessRequireBlockForTesting(block);
   ASSERT_TRUE(r.IsSuccess());
 
-  auto script = ToVkScript(parser.GetScript());
+  auto amber_script = parser.GetScript();
+  auto script = ToVkScript(amber_script.get());
   EXPECT_EQ(1U, script->Nodes().size());
 
   auto& nodes = script->Nodes();
@@ -163,7 +166,8 @@ TEST_F(VkScriptParserTest, RequireBlockDepthStencil) {
   Result r = parser.ProcessRequireBlockForTesting(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToVkScript(parser.GetScript());
+  auto amber_script = parser.GetScript();
+  auto script = ToVkScript(amber_script.get());
   EXPECT_EQ(1U, script->Nodes().size());
 
   auto& nodes = script->Nodes();
@@ -192,7 +196,8 @@ inheritedQueries # line comment
   Result r = parser.ProcessRequireBlockForTesting(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto script = ToVkScript(parser.GetScript());
+  auto amber_script = parser.GetScript();
+  auto script = ToVkScript(amber_script.get());
   EXPECT_EQ(1U, script->Nodes().size());
 
   auto& nodes = script->Nodes();
@@ -221,7 +226,8 @@ TEST_F(VkScriptParserTest, IndicesBlock) {
   Result r = parser.ProcessIndicesBlockForTesting(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& nodes = ToVkScript(parser.GetScript())->Nodes();
+  auto script = parser.GetScript();
+  auto& nodes = ToVkScript(script.get())->Nodes();
   ASSERT_EQ(1U, nodes.size());
   ASSERT_TRUE(nodes[0]->IsIndices());
 
@@ -250,7 +256,8 @@ TEST_F(VkScriptParserTest, IndicesBlockMultipleLines) {
   Result r = parser.ProcessIndicesBlockForTesting(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& nodes = ToVkScript(parser.GetScript())->Nodes();
+  auto amber_script = parser.GetScript();
+  auto& nodes = ToVkScript(amber_script.get())->Nodes();
   ASSERT_EQ(1U, nodes.size());
   ASSERT_TRUE(nodes[0]->IsIndices());
 
@@ -287,7 +294,8 @@ TEST_F(VkScriptParserTest, VertexDataEmpty) {
   Result r = parser.ProcessVertexDataBlockForTesting(block);
   ASSERT_TRUE(r.IsSuccess());
 
-  auto& nodes = ToVkScript(parser.GetScript())->Nodes();
+  auto amber_script = parser.GetScript();
+  auto& nodes = ToVkScript(amber_script.get())->Nodes();
   EXPECT_TRUE(nodes.empty());
 }
 
@@ -298,7 +306,8 @@ TEST_F(VkScriptParserTest, VertexDataHeaderFormatString) {
   Result r = parser.ProcessVertexDataBlockForTesting(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& nodes = ToVkScript(parser.GetScript())->Nodes();
+  auto amber_script = parser.GetScript();
+  auto& nodes = ToVkScript(amber_script.get())->Nodes();
   ASSERT_EQ(1U, nodes.size());
   ASSERT_TRUE(nodes[0]->IsVertexData());
 
@@ -324,7 +333,8 @@ TEST_F(VkScriptParserTest, VertexDataHeaderGlslString) {
   Result r = parser.ProcessVertexDataBlockForTesting(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& nodes = ToVkScript(parser.GetScript())->Nodes();
+  auto amber_script = parser.GetScript();
+  auto& nodes = ToVkScript(amber_script.get())->Nodes();
   ASSERT_EQ(1U, nodes.size());
   ASSERT_TRUE(nodes[0]->IsVertexData());
 
@@ -363,7 +373,8 @@ clear)";
   Result r = parser.ProcessTestBlockForTesting(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  const auto& cmds = parser.GetScript()->GetCommands();
+  auto script = parser.GetScript();
+  const auto& cmds = script->GetCommands();
   ASSERT_EQ(4U, cmds.size());
 
   ASSERT_TRUE(cmds[0]->IsClearColor());
@@ -395,7 +406,8 @@ TEST_F(VkScriptParserTest, VertexDataRows) {
   Result r = parser.ProcessVertexDataBlockForTesting(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& nodes = ToVkScript(parser.GetScript())->Nodes();
+  auto script = parser.GetScript();
+  auto& nodes = ToVkScript(script.get())->Nodes();
   ASSERT_EQ(1U, nodes.size());
   ASSERT_TRUE(nodes[0]->IsVertexData());
 
@@ -456,7 +468,8 @@ TEST_F(VkScriptParserTest, VertexDataRowsWithHex) {
   Result r = parser.ProcessVertexDataBlockForTesting(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto& nodes = ToVkScript(parser.GetScript())->Nodes();
+  auto script = parser.GetScript();
+  auto& nodes = ToVkScript(script.get())->Nodes();
   ASSERT_EQ(1U, nodes.size());
   ASSERT_TRUE(nodes[0]->IsVertexData());
 

--- a/src/vkscript/section_parser.cc
+++ b/src/vkscript/section_parser.cc
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "src/make_unique.h"
+#include "src/shader_data.h"
 
 namespace amber {
 namespace vkscript {

--- a/src/vkscript/section_parser.h
+++ b/src/vkscript/section_parser.h
@@ -20,7 +20,7 @@
 #include <vector>
 
 #include "amber/result.h"
-#include "src/shader_data.h"
+#include "amber/shader_info.h"
 
 namespace amber {
 namespace vkscript {

--- a/src/vkscript/section_parser_test.cc
+++ b/src/vkscript/section_parser_test.cc
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "src/vkscript/section_parser.h"
 #include "gtest/gtest.h"
+#include "src/shader_data.h"
+#include "src/vkscript/section_parser.h"
 
 namespace amber {
 namespace vkscript {


### PR DESCRIPTION
This CL splits Amber::Execute into a parse and execute step. The Parse
step accepts a Recipe to fill out, that Recipe is then passed into the
Execute step. The recipe, in the future, will allow retrieving
information about the given script.