### PR TITLE
Vulkan: change framebuffer image layout correctly

### DIFF
--- a/src/vulkan/descriptor.h
+++ b/src/vulkan/descriptor.h
@@ -60,11 +60,6 @@ class Descriptor {
 
   uint32_t GetDescriptorSet() const { return descriptor_set_; }
   uint32_t GetBinding() const { return binding_; }
-  bool operator<(const Descriptor& r) {
-    if (descriptor_set_ == r.descriptor_set_)
-      return binding_ < r.binding_;
-    return descriptor_set_ < r.descriptor_set_;
-  }
 
   DescriptorType GetType() const { return type_; }
 

--- a/src/vulkan/frame_buffer.cc
+++ b/src/vulkan/frame_buffer.cc
@@ -89,10 +89,22 @@ Result FrameBuffer::ChangeFrameImageLayout(VkCommandBuffer command,
           "FrameBuffer::ChangeFrameImageLayout new layout cannot be kProbe "
           "from kInit");
     }
-    // Note that we set the final layout of RenderPass as
-    // VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, thus we must not change
-    // image layout of frame buffer from color attachment to transfer
-    // source here.
+
+    if (color_image_) {
+      color_image_->ChangeLayout(command,
+                                 VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+                                 VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                 VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                                 VK_PIPELINE_STAGE_TRANSFER_BIT);
+    }
+    if (depth_image_) {
+      depth_image_->ChangeLayout(
+          command, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+          VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+          VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+          VK_PIPELINE_STAGE_TRANSFER_BIT);
+    }
+
     frame_image_layout_ = FrameImageState::kProbe;
     return {};
   }
@@ -113,7 +125,7 @@ Result FrameBuffer::ChangeFrameImageLayout(VkCommandBuffer command,
                                VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                                VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
   }
-  frame_image_layout_ = layout;
+  frame_image_layout_ = FrameImageState::kClearOrDraw;
   return {};
 }
 

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -85,7 +85,7 @@ class GraphicsPipeline : public Pipeline {
   Result CreateVkGraphicsPipeline(VkPrimitiveTopology topology);
 
   Result CreateRenderPass();
-  void ActivateRenderPassIfNeeded();
+  Result ActivateRenderPassIfNeeded();
   void DeactivateRenderPassIfNeeded();
 
   // Send vertex and index buffers.


### PR DESCRIPTION
`oldLayout` of `VkImageMemoryBarrier` when calling
`vkCmdPipelineBarrier()` must match previous image layout. This
commit changes image layout of framebuffer correctly and fixes bugs
of incorrect drawing results in Intel GPU.

Fixes #155