### PR TITLE
Vulkan: fix discontinuous descriptor set error

### DIFF
--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -366,17 +366,18 @@ Result Pipeline::SendDescriptorDataToDeviceIfNeeded() {
 }
 
 void Pipeline::BindVkDescriptorSets() {
-  for (size_t desc = 0, set = 0; desc < descriptor_set_layout_types_.size() &&
-                                 set < descriptor_sets_.size();
+  for (size_t desc = 0, non_empty_desc = 0;
+       desc < descriptor_set_layout_types_.size() &&
+       non_empty_desc < descriptor_sets_.size();
        ++desc) {
     if (descriptor_set_layout_types_[desc] ==
         DescriptorSetLayoutType::kNonEmpty) {
       vkCmdBindDescriptorSets(command_->GetCommandBuffer(),
                               IsGraphics() ? VK_PIPELINE_BIND_POINT_GRAPHICS
                                            : VK_PIPELINE_BIND_POINT_COMPUTE,
-                              pipeline_layout_, desc, 1, &descriptor_sets_[set],
-                              0, nullptr);
-      ++set;
+                              pipeline_layout_, desc, 1,
+                              &descriptor_sets_[non_empty_desc], 0, nullptr);
+      ++non_empty_desc;
     }
   }
 }

--- a/src/vulkan/pipeline.h
+++ b/src/vulkan/pipeline.h
@@ -83,10 +83,6 @@ class Pipeline {
   VkPipeline pipeline_ = VK_NULL_HANDLE;
   VkPipelineLayout pipeline_layout_ = VK_NULL_HANDLE;
 
-  std::vector<VkDescriptorSetLayout> descriptor_set_layouts_;
-  std::vector<VkDescriptorPool> descriptor_pools_;
-  std::vector<VkDescriptorSet> descriptor_sets_;
-
   VkDevice device_ = VK_NULL_HANDLE;
   VkPhysicalDeviceMemoryProperties memory_properties_;
   std::unique_ptr<CommandBuffer> command_;
@@ -98,11 +94,24 @@ class Pipeline {
   Result CreateDescriptorPools();
   Result CreateDescriptorSets();
 
-  void DestoryDescriptorSetLayouts();
-  void DestoryDescriptorPools();
+  void DestroyDescriptorSetLayouts();
+  void DestroyDescriptorPools();
+
+  // When actually used descriptor sets are discontinuous, we must
+  // put empty descriptor set layouts between them when building
+  // pipeline layout. This method creates those empty descriptor set
+  // layouts that are not actually used but just for shaping
+  // pipeline layout correctly.
+  Result CreateEmptyDescriptorSetLayouts();
+  void DestroyEmptyDescriptorSetLayouts();
 
   PipelineType pipeline_type_;
   std::vector<std::unique_ptr<Descriptor>> descriptors_;
+  std::vector<uint32_t> descriptor_set_numbers_;
+  std::vector<VkDescriptorSetLayout> descriptor_set_layouts_;
+  std::vector<VkDescriptorSetLayout> empty_descriptor_set_layouts_;
+  std::vector<VkDescriptorPool> descriptor_pools_;
+  std::vector<VkDescriptorSet> descriptor_sets_;
   std::vector<VkPipelineShaderStageCreateInfo> shader_stage_info_;
   uint32_t fence_timeout_ms_ = 100;
   bool descriptor_related_objects_already_created_ = false;

--- a/src/vulkan/pipeline.h
+++ b/src/vulkan/pipeline.h
@@ -88,11 +88,12 @@ class Pipeline {
   std::unique_ptr<CommandBuffer> command_;
 
  private:
-  struct DescriptorSet {
+  struct DescriptorSetInfo {
     bool empty = true;
     VkDescriptorSetLayout layout = VK_NULL_HANDLE;
     VkDescriptorPool pool = VK_NULL_HANDLE;
     VkDescriptorSet vk_desc_set = VK_NULL_HANDLE;
+    std::vector<std::unique_ptr<Descriptor>> descriptors_;
   };
 
   Result CreatePipelineLayout();
@@ -101,12 +102,8 @@ class Pipeline {
   Result CreateDescriptorPools();
   Result CreateDescriptorSets();
 
-  // Sort |descriptors_| in the order of |descriptors_set_| and |binding_|.
-  void SortDescriptorsBySetAndBinding();
-
   PipelineType pipeline_type_;
-  std::vector<std::unique_ptr<Descriptor>> descriptors_;
-  std::vector<DescriptorSet> descriptor_sets_;
+  std::vector<DescriptorSetInfo> descriptor_set_info_;
   std::vector<VkPipelineShaderStageCreateInfo> shader_stage_info_;
   uint32_t fence_timeout_ms_ = 100;
   bool descriptor_related_objects_already_created_ = false;

--- a/src/vulkan/pipeline.h
+++ b/src/vulkan/pipeline.h
@@ -88,6 +88,11 @@ class Pipeline {
   std::unique_ptr<CommandBuffer> command_;
 
  private:
+  enum class DescriptorSetLayoutType : uint8_t {
+    kEmpty = 0,
+    kNonEmpty,
+  };
+
   Result CreatePipelineLayout();
 
   Result CreateDescriptorSetLayouts();
@@ -97,24 +102,19 @@ class Pipeline {
   void DestroyDescriptorSetLayouts();
   void DestroyDescriptorPools();
 
-  // When actually used descriptor sets are discontinuous, we must
-  // put empty descriptor set layouts between them when building
-  // pipeline layout. This method creates those empty descriptor set
-  // layouts that are not actually used but just for shaping
-  // pipeline layout correctly.
-  Result CreateEmptyDescriptorSetLayouts();
-  void DestroyEmptyDescriptorSetLayouts();
+  // Sort |descriptors_| in the order of |descriptors_set_| and |binding_|.
+  void SortDescriptorsBySetAndBinding();
 
   PipelineType pipeline_type_;
   std::vector<std::unique_ptr<Descriptor>> descriptors_;
-  std::vector<uint32_t> descriptor_set_numbers_;
+  std::vector<DescriptorSetLayoutType> descriptor_set_layout_types_;
   std::vector<VkDescriptorSetLayout> descriptor_set_layouts_;
-  std::vector<VkDescriptorSetLayout> empty_descriptor_set_layouts_;
   std::vector<VkDescriptorPool> descriptor_pools_;
   std::vector<VkDescriptorSet> descriptor_sets_;
   std::vector<VkPipelineShaderStageCreateInfo> shader_stage_info_;
   uint32_t fence_timeout_ms_ = 100;
   bool descriptor_related_objects_already_created_ = false;
+  bool need_sort_descriptors_ = true;
 };
 
 }  // namespace vulkan

--- a/src/vulkan/pipeline.h
+++ b/src/vulkan/pipeline.h
@@ -88,9 +88,11 @@ class Pipeline {
   std::unique_ptr<CommandBuffer> command_;
 
  private:
-  enum class DescriptorSetLayoutType : uint8_t {
-    kEmpty = 0,
-    kNonEmpty,
+  struct DescriptorSet {
+    bool empty = true;
+    VkDescriptorSetLayout layout = VK_NULL_HANDLE;
+    VkDescriptorPool pool = VK_NULL_HANDLE;
+    VkDescriptorSet vk_desc_set = VK_NULL_HANDLE;
   };
 
   Result CreatePipelineLayout();
@@ -99,18 +101,12 @@ class Pipeline {
   Result CreateDescriptorPools();
   Result CreateDescriptorSets();
 
-  void DestroyDescriptorSetLayouts();
-  void DestroyDescriptorPools();
-
   // Sort |descriptors_| in the order of |descriptors_set_| and |binding_|.
   void SortDescriptorsBySetAndBinding();
 
   PipelineType pipeline_type_;
   std::vector<std::unique_ptr<Descriptor>> descriptors_;
-  std::vector<DescriptorSetLayoutType> descriptor_set_layout_types_;
-  std::vector<VkDescriptorSetLayout> descriptor_set_layouts_;
-  std::vector<VkDescriptorPool> descriptor_pools_;
-  std::vector<VkDescriptorSet> descriptor_sets_;
+  std::vector<DescriptorSet> descriptor_sets_;
   std::vector<VkPipelineShaderStageCreateInfo> shader_stage_info_;
   uint32_t fence_timeout_ms_ = 100;
   bool descriptor_related_objects_already_created_ = false;

--- a/tests/cases/compute_nothing_with_ssbo.amber
+++ b/tests/cases/compute_nothing_with_ssbo.amber
@@ -1,0 +1,37 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[compute shader]
+#version 430
+
+layout(set = 1, binding = 2) buffer block1 {
+  float data_set1_binding2[11];
+};
+
+void main() {
+}
+
+[test]
+ssbo 1:2 subdata vec4  0 0.1 0.2 0.3 0.4
+compute 4 1 1
+probe ssbo float 1:2 0  ~= 0.1 0.2  0.3  0.4
+
+
+ssbo 1:2 subdata float 0 0.57 0.56 0.55 0.54 \
+                         0.53 0.52 0.51 0.50 \
+                         0.49 0.48 0.47
+compute 4 1 1
+probe ssbo float 1:2 0  ~= 0.57 0.56 0.55 0.54 \
+                           0.53 0.52 0.51 0.50 \
+                           0.49 0.48 0.47

--- a/tests/cases/multiple_ssbo_with_sparse_descriptor_set_in_compute_pipeline.amber
+++ b/tests/cases/multiple_ssbo_with_sparse_descriptor_set_in_compute_pipeline.amber
@@ -1,0 +1,116 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[compute shader]
+#version 430
+
+layout(set = 1, binding = 0) buffer block1 {
+  float data_set1_binding0[11];
+  float data_set1_binding0_result[11];
+};
+
+layout(set = 1, binding = 2) buffer block2 {
+  float data_set1_binding2[11];
+  float data_set1_binding2_result[11];
+};
+
+layout(set = 3, binding = 1) buffer block3 {
+  float data_set3_binding1[11];
+  float data_set3_binding1_result[11];
+};
+
+layout(set = 5, binding = 3) buffer block4 {
+  float data_set5_binding3[11];
+  float data_set5_binding3_result[11];
+};
+
+void main() {
+  for (int i = 0; i < 11; ++i) {
+    data_set1_binding0_result[i] = data_set1_binding2[i];
+    data_set1_binding2_result[i] = data_set3_binding1[i];
+    data_set3_binding1_result[i] = data_set5_binding3[i];
+    data_set5_binding3_result[i] = data_set1_binding0[i];
+  }
+}
+
+[test]
+ssbo 1:0 subdata vec4  0 0.1 0.2 0.3 0.4
+ssbo 1:2 subdata vec4  0 0.1 0.2 0.3 0.4
+ssbo 3:1 subdata vec4  0 0.1 0.2 0.3 0.4
+ssbo 5:3 subdata vec4  0 0.1 0.2 0.3 0.4
+
+compute 4 1 1
+
+probe ssbo float 1:0 0  ~= 0.1 0.2  0.3  0.4
+probe ssbo float 1:2 0  ~= 0.1 0.2  0.3  0.4
+probe ssbo float 3:1 0  ~= 0.1 0.2  0.3  0.4
+probe ssbo float 5:3 0  ~= 0.1 0.2  0.3  0.4
+
+ssbo 1:0 subdata float 0 0.1 0.2  0.3  0.4 \
+                         0.5 0.6  0.7  0.8 \
+                         0.9 0.10 0.11     \
+                         0.1 0.2  0.3  0.4 \
+                         0.5 0.6  0.7  0.8 \
+                         0.9 0.10 0.11
+
+ssbo 1:2 subdata float 0 0.57 0.56 0.55 0.54 \
+                         0.53 0.52 0.51 0.50 \
+                         0.49 0.48 0.47      \
+                         0.57 0.56 0.55 0.54 \
+                         0.53 0.52 0.51 0.50 \
+                         0.49 0.48 0.47
+
+ssbo 3:1 subdata float 0 0.21 0.22 0.23 0.24 \
+                         0.25 0.26 0.27 0.28 \
+                         0.29 0.30 0.31      \
+                         0.21 0.22 0.23 0.24 \
+                         0.25 0.26 0.27 0.28 \
+                         0.29 0.30 0.31
+
+ssbo 5:3 subdata float 0 0.23  0.229 0.228 0.227 \
+                         0.226 0.225 0.224 0.223 \
+                         0.222 0.221 0.22        \
+                         0.23  0.229 0.228 0.227 \
+                         0.226 0.225 0.224 0.223 \
+                         0.222 0.221 0.22
+
+compute 4 1 1
+
+probe ssbo float 1:0 0  ~= 0.1 0.2  0.3  0.4 \
+                           0.5 0.6  0.7  0.8 \
+                           0.9 0.10 0.11
+probe ssbo float 1:0 44 ~= 0.57 0.56 0.55 0.54 \
+                           0.53 0.52 0.51 0.50 \
+                           0.49 0.48 0.47
+
+probe ssbo float 1:2 0  ~= 0.57 0.56 0.55 0.54 \
+                           0.53 0.52 0.51 0.50 \
+                           0.49 0.48 0.47
+probe ssbo float 1:2 44 ~= 0.21 0.22 0.23 0.24 \
+                           0.25 0.26 0.27 0.28 \
+                           0.29 0.30 0.31
+
+probe ssbo float 3:1 0  ~= 0.21 0.22 0.23 0.24 \
+                           0.25 0.26 0.27 0.28 \
+                           0.29 0.30 0.31
+probe ssbo float 3:1 44 ~= 0.23  0.229 0.228 0.227 \
+                           0.226 0.225 0.224 0.223 \
+                           0.222 0.221 0.22
+
+probe ssbo float 5:3 0  ~= 0.23  0.229 0.228 0.227 \
+                           0.226 0.225 0.224 0.223 \
+                           0.222 0.221 0.22
+probe ssbo float 5:3 44 ~= 0.1 0.2  0.3  0.4 \
+                           0.5 0.6  0.7  0.8 \
+                           0.9 0.10 0.11


### PR DESCRIPTION
Without this commit, Amber supports descriptors with consecutive
descriptor sets from `[0, N]`, but it does not support discontinuous
descriptor sets e.g., `1, 3, 5`. To support discontinuous
descriptor sets, this commit creates empty descriptor set layouts
and puts them on pipeline layout.

Fixes #158