### PR TITLE
Output any errors produced during test runs.

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -53,7 +53,11 @@ class TestRunner:
     cmd += [tc.GetInputPath()]
 
     try:
-      subprocess.check_output(cmd)
+      err = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+      if err != "" and not tc.IsExpectedFail():
+        sys.stdout.write(err)
+        return False
+
     except Exception as e:
       if not tc.IsExpectedFail():
         print e

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -59,6 +59,7 @@ class TestRunner:
         return False
 
     except Exception as e:
+      print e.output
       if not tc.IsExpectedFail():
         print e
       return False


### PR DESCRIPTION
This CL captures the stderr of the amber process and fails the tests if
there were error messages reported. This should allow catching vulkan
validation errors.

Fixes #151