### PR TITLE
Vulkan: fix draw rect once bug

### DIFF
--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -482,9 +482,13 @@ Result GraphicsPipeline::ClearBuffer(const VkClearValue& clear_value,
 }
 
 Result GraphicsPipeline::ResetPipelineAndVertexBuffer() {
+  Result r = command_->BeginIfNotInRecording();
+  if (!r.IsSuccess())
+    return r;
+
   DeactivateRenderPassIfNeeded();
 
-  Result r = command_->End();
+  r = command_->End();
   if (!r.IsSuccess())
     return r;
 

--- a/tests/cases/clear_color_without_probe.amber
+++ b/tests/cases/clear_color_without_probe.amber
@@ -1,0 +1,32 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[vertex shader passthrough]
+
+[fragment shader]
+#version 430
+
+layout(location = 0) in vec4 color_in;
+layout(location = 0) out vec4 color_out;
+
+void main() {
+  color_out = color_in;
+}
+
+[test]
+clear color 1 0.4 0.5 0.2
+clear
+
+clear color 0.4 0.2 1 0.5
+clear

--- a/tests/cases/compute_ssbo_without_probe.amber
+++ b/tests/cases/compute_ssbo_without_probe.amber
@@ -1,0 +1,49 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[compute shader]
+#version 430
+
+layout(set = 0, binding = 0) buffer block0 {
+  float data_set0_binding0[3];
+};
+
+layout(set = 1, binding = 2) buffer block1 {
+  float data_set1_binding2[3];
+};
+
+layout(set = 2, binding = 1) buffer block2 {
+  float data_set2_binding1[3];
+};
+
+layout(set = 2, binding = 3) buffer block3 {
+  float data_set2_binding3[3];
+};
+
+void main() {
+  const uint index = gl_WorkGroupID.x;
+  data_set0_binding0[index] = data_set0_binding0[index] + 1.0f;
+  data_set1_binding2[index] = data_set2_binding1[index] -
+                              data_set1_binding2[index];
+  data_set2_binding1[index] = 10.0f * data_set2_binding3[index] +
+                              data_set2_binding1[index];
+  data_set2_binding3[index] = 30.0f * data_set2_binding3[index];
+}
+
+[test]
+ssbo 0:0 subdata vec3  0  1.0  2.0  3.0
+ssbo 1:2 subdata vec3  0  4.0  5.0  6.0
+ssbo 2:1 subdata vec3  0 21.0 22.0 23.0
+ssbo 2:3 subdata vec3  0  0.7  0.8  0.9
+compute 3 1 1

--- a/tests/cases/draw_rectangles_once.amber
+++ b/tests/cases/draw_rectangles_once.amber
@@ -1,0 +1,46 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[require]
+vertexPipelineStoresAndAtomics
+
+[vertex shader]
+#version 430
+
+layout(location = 0) in vec4 position;
+layout(location = 0) out vec4 frag_color;
+
+layout(set = 0, binding = 0) buffer block1 {
+  vec4 in_color;
+};
+
+void main() {
+  gl_Position = position;
+  frag_color = in_color;
+}
+
+[fragment shader]
+#version 430
+
+layout(location = 0) in vec4 frag_color;
+layout(location = 0) out vec4 final_color;
+
+void main() {
+  final_color = frag_color;
+}
+
+[test]
+ssbo 0 subdata vec4 0 1.0 0.0 0.0 1.0
+draw rect -1 -1 1 1
+relative probe rect rgba (0.0, 0.0, 0.5, 0.5) (1.0, 0, 0, 1.0)

--- a/tests/cases/draw_rectangles_without_probe.amber
+++ b/tests/cases/draw_rectangles_without_probe.amber
@@ -1,0 +1,45 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[require]
+vertexPipelineStoresAndAtomics
+
+[vertex shader]
+#version 430
+
+layout(location = 0) in vec4 position;
+layout(location = 0) out vec4 frag_color;
+
+layout(set = 0, binding = 0) buffer block1 {
+  vec4 in_color;
+};
+
+void main() {
+  gl_Position = position;
+  frag_color = in_color;
+}
+
+[fragment shader]
+#version 430
+
+layout(location = 0) in vec4 frag_color;
+layout(location = 0) out vec4 final_color;
+
+void main() {
+  final_color = frag_color;
+}
+
+[test]
+ssbo 0 subdata vec4 0 1.0 0.0 0.0 1.0
+draw rect -1 -1 1 1

--- a/tests/cases/draw_triangle_list_without_probe.amber
+++ b/tests/cases/draw_triangle_list_without_probe.amber
@@ -1,0 +1,52 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[vertex shader]
+#version 430
+
+layout(location = 0) in vec4 position;
+layout(location = 1) in vec4 vert_color;
+layout(location = 0) out vec4 frag_color;
+
+void main() {
+  gl_Position = position;
+  frag_color = vert_color;
+}
+
+[fragment shader]
+#version 430
+
+layout(location = 0) in vec4 frag_color;
+layout(location = 0) out vec4 final_color;
+
+void main() {
+  final_color = frag_color;
+}
+
+[vertex data]
+#        position     vert_color
+     0/R8G8_SNORM 1/R8G8B8_UNORM
+
+#           Red for entire frame
+#         R8   G8     R8  G8  B8
+        -128 -128    255   0   0
+         127  127    255   0   0
+        -128  127    255   0   0
+
+        -128 -128    255   0   0
+         127  127    255   0   0
+         127 -128    255   0   0
+
+[test]
+draw arrays TRIANGLE_LIST 0 6


### PR DESCRIPTION
Running just one draw rect command without any other draw array,
draw rect, nor clear fails because
`GraphicsPipeline::ResetPipelineAndVertexBuffer()` calls
`CommandBuffer::End()` even when CommandBuffer is not in
`CommandBufferState::kRecording`. This CL fixes it.
    
Fixes #173 