### PR TITLE
Vulkan: separate descriptor set update from use

### DIFF
--- a/src/vulkan/compute_pipeline.cc
+++ b/src/vulkan/compute_pipeline.cc
@@ -93,10 +93,6 @@ Result ComputePipeline::Compute(uint32_t x, uint32_t y, uint32_t z) {
   if (!r.IsSuccess())
     return r;
 
-  r = UpdateDescriptorSetsIfNeeded();
-  if (!r.IsSuccess())
-    return r;
-
   BindVkDescriptorSets();
   BindVkPipeline();
 

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -516,11 +516,30 @@ Result GraphicsPipeline::Draw(const DrawArraysCommand* command) {
   if (!r.IsSuccess())
     return r;
 
+  r = command_->End();
+  if (!r.IsSuccess())
+    return r;
+
+  r = command_->SubmitAndReset(GetFenceTimeout());
+  if (!r.IsSuccess())
+    return r;
+
   if (pipeline_ == VK_NULL_HANDLE) {
     r = CreateVkGraphicsPipeline(ToVkTopology(command->GetTopology()));
     if (!r.IsSuccess())
       return r;
   }
+
+  // Note that a command updating a descriptor set and a command using
+  // it must be submitted separately, because using a descriptor set
+  // while updating it is not safe.
+  r = UpdateDescriptorSetsIfNeeded();
+  if (!r.IsSuccess())
+    return r;
+
+  r = command_->BeginIfNotInRecording();
+  if (!r.IsSuccess())
+    return r;
 
   r = UpdateDescriptorSetsIfNeeded();
   if (!r.IsSuccess())

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -541,10 +541,6 @@ Result GraphicsPipeline::Draw(const DrawArraysCommand* command) {
   if (!r.IsSuccess())
     return r;
 
-  r = UpdateDescriptorSetsIfNeeded();
-  if (!r.IsSuccess())
-    return r;
-
   r = SendBufferDataIfNeeded();
   if (!r.IsSuccess())
     return r;


### PR DESCRIPTION
If commands for updating a descriptor set and using the descriptor
set are submitted at the same time, it is not guaranteed that the
descriptor has correct values when using it. This CL separates a
command submission for updating a descriptor set from the one for
using it.

Fixes #161