### PR TITLE
Output token on VkScript parse error

### DIFF
--- a/src/tokenizer.cc
+++ b/src/tokenizer.cc
@@ -157,6 +157,8 @@ std::unique_ptr<Token> Tokenizer::NextToken() {
   if (tok_str.size() > 1 && tok_str[0] == '-')
     tok->SetNegative();
 
+  tok->SetOriginalString(tok_str);
+
   // If the number isn't the whole token then move back so we can then parse
   // the string portion.
   auto diff = size_t(final_pos - tok_str.c_str());

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -80,6 +80,13 @@ class Token {
     return uint64_t(std::strtoull(string_value_.c_str(), nullptr, 16));
   }
 
+  /// The OriginalString is set for integer and double values to store the
+  /// unparsed number which we can return in error messages.
+  void SetOriginalString(const std::string& orig_string) {
+    string_value_ = orig_string;
+  }
+  std::string ToOriginalString() const { return string_value_; }
+
  private:
   TokenType type_;
   std::string string_value_;

--- a/src/vkscript/command_parser.cc
+++ b/src/vkscript/command_parser.cc
@@ -74,7 +74,7 @@ Result CommandParser::ParseBoolean(const std::string& str, bool* result) {
     *result = false;
     return {};
   }
-  return Result("Invalid value passed as a boolean string");
+  return Result("Invalid value passed as a boolean string: " + str);
 }
 
 Result CommandParser::Parse() {
@@ -85,7 +85,8 @@ Result CommandParser::Parse() {
 
     if (!token->IsString()) {
       return Result(make_error(
-          "Command not recognized. Received something other then a string."));
+          "Command not recognized. Received something other then a string: " +
+          token->ToOriginalString()));
     }
 
     std::string cmd_name = token->AsString();
@@ -93,7 +94,8 @@ Result CommandParser::Parse() {
     if (cmd_name == "draw") {
       token = tokenizer_->NextToken();
       if (!token->IsString())
-        return Result(make_error("Invalid draw command in test"));
+        return Result(make_error("Invalid draw command in test: " +
+                                 token->ToOriginalString()));
 
       cmd_name = token->AsString();
       if (cmd_name == "rect")
@@ -118,7 +120,8 @@ Result CommandParser::Parse() {
     } else if (cmd_name == "relative") {
       token = tokenizer_->NextToken();
       if (!token->IsString() || token->AsString() != "probe")
-        return Result(make_error("relative must be used with probe"));
+        return Result(make_error("relative must be used with probe: " +
+                                 token->ToOriginalString()));
 
       r = ProcessProbe(true);
     } else if (cmd_name == "compute") {
@@ -132,7 +135,8 @@ Result CommandParser::Parse() {
                                    token->AsString() != "evaluation")) {
           return Result(
               make_error("Tessellation entrypoint must have "
-                         "<evaluation|control> in name"));
+                         "<evaluation|control> in name: " +
+                         token->ToOriginalString()));
         }
         shader_name += " " + token->AsString();
       }
@@ -283,7 +287,8 @@ Result CommandParser::ProcessDrawRect() {
 
   token = tokenizer_->NextToken();
   if (!token->IsEOS() && !token->IsEOL())
-    return Result("Extra parameter to draw rect command");
+    return Result("Extra parameter to draw rect command: " +
+                  token->ToOriginalString());
 
   commands_.push_back(std::move(cmd));
   return {};
@@ -319,19 +324,22 @@ Result CommandParser::ProcessDrawArrays() {
     return Result("Missing draw arrays topology");
 
   if (!token->IsInteger())
-    return Result("Missing integer first vertex value for draw arrays");
+    return Result("Missing integer first vertex value for draw arrays: " +
+                  token->ToOriginalString());
   cmd->SetFirstVertexIndex(token->AsUint32());
 
   token = tokenizer_->NextToken();
   if (!token->IsInteger())
-    return Result("Missing integer vertex count value for draw arrays");
+    return Result("Missing integer vertex count value for draw arrays: " +
+                  token->ToOriginalString());
   cmd->SetVertexCount(token->AsUint32());
 
   token = tokenizer_->NextToken();
   if (cmd->IsInstanced()) {
     if (!token->IsEOL() && !token->IsEOS()) {
       if (!token->IsInteger())
-        return Result("Invalid instance count for draw arrays");
+        return Result("Invalid instance count for draw arrays: " +
+                      token->ToOriginalString());
 
       cmd->SetInstanceCount(token->AsUint32());
     }
@@ -339,7 +347,8 @@ Result CommandParser::ProcessDrawArrays() {
   }
 
   if (!token->IsEOL() && !token->IsEOS())
-    return Result("Extra parameter to draw arrays command");
+    return Result("Extra parameter to draw arrays command: " +
+                  token->ToOriginalString());
 
   commands_.push_back(std::move(cmd));
   return {};
@@ -355,22 +364,26 @@ Result CommandParser::ProcessCompute() {
     return ProcessEntryPoint("compute");
 
   if (!token->IsInteger())
-    return Result("Missing integer value for compute X entry");
+    return Result("Missing integer value for compute X entry: " +
+                  token->ToOriginalString());
   cmd->SetX(token->AsUint32());
 
   token = tokenizer_->NextToken();
   if (!token->IsInteger())
-    return Result("Missing integer value for compute Y entry");
+    return Result("Missing integer value for compute Y entry: " +
+                  token->ToOriginalString());
   cmd->SetY(token->AsUint32());
 
   token = tokenizer_->NextToken();
   if (!token->IsInteger())
-    return Result("Missing integer value for compute Z entry");
+    return Result("Missing integer value for compute Z entry: " +
+                  token->ToOriginalString());
   cmd->SetZ(token->AsUint32());
 
   token = tokenizer_->NextToken();
   if (!token->IsEOS() && !token->IsEOL())
-    return Result("Extra parameter to compute command");
+    return Result("Extra parameter to compute command: " +
+                  token->ToOriginalString());
 
   commands_.push_back(std::move(cmd));
   return {};
@@ -398,9 +411,11 @@ Result CommandParser::ProcessClear() {
 
       token = tokenizer_->NextToken();
       if (token->IsEOL() || token->IsEOS())
-        return Result("Missing stencil value for clear stencil command");
+        return Result("Missing stencil value for clear stencil command: " +
+                      token->ToOriginalString());
       if (!token->IsInteger())
-        return Result("Invalid stencil value for clear stencil command");
+        return Result("Invalid stencil value for clear stencil command: " +
+                      token->ToOriginalString());
 
       cmd->AsClearStencil()->SetValue(token->AsUint32());
     } else if (str == "color") {
@@ -430,7 +445,8 @@ Result CommandParser::ProcessClear() {
         return r;
       cmd->AsClearColor()->SetA(token->AsFloat());
     } else {
-      return Result("Extra parameter to clear command");
+      return Result("Extra parameter to clear command: " +
+                    token->ToOriginalString());
     }
 
     token = tokenizer_->NextToken();
@@ -438,7 +454,8 @@ Result CommandParser::ProcessClear() {
     cmd = MakeUnique<ClearCommand>();
   }
   if (!token->IsEOS() && !token->IsEOL())
-    return Result("Extra parameter to clear " + cmd_suffix + "command");
+    return Result("Extra parameter to clear " + cmd_suffix +
+                  "command: " + token->ToOriginalString());
 
   commands_.push_back(std::move(cmd));
   return {};
@@ -456,7 +473,7 @@ Result CommandParser::ParseValues(const std::string& name,
     if ((type.IsFloat() || type.IsDouble())) {
       if (!token->IsInteger() && !token->IsDouble()) {
         return Result(std::string("Invalid value provided to ") + name +
-                      "  command");
+                      " command: " + token->ToOriginalString());
       }
 
       Result r = token->ConvertToDouble();
@@ -467,7 +484,7 @@ Result CommandParser::ParseValues(const std::string& name,
     } else {
       if (!token->IsInteger()) {
         return Result(std::string("Invalid value provided to ") + name +
-                      " command");
+                      " command: " + token->ToOriginalString());
       }
 
       v.SetIntValue(token->AsUint64());
@@ -513,7 +530,8 @@ Result CommandParser::ProcessSSBO() {
 
       cmd->SetBinding(static_cast<uint32_t>(binding_val));
     } else {
-      return Result("Invalid value for ssbo command");
+      return Result("Invalid value for ssbo command: " +
+                    token->ToOriginalString());
     }
 
     token = tokenizer_->NextToken();
@@ -526,7 +544,8 @@ Result CommandParser::ProcessSSBO() {
 
     token = tokenizer_->NextToken();
     if (!token->IsString())
-      return Result("Invalid type for ssbo command");
+      return Result("Invalid type for ssbo command: " +
+                    token->ToOriginalString());
 
     DatumTypeParser tp;
     Result r = tp.Parse(token->AsString());
@@ -537,7 +556,8 @@ Result CommandParser::ProcessSSBO() {
 
     token = tokenizer_->NextToken();
     if (!token->IsInteger())
-      return Result("Invalid offset for ssbo command");
+      return Result("Invalid offset for ssbo command: " +
+                    token->ToOriginalString());
 
     cmd->SetOffset(token->AsUint32());
 
@@ -550,15 +570,18 @@ Result CommandParser::ProcessSSBO() {
 
   } else {
     if (token->IsEOL() || token->IsEOS())
-      return Result("Missing size value for ssbo command");
+      return Result("Missing size value for ssbo command: " +
+                    token->ToOriginalString());
     if (!token->IsInteger())
-      return Result("Invalid size value for ssbo command");
+      return Result("Invalid size value for ssbo command: " +
+                    token->ToOriginalString());
 
     cmd->SetSize(token->AsUint32());
 
     token = tokenizer_->NextToken();
     if (!token->IsEOS() && !token->IsEOL())
-      return Result("Extra parameter for ssbo command");
+      return Result("Extra parameter for ssbo command: " +
+                    token->ToOriginalString());
   }
 
   commands_.push_back(std::move(cmd));
@@ -568,9 +591,11 @@ Result CommandParser::ProcessSSBO() {
 Result CommandParser::ProcessUniform() {
   auto token = tokenizer_->NextToken();
   if (token->IsEOL() || token->IsEOS())
-    return Result("Missing binding and size values for uniform command");
+    return Result("Missing binding and size values for uniform command: " +
+                  token->ToOriginalString());
   if (!token->IsString())
-    return Result("Invalid type value for uniform command");
+    return Result("Invalid type value for uniform command: " +
+                  token->ToOriginalString());
 
   std::unique_ptr<BufferCommand> cmd;
   if (token->AsString() == "ubo") {
@@ -578,13 +603,15 @@ Result CommandParser::ProcessUniform() {
 
     token = tokenizer_->NextToken();
     if (!token->IsInteger())
-      return Result("Invalid binding value for uniform ubo command");
+      return Result("Invalid binding value for uniform ubo command: " +
+                    token->ToOriginalString());
 
     uint32_t val = token->AsUint32();
 
     token = tokenizer_->NextToken();
     if (!token->IsString())
-      return Result("Invalid type value for uniform ubo command");
+      return Result("Invalid type value for uniform ubo command: " +
+                    token->ToOriginalString());
 
     auto& str = token->AsString();
     if (str.size() >= 2 && str[0] == ':') {
@@ -593,13 +620,15 @@ Result CommandParser::ProcessUniform() {
       auto substr = str.substr(1, str.size());
       uint64_t binding_val = strtoul(substr.c_str(), nullptr, 10);
       if (binding_val > std::numeric_limits<uint32_t>::max())
-        return Result("binding value too large in uniform ubo command");
+        return Result("binding value too large in uniform ubo command: " +
+                      token->ToOriginalString());
 
       cmd->SetBinding(static_cast<uint32_t>(binding_val));
 
       token = tokenizer_->NextToken();
       if (!token->IsString())
-        return Result("Invalid type value for uniform ubo command");
+        return Result("Invalid type value for uniform ubo command: " +
+                      token->ToOriginalString());
     } else {
       cmd->SetBinding(val);
     }
@@ -617,7 +646,8 @@ Result CommandParser::ProcessUniform() {
 
   token = tokenizer_->NextToken();
   if (!token->IsInteger())
-    return Result("Invalid offset value for uniform command");
+    return Result("Invalid offset value for uniform command: " +
+                  token->ToOriginalString());
 
   cmd->SetOffset(token->AsUint32());
 
@@ -652,7 +682,8 @@ Result CommandParser::ProcessTolerance() {
       token = tokenizer_->NextToken();
       if (token->IsString() && token->AsString() != ",") {
         if (token->AsString() != "%")
-          return Result("Invalid value for tolerance command");
+          return Result("Invalid value for tolerance command: " +
+                        token->ToOriginalString());
 
         current_tolerances_.push_back(Probe::Tolerance{true, value});
         token = tokenizer_->NextToken();
@@ -660,7 +691,8 @@ Result CommandParser::ProcessTolerance() {
         current_tolerances_.push_back(Probe::Tolerance{false, value});
       }
     } else {
-      return Result("Invalid value for tolerance command");
+      return Result("Invalid value for tolerance command: " +
+                    token->ToOriginalString());
     }
 
     ++found_tokens;
@@ -671,7 +703,8 @@ Result CommandParser::ProcessTolerance() {
     return Result("Invalid number of tolerance parameters provided");
 
   if (!token->IsEOS() && !token->IsEOL())
-    return Result("Extra parameter for tolerance command");
+    return Result("Extra parameter for tolerance command: " +
+                  token->ToOriginalString());
 
   return {};
 }
@@ -681,20 +714,24 @@ Result CommandParser::ProcessPatch() {
 
   auto token = tokenizer_->NextToken();
   if (!token->IsString() || token->AsString() != "parameter")
-    return Result("Missing parameter flag to patch command");
+    return Result("Missing parameter flag to patch command: " +
+                  token->ToOriginalString());
 
   token = tokenizer_->NextToken();
   if (!token->IsString() || token->AsString() != "vertices")
-    return Result("Missing vertices flag to patch command");
+    return Result("Missing vertices flag to patch command: " +
+                  token->ToOriginalString());
 
   token = tokenizer_->NextToken();
   if (!token->IsInteger())
-    return Result("Invalid count parameter for patch parameter vertices");
+    return Result("Invalid count parameter for patch parameter vertices: " +
+                  token->ToOriginalString());
   cmd->SetControlPointCount(token->AsUint32());
 
   token = tokenizer_->NextToken();
   if (!token->IsEOS() && !token->IsEOL())
-    return Result("Extra parameter for patch parameter vertices command");
+    return Result("Extra parameter for patch parameter vertices command: " +
+                  token->ToOriginalString());
 
   commands_.push_back(std::move(cmd));
   return {};
@@ -708,14 +745,16 @@ Result CommandParser::ProcessEntryPoint(const std::string& name) {
     return Result("Missing entrypoint name");
 
   if (!token->IsString())
-    return Result("Entrypoint name must be a string");
+    return Result("Entrypoint name must be a string: " +
+                  token->ToOriginalString());
 
   cmd->SetShaderType(ShaderNameToType(name));
   cmd->SetEntryPointName(token->AsString());
 
   token = tokenizer_->NextToken();
   if (!token->IsEOS() && !token->IsEOL())
-    return Result("Extra parameter for entrypoint command");
+    return Result("Extra parameter for entrypoint command: " +
+                  token->ToOriginalString());
 
   commands_.push_back(std::move(cmd));
 
@@ -725,7 +764,8 @@ Result CommandParser::ProcessEntryPoint(const std::string& name) {
 Result CommandParser::ProcessProbe(bool relative) {
   auto token = tokenizer_->NextToken();
   if (!token->IsString())
-    return Result("Invalid token in probe command");
+    return Result("Invalid token in probe command: " +
+                  token->ToOriginalString());
 
   // The SSBO syntax is different from probe or probe all so handle specially.
   if (token->AsString() == "ssbo")
@@ -742,18 +782,21 @@ Result CommandParser::ProcessProbe(bool relative) {
 
     token = tokenizer_->NextToken();
     if (!token->IsString())
-      return Result("Invalid token in probe command");
+      return Result("Invalid token in probe command: " +
+                    token->ToOriginalString());
   } else if (token->AsString() == "all") {
     cmd->SetWholeWindow();
 
     token = tokenizer_->NextToken();
     if (!token->IsString())
-      return Result("Invalid token in probe command");
+      return Result("Invalid token in probe command: " +
+                    token->ToOriginalString());
   }
 
   std::string format = token->AsString();
   if (format != "rgba" && format != "rgb")
-    return Result("Invalid format specified to probe command");
+    return Result("Invalid format specified to probe command: " +
+                  token->ToOriginalString());
 
   if (format == "rgba")
     cmd->SetIsRGBA();
@@ -866,7 +909,8 @@ Result CommandParser::ProcessProbe(bool relative) {
   }
 
   if (!token->IsEOS() && !token->IsEOL())
-    return Result("Extra parameter to probe command");
+    return Result("Extra parameter to probe command: " +
+                  token->ToOriginalString());
 
   commands_.push_back(std::move(cmd));
   return {};
@@ -877,7 +921,8 @@ Result CommandParser::ProcessTopology() {
   if (token->IsEOS() || token->IsEOL())
     return Result("Missing value for topology command");
   if (!token->IsString())
-    return Result("Invalid value for topology command");
+    return Result("Invalid value for topology command: " +
+                  token->ToOriginalString());
 
   Topology topology = Topology::kPatchList;
   std::string topo = token->AsString();
@@ -905,11 +950,13 @@ Result CommandParser::ProcessTopology() {
   else if (topo == "VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY")
     topology = Topology::kTriangleStripWithAdjacency;
   else
-    return Result("Unknown value for topology command");
+    return Result("Unknown value for topology command: " +
+                  token->ToOriginalString());
 
   token = tokenizer_->NextToken();
   if (!token->IsEOS() && !token->IsEOL())
-    return Result("Extra parameter for topology command");
+    return Result("Extra parameter for topology command: " +
+                  token->ToOriginalString());
 
   pipeline_data_.SetTopology(topology);
   return {};
@@ -920,7 +967,8 @@ Result CommandParser::ProcessPolygonMode() {
   if (token->IsEOS() || token->IsEOL())
     return Result("Missing value for polygonMode command");
   if (!token->IsString())
-    return Result("Invalid value for polygonMode command");
+    return Result("Invalid value for polygonMode command: " +
+                  token->ToOriginalString());
 
   PolygonMode mode = PolygonMode::kFill;
   std::string m = token->AsString();
@@ -931,11 +979,13 @@ Result CommandParser::ProcessPolygonMode() {
   else if (m == "VK_POLYGON_MODE_POINT")
     mode = PolygonMode::kPoint;
   else
-    return Result("Unknown value for polygonMode command");
+    return Result("Unknown value for polygonMode command: " +
+                  token->ToOriginalString());
 
   token = tokenizer_->NextToken();
   if (!token->IsEOS() && !token->IsEOL())
-    return Result("Extra parameter for polygonMode command");
+    return Result("Extra parameter for polygonMode command: " +
+                  token->ToOriginalString());
 
   pipeline_data_.SetPolygonMode(mode);
   return {};
@@ -946,7 +996,8 @@ Result CommandParser::ProcessLogicOp() {
   if (token->IsEOS() || token->IsEOL())
     return Result("Missing value for logicOp command");
   if (!token->IsString())
-    return Result("Invalid value for logicOp command");
+    return Result("Invalid value for logicOp command: " +
+                  token->ToOriginalString());
 
   LogicOp op = LogicOp::kClear;
   std::string name = token->AsString();
@@ -983,11 +1034,13 @@ Result CommandParser::ProcessLogicOp() {
   else if (name == "VK_LOGIC_OP_SET")
     op = LogicOp::kSet;
   else
-    return Result("Unknown value for logicOp command");
+    return Result("Unknown value for logicOp command: " +
+                  token->ToOriginalString());
 
   token = tokenizer_->NextToken();
   if (!token->IsEOS() && !token->IsEOL())
-    return Result("Extra parameter for logicOp command");
+    return Result("Extra parameter for logicOp command: " +
+                  token->ToOriginalString());
 
   pipeline_data_.SetLogicOp(op);
   return {};
@@ -998,7 +1051,8 @@ Result CommandParser::ProcessCullMode() {
   if (token->IsEOS() || token->IsEOL())
     return Result("Missing value for cullMode command");
   if (!token->IsString())
-    return Result("Invalid value for cullMode command");
+    return Result("Invalid value for cullMode command: " +
+                  token->ToOriginalString());
 
   CullMode mode = CullMode::kNone;
   while (!token->IsEOS() && !token->IsEOL()) {
@@ -1021,7 +1075,8 @@ Result CommandParser::ProcessCullMode() {
     } else if (name == "VK_CULL_MODE_NONE") {
       // Do nothing ...
     } else {
-      return Result("Unknown value for cullMode command");
+      return Result("Unknown value for cullMode command: " +
+                    token->ToOriginalString());
     }
 
     token = tokenizer_->NextToken();
@@ -1036,7 +1091,8 @@ Result CommandParser::ProcessFrontFace() {
   if (token->IsEOS() || token->IsEOL())
     return Result("Missing value for frontFace command");
   if (!token->IsString())
-    return Result("Invalid value for frontFace command");
+    return Result("Invalid value for frontFace command: " +
+                  token->ToOriginalString());
 
   FrontFace face = FrontFace::kCounterClockwise;
   std::string f = token->AsString();
@@ -1045,11 +1101,13 @@ Result CommandParser::ProcessFrontFace() {
   else if (f == "VK_FRONT_FACE_CLOCKWISE")
     face = FrontFace::kClockwise;
   else
-    return Result("Unknown value for frontFace command");
+    return Result("Unknown value for frontFace command: " +
+                  token->ToOriginalString());
 
   token = tokenizer_->NextToken();
   if (!token->IsEOS() && !token->IsEOL())
-    return Result("Extra parameter for frontFace command");
+    return Result("Extra parameter for frontFace command: " +
+                  token->ToOriginalString());
 
   pipeline_data_.SetFrontFace(face);
   return {};
@@ -1061,7 +1119,8 @@ Result CommandParser::ProcessBooleanPipelineData(const std::string& name,
   if (token->IsEOS() || token->IsEOL())
     return Result("Missing value for " + name + " command");
   if (!token->IsString())
-    return Result("Invalid value for " + name + " command");
+    return Result("Invalid value for " + name +
+                  " command: " + token->ToOriginalString());
 
   Result r = ParseBoolean(token->AsString(), value);
   if (!r.IsSuccess())
@@ -1069,7 +1128,8 @@ Result CommandParser::ProcessBooleanPipelineData(const std::string& name,
 
   token = tokenizer_->NextToken();
   if (!token->IsEOS() && !token->IsEOL())
-    return Result("Extra parameter for " + name + " command");
+    return Result("Extra parameter for " + name +
+                  " command: " + token->ToOriginalString());
 
   return {};
 }
@@ -1190,7 +1250,8 @@ Result CommandParser::ProcessFloatPipelineData(const std::string& name,
 
   token = tokenizer_->NextToken();
   if (!token->IsEOS() && !token->IsEOL())
-    return Result("Extra parameter for " + name + " command");
+    return Result("Extra parameter for " + name +
+                  " command: " + token->ToOriginalString());
 
   return {};
 }
@@ -1309,7 +1370,8 @@ Result CommandParser::ParseBlendFactor(const std::string& name,
   if (token->IsEOL() || token->IsEOS())
     return Result(std::string("Missing parameter for ") + name + " command");
   if (!token->IsString())
-    return Result(std::string("Invalid parameter for ") + name + " command");
+    return Result(std::string("Invalid parameter for ") + name +
+                  " command: " + token->ToOriginalString());
 
   Result r = ParseBlendFactorName(token->AsString(), factor);
   if (!r.IsSuccess())
@@ -1317,7 +1379,8 @@ Result CommandParser::ParseBlendFactor(const std::string& name,
 
   token = tokenizer_->NextToken();
   if (!token->IsEOS() && !token->IsEOL())
-    return Result(std::string("Extra parameter for ") + name + " command");
+    return Result(std::string("Extra parameter for ") + name +
+                  " command: " + token->ToOriginalString());
 
   return {};
 }
@@ -1480,7 +1543,8 @@ Result CommandParser::ParseBlendOp(const std::string& name, BlendOp* op) {
   if (token->IsEOL() || token->IsEOS())
     return Result(std::string("Missing parameter for ") + name + " command");
   if (!token->IsString())
-    return Result(std::string("Invalid parameter for ") + name + " command");
+    return Result(std::string("Invalid parameter for ") + name +
+                  " command: " + token->ToOriginalString());
 
   Result r = ParseBlendOpName(token->AsString(), op);
   if (!r.IsSuccess())
@@ -1488,7 +1552,8 @@ Result CommandParser::ParseBlendOp(const std::string& name, BlendOp* op) {
 
   token = tokenizer_->NextToken();
   if (!token->IsEOS() && !token->IsEOL())
-    return Result(std::string("Extra parameter for ") + name + " command");
+    return Result(std::string("Extra parameter for ") + name +
+                  " command: " + token->ToOriginalString());
 
   return {};
 }
@@ -1518,7 +1583,8 @@ Result CommandParser::ParseCompareOp(const std::string& name, CompareOp* op) {
   if (token->IsEOL() || token->IsEOS())
     return Result(std::string("Missing parameter for ") + name + " command");
   if (!token->IsString())
-    return Result(std::string("Invalid parameter for ") + name + " command");
+    return Result(std::string("Invalid parameter for ") + name +
+                  " command: " + token->ToOriginalString());
 
   Result r = ParseCompareOpName(token->AsString(), op);
   if (!r.IsSuccess())
@@ -1526,7 +1592,8 @@ Result CommandParser::ParseCompareOp(const std::string& name, CompareOp* op) {
 
   token = tokenizer_->NextToken();
   if (!token->IsEOS() && !token->IsEOL())
-    return Result(std::string("Extra parameter for ") + name + " command");
+    return Result(std::string("Extra parameter for ") + name +
+                  " command: " + token->ToOriginalString());
 
   return {};
 }
@@ -1592,7 +1659,8 @@ Result CommandParser::ParseStencilOp(const std::string& name, StencilOp* op) {
   if (token->IsEOL() || token->IsEOS())
     return Result(std::string("Missing parameter for ") + name + " command");
   if (!token->IsString())
-    return Result(std::string("Invalid parameter for ") + name + " command");
+    return Result(std::string("Invalid parameter for ") + name +
+                  " command: " + token->ToOriginalString());
 
   Result r = ParseStencilOpName(token->AsString(), op);
   if (!r.IsSuccess())
@@ -1600,7 +1668,8 @@ Result CommandParser::ParseStencilOp(const std::string& name, StencilOp* op) {
 
   token = tokenizer_->NextToken();
   if (!token->IsEOS() && !token->IsEOL())
-    return Result(std::string("Extra parameter for ") + name + " command");
+    return Result(std::string("Extra parameter for ") + name +
+                  " command: " + token->ToOriginalString());
 
   return {};
 }
@@ -1712,13 +1781,15 @@ Result CommandParser::ProcessFrontReference() {
   if (token->IsEOL() || token->IsEOS())
     return Result("Missing parameter for front.reference command");
   if (!token->IsInteger())
-    return Result("Invalid parameter for front.reference command");
+    return Result("Invalid parameter for front.reference command: " +
+                  token->ToOriginalString());
 
   pipeline_data_.SetFrontReference(token->AsUint32());
 
   token = tokenizer_->NextToken();
   if (!token->IsEOS() && !token->IsEOL())
-    return Result("Extra parameter for front.reference command");
+    return Result("Extra parameter for front.reference command: " +
+                  token->ToOriginalString());
 
   return {};
 }
@@ -1728,13 +1799,15 @@ Result CommandParser::ProcessBackReference() {
   if (token->IsEOL() || token->IsEOS())
     return Result("Missing parameter for back.reference command");
   if (!token->IsInteger())
-    return Result("Invalid parameter for back.reference command");
+    return Result("Invalid parameter for back.reference command: " +
+                  token->ToOriginalString());
 
   pipeline_data_.SetBackReference(token->AsUint32());
 
   token = tokenizer_->NextToken();
   if (!token->IsEOS() && !token->IsEOL())
-    return Result("Extra parameter for back.reference command");
+    return Result("Extra parameter for back.reference command: " +
+                  token->ToOriginalString());
 
   return {};
 }
@@ -1744,7 +1817,8 @@ Result CommandParser::ProcessColorWriteMask() {
   if (token->IsEOS() || token->IsEOL())
     return Result("Missing parameter for colorWriteMask command");
   if (!token->IsString())
-    return Result("Invalid parameter for colorWriteMask command");
+    return Result("Invalid parameter for colorWriteMask command: " +
+                  token->ToOriginalString());
 
   uint8_t mask = 0;
   while (!token->IsEOS() && !token->IsEOL()) {
@@ -1761,7 +1835,7 @@ Result CommandParser::ProcessColorWriteMask() {
     } else if (name == "VK_COLOR_COMPONENT_A_BIT") {
       mask |= kColorMaskA;
     } else {
-      return Result("Unknown parameter for colorWriteMask command");
+      return Result("Unknown parameter for colorWriteMask command: " + name);
     }
 
     token = tokenizer_->NextToken();
@@ -1788,7 +1862,7 @@ Result CommandParser::ParseComparator(const std::string& name,
   else if (name == ">=")
     *op = ProbeSSBOCommand::Comparator::kGreaterOrEqual;
   else
-    return Result("Invalid comparator");
+    return Result("Invalid comparator: " + name);
   return {};
 }
 
@@ -1800,7 +1874,8 @@ Result CommandParser::ProcessProbeSSBO() {
   if (token->IsEOL() || token->IsEOS())
     return Result("Missing values for probe ssbo command");
   if (!token->IsString())
-    return Result("Invalid type for probe ssbo command");
+    return Result("Invalid type for probe ssbo command: " +
+                  token->ToOriginalString());
 
   DatumTypeParser tp;
   Result r = tp.Parse(token->AsString());
@@ -1811,7 +1886,8 @@ Result CommandParser::ProcessProbeSSBO() {
 
   token = tokenizer_->NextToken();
   if (!token->IsInteger())
-    return Result("Invalid binding value for probe ssbo command");
+    return Result("Invalid binding value for probe ssbo command: " +
+                  token->ToOriginalString());
 
   uint32_t val = token->AsUint32();
 
@@ -1824,11 +1900,13 @@ Result CommandParser::ProcessProbeSSBO() {
       auto substr = str.substr(1, str.size());
       uint64_t binding_val = strtoul(substr.c_str(), nullptr, 10);
       if (binding_val > std::numeric_limits<uint32_t>::max())
-        return Result("binding value too large in probe ssbo command");
+        return Result("binding value too large in probe ssbo command: " +
+                      token->ToOriginalString());
 
       cmd->SetBinding(static_cast<uint32_t>(binding_val));
     } else {
-      return Result("Invalid value for probe ssbo command");
+      return Result("Invalid value for probe ssbo command: " +
+                    token->ToOriginalString());
     }
 
     token = tokenizer_->NextToken();
@@ -1837,13 +1915,15 @@ Result CommandParser::ProcessProbeSSBO() {
   }
 
   if (!token->IsInteger())
-    return Result("Invalid offset for probe ssbo command");
+    return Result("Invalid offset for probe ssbo command: " +
+                  token->ToOriginalString());
 
   cmd->SetOffset(token->AsUint32());
 
   token = tokenizer_->NextToken();
   if (!token->IsString())
-    return Result("Invalid comparator for probe ssbo command");
+    return Result("Invalid comparator for probe ssbo command: " +
+                  token->ToOriginalString());
 
   ProbeSSBOCommand::Comparator comp;
   r = ParseComparator(token->AsString(), &comp);

--- a/src/vkscript/command_parser_test.cc
+++ b/src/vkscript/command_parser_test.cc
@@ -157,7 +157,7 @@ TEST_F(CommandParserTest, DrawRectExtraParameters) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Extra parameter to draw rect command", r.Error());
+  EXPECT_EQ("1: Extra parameter to draw rect command: EXTRA", r.Error());
 }
 
 TEST_F(CommandParserTest, DrawArrays) {
@@ -206,7 +206,8 @@ TEST_F(CommandParserTest, DrawArraysExtraParams) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Extra parameter to draw arrays command", r.Error());
+  EXPECT_EQ("1: Extra parameter to draw arrays command: EXTRA_PARAM",
+            r.Error());
 }
 
 TEST_F(CommandParserTest, DrawArraysInstanced) {
@@ -236,7 +237,8 @@ TEST_F(CommandParserTest, DrawArraysInstancedExtraParams) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Extra parameter to draw arrays command", r.Error());
+  EXPECT_EQ("1: Extra parameter to draw arrays command: EXTRA_COMMAND",
+            r.Error());
 }
 
 TEST_F(CommandParserTest, DrawArraysIndexedAndInstanced) {
@@ -295,7 +297,8 @@ TEST_F(CommandParserTest, DrawArraysTooShort) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Missing integer vertex count value for draw arrays", r.Error());
+  EXPECT_EQ("1: Missing integer vertex count value for draw arrays: ",
+            r.Error());
 }
 
 TEST_F(CommandParserTest, DrawArraysInstanceCountWithoutInstanced) {
@@ -304,7 +307,7 @@ TEST_F(CommandParserTest, DrawArraysInstanceCountWithoutInstanced) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Extra parameter to draw arrays command", r.Error());
+  EXPECT_EQ("1: Extra parameter to draw arrays command: 3", r.Error());
 }
 
 TEST_F(CommandParserTest, DrawArraysMissingTopology) {
@@ -339,7 +342,7 @@ TEST_F(CommandParserTest, ComputeTooShort) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Missing integer value for compute Z entry", r.Error());
+  EXPECT_EQ("1: Missing integer value for compute Z entry: ", r.Error());
 }
 
 TEST_F(CommandParserTest, ComputeInvalidX) {
@@ -348,7 +351,7 @@ TEST_F(CommandParserTest, ComputeInvalidX) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Missing integer value for compute X entry", r.Error());
+  EXPECT_EQ("1: Missing integer value for compute X entry: 1.2", r.Error());
 }
 
 TEST_F(CommandParserTest, ComputeInvalidY) {
@@ -357,7 +360,7 @@ TEST_F(CommandParserTest, ComputeInvalidY) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Missing integer value for compute Y entry", r.Error());
+  EXPECT_EQ("1: Missing integer value for compute Y entry: a", r.Error());
 }
 
 TEST_F(CommandParserTest, ComputeInvalidZ) {
@@ -366,7 +369,7 @@ TEST_F(CommandParserTest, ComputeInvalidZ) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Missing integer value for compute Z entry", r.Error());
+  EXPECT_EQ("1: Missing integer value for compute Z entry: 1.5", r.Error());
 }
 
 TEST_F(CommandParserTest, ComputeExtraCommands) {
@@ -375,7 +378,7 @@ TEST_F(CommandParserTest, ComputeExtraCommands) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Extra parameter to compute command", r.Error());
+  EXPECT_EQ("1: Extra parameter to compute command: EXTRA", r.Error());
 }
 
 TEST_F(CommandParserTest, Clear) {
@@ -396,7 +399,7 @@ TEST_F(CommandParserTest, ClearExtraParams) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Extra parameter to clear command", r.Error());
+  EXPECT_EQ("1: Extra parameter to clear command: EXTRA", r.Error());
 }
 
 TEST_F(CommandParserTest, ClearDepth) {
@@ -429,7 +432,7 @@ TEST_F(CommandParserTest, ClearDepthExtraParameters) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Extra parameter to clear depth command", r.Error());
+  EXPECT_EQ("1: Extra parameter to clear depth command: EXTRA", r.Error());
 }
 
 TEST_F(CommandParserTest, ClearStencil) {
@@ -453,7 +456,7 @@ TEST_F(CommandParserTest, ClearStencilMissingValue) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Missing stencil value for clear stencil command", r.Error());
+  EXPECT_EQ("1: Missing stencil value for clear stencil command: ", r.Error());
 }
 
 TEST_F(CommandParserTest, ClearStencilExtraParameters) {
@@ -462,7 +465,7 @@ TEST_F(CommandParserTest, ClearStencilExtraParameters) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Extra parameter to clear stencil command", r.Error());
+  EXPECT_EQ("1: Extra parameter to clear stencil command: EXTRA", r.Error());
 }
 
 TEST_F(CommandParserTest, ClearStencilNotInteger) {
@@ -471,7 +474,8 @@ TEST_F(CommandParserTest, ClearStencilNotInteger) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid stencil value for clear stencil command", r.Error());
+  EXPECT_EQ("1: Invalid stencil value for clear stencil command: 2.3",
+            r.Error());
 }
 
 TEST_F(CommandParserTest, ClearColor) {
@@ -507,7 +511,7 @@ TEST_F(CommandParserTest, ClearColorExtraParams) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Extra parameter to clear color command", r.Error());
+  EXPECT_EQ("1: Extra parameter to clear color command: EXTRA", r.Error());
 }
 
 TEST_F(CommandParserTest, ClearColorBadR) {
@@ -567,7 +571,7 @@ TEST_F(CommandParserTest, PatchParameterVerticesMissingParameter) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Missing parameter flag to patch command", r.Error());
+  EXPECT_EQ("1: Missing parameter flag to patch command: vertices", r.Error());
 }
 
 TEST_F(CommandParserTest, PatchParameterVerticesMissingVertices) {
@@ -576,7 +580,7 @@ TEST_F(CommandParserTest, PatchParameterVerticesMissingVertices) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Missing vertices flag to patch command", r.Error());
+  EXPECT_EQ("1: Missing vertices flag to patch command: 5", r.Error());
 }
 
 TEST_F(CommandParserTest, PatchParameterVerticesMissingParam) {
@@ -585,7 +589,7 @@ TEST_F(CommandParserTest, PatchParameterVerticesMissingParam) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid count parameter for patch parameter vertices",
+  EXPECT_EQ("1: Invalid count parameter for patch parameter vertices: ",
             r.Error());
 }
 
@@ -595,7 +599,7 @@ TEST_F(CommandParserTest, PatchParameterVerticesInvalidParam) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid count parameter for patch parameter vertices",
+  EXPECT_EQ("1: Invalid count parameter for patch parameter vertices: invalid",
             r.Error());
 }
 
@@ -605,7 +609,7 @@ TEST_F(CommandParserTest, PatchParameterVerticesExtraParam) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Extra parameter for patch parameter vertices command",
+  EXPECT_EQ("1: Extra parameter for patch parameter vertices command: EXTRA",
             r.Error());
 }
 
@@ -673,7 +677,7 @@ TEST_F(CommandParserTest, EntryPointExtraParam) {
     CommandParser cp(1, data);
     Result r = cp.Parse();
     ASSERT_FALSE(r.IsSuccess());
-    EXPECT_EQ("1: Extra parameter for entrypoint command", r.Error());
+    EXPECT_EQ("1: Extra parameter for entrypoint command: EXTRA", r.Error());
   }
 }
 
@@ -684,7 +688,7 @@ TEST_F(CommandParserTest, EntryPointInvalidValue) {
     CommandParser cp(1, data);
     Result r = cp.Parse();
     ASSERT_FALSE(r.IsSuccess());
-    EXPECT_EQ("1: Entrypoint name must be a string", r.Error());
+    EXPECT_EQ("1: Entrypoint name must be a string: 123", r.Error());
   }
 }
 
@@ -694,8 +698,10 @@ TEST_F(CommandParserTest, TessellationEntryPointRequiresASuffix) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Tessellation entrypoint must have <evaluation|control> in name",
-            r.Error());
+  EXPECT_EQ(
+      "1: Tessellation entrypoint must have <evaluation|control> in name: "
+      "entrypoint",
+      r.Error());
 }
 
 TEST_F(CommandParserTest, TessellationEntryPointRequiresAKnownSuffix) {
@@ -704,8 +710,10 @@ TEST_F(CommandParserTest, TessellationEntryPointRequiresAKnownSuffix) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Tessellation entrypoint must have <evaluation|control> in name",
-            r.Error());
+  EXPECT_EQ(
+      "1: Tessellation entrypoint must have <evaluation|control> in name: "
+      "unknown",
+      r.Error());
 }
 
 TEST_F(CommandParserTest, InvalidEntryPoint) {
@@ -1006,23 +1014,25 @@ TEST_F(CommandParserTest, ProbeErrors) {
       {"probe all rgba 2 3 ab 5", "Invalid conversion to double"},
       {"probe all rgba 2 3 4 ab", "Invalid conversion to double"},
 
-      {"probe rgb 10 30 0.2 0.3 0.4 extra", "Extra parameter to probe command"},
+      {"probe rgb 10 30 0.2 0.3 0.4 extra",
+       "Extra parameter to probe command: extra"},
       {"probe rgba 10 30 0.2 0.3 0.4 0.4 extra",
-       "Extra parameter to probe command"},
+       "Extra parameter to probe command: extra"},
       {"relative probe rgb 10 30 0.2 0.3 0.4 extra",
-       "Extra parameter to probe command"},
+       "Extra parameter to probe command: extra"},
       {"relative probe rgba 10 30 0.2 0.3 0.4 0.4 extra",
-       "Extra parameter to probe command"},
+       "Extra parameter to probe command: extra"},
       {"probe rect rgb 10 30 40 50 0.2 0.3 0.4 extra",
-       "Extra parameter to probe command"},
+       "Extra parameter to probe command: extra"},
       {"probe rect rgba 10 30 40 50 0.2 0.3 0.4 0.4 extra",
-       "Extra parameter to probe command"},
+       "Extra parameter to probe command: extra"},
       {"relative probe rect rgb 10 30 40 50 0.2 0.3 0.4 extra",
-       "Extra parameter to probe command"},
+       "Extra parameter to probe command: extra"},
       {"relative probe rect rgba 10 30 40 50 0.2 0.3 0.4 0.4 extra",
-       "Extra parameter to probe command"},
-      {"probe all rgb 2 3 4 EXTRA", "Extra parameter to probe command"},
-      {"probe all rgba 2 3 4 5 EXTRA", "Extra parameter to probe command"},
+       "Extra parameter to probe command: extra"},
+      {"probe all rgb 2 3 4 extra", "Extra parameter to probe command: extra"},
+      {"probe all rgba 2 3 4 5 extra",
+       "Extra parameter to probe command: extra"},
 
       {"relative probe rect rgb 0.5 0.6 0.3 0.4 1 2 3)",
        "Missing open bracket for probe command"},
@@ -1050,7 +1060,7 @@ TEST_F(CommandParserTest, RelativeWithoutProbe) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: relative must be used with probe", r.Error());
+  EXPECT_EQ("1: relative must be used with probe: unknown", r.Error());
 }
 
 TEST_F(CommandParserTest, ProbeWithInvalidRGBA) {
@@ -1059,7 +1069,7 @@ TEST_F(CommandParserTest, ProbeWithInvalidRGBA) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid token in probe command", r.Error());
+  EXPECT_EQ("1: Invalid token in probe command: 1", r.Error());
 }
 
 TEST_F(CommandParserTest, ProbeWithRectAndInvalidRGB) {
@@ -1068,7 +1078,7 @@ TEST_F(CommandParserTest, ProbeWithRectAndInvalidRGB) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid token in probe command", r.Error());
+  EXPECT_EQ("1: Invalid token in probe command: 1", r.Error());
 }
 
 TEST_F(CommandParserTest, ProbeWithRectMissingFormat) {
@@ -1077,7 +1087,7 @@ TEST_F(CommandParserTest, ProbeWithRectMissingFormat) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid format specified to probe command", r.Error());
+  EXPECT_EQ("1: Invalid format specified to probe command: unknown", r.Error());
 }
 
 TEST_F(CommandParserTest, ProbeAllMissingFormat) {
@@ -1086,7 +1096,7 @@ TEST_F(CommandParserTest, ProbeAllMissingFormat) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid format specified to probe command", r.Error());
+  EXPECT_EQ("1: Invalid format specified to probe command: unknown", r.Error());
 }
 
 TEST_F(CommandParserTest, ProbeAlWithInvalidRGB) {
@@ -1095,7 +1105,7 @@ TEST_F(CommandParserTest, ProbeAlWithInvalidRGB) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid format specified to probe command", r.Error());
+  EXPECT_EQ("1: Invalid format specified to probe command: unknown", r.Error());
 }
 
 struct TopologyTestData {
@@ -1160,8 +1170,9 @@ TEST_P(CommandDataPipelineDataInvalidParser, InvalidPipelineParamValue) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ(std::string("1: Invalid value for ") + test_data.name + " command",
-            r.Error());
+  EXPECT_EQ(
+      std::string("1: Invalid value for ") + test_data.name + " command: 123",
+      r.Error());
 }
 
 TEST_P(CommandDataPipelineDataInvalidParser, MissingTopologyValue) {
@@ -1184,7 +1195,8 @@ TEST_P(CommandDataPipelineDataInvalidParser, UnknownPipelineParamValue) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ(std::string("1: Unknown value for ") + test_data.name + " command",
+  EXPECT_EQ(std::string("1: Unknown value for ") + test_data.name +
+                " command: UNKNOWN",
             r.Error());
 }
 
@@ -1201,9 +1213,9 @@ TEST_P(CommandDataPipelineDataInvalidParser, ExtraPipelineParamValue) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ(
-      std::string("1: Extra parameter for ") + test_data.name + " command",
-      r.Error());
+  EXPECT_EQ(std::string("1: Extra parameter for ") + test_data.name +
+                " command: EXTRA",
+            r.Error());
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -1258,7 +1270,9 @@ TEST_F(CommandParserTest, BooleanInvalid) {
     bool value = true;
     Result r = cp.ParseBooleanForTesting(d.name, &value);
     ASSERT_FALSE(r.IsSuccess()) << d.name;
-    EXPECT_EQ("Invalid value passed as a boolean string", r.Error());
+    EXPECT_EQ(
+        std::string("Invalid value passed as a boolean string: ") + d.name,
+        r.Error());
   }
 }
 
@@ -1467,8 +1481,9 @@ TEST_P(CommandParserBooleanTests, IllegalParam) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ(std::string("1: Invalid value for ") + test_data.name + " command",
-            r.Error());
+  EXPECT_EQ(
+      std::string("1: Invalid value for ") + test_data.name + " command: 123",
+      r.Error());
 }
 
 TEST_P(CommandParserBooleanTests, ExtraParam) {
@@ -1479,9 +1494,9 @@ TEST_P(CommandParserBooleanTests, ExtraParam) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ(
-      std::string("1: Extra parameter for ") + test_data.name + " command",
-      r.Error());
+  EXPECT_EQ(std::string("1: Extra parameter for ") + test_data.name +
+                " command: EXTRA",
+            r.Error());
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -1719,9 +1734,9 @@ TEST_P(CommandParserFloatTests, ExtraParam) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ(
-      std::string("1: Extra parameter for ") + test_data.name + " command",
-      r.Error());
+  EXPECT_EQ(std::string("1: Extra parameter for ") + test_data.name +
+                " command: EXTRA",
+            r.Error());
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -1861,9 +1876,9 @@ TEST_P(CommandParserBlendFactorTests, IllegalParam) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ(
-      std::string("1: Invalid parameter for ") + test_data.name + " command",
-      r.Error());
+  EXPECT_EQ(std::string("1: Invalid parameter for ") + test_data.name +
+                " command: 1.23",
+            r.Error());
 }
 
 TEST_P(CommandParserBlendFactorTests, ExtraParam) {
@@ -1874,9 +1889,9 @@ TEST_P(CommandParserBlendFactorTests, ExtraParam) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ(
-      std::string("1: Extra parameter for ") + test_data.name + " command",
-      r.Error());
+  EXPECT_EQ(std::string("1: Extra parameter for ") + test_data.name +
+                " command: EXTRA",
+            r.Error());
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -2021,9 +2036,9 @@ TEST_P(CommandParserBlendOpTests, IllegalParam) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ(
-      std::string("1: Invalid parameter for ") + test_data.name + " command",
-      r.Error());
+  EXPECT_EQ(std::string("1: Invalid parameter for ") + test_data.name +
+                " command: 1.23",
+            r.Error());
 }
 
 TEST_P(CommandParserBlendOpTests, ExtraParam) {
@@ -2034,9 +2049,9 @@ TEST_P(CommandParserBlendOpTests, ExtraParam) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ(
-      std::string("1: Extra parameter for ") + test_data.name + " command",
-      r.Error());
+  EXPECT_EQ(std::string("1: Extra parameter for ") + test_data.name +
+                " command: EXTRA",
+            r.Error());
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -2140,9 +2155,9 @@ TEST_P(CommandParserCompareOpTests, IllegalParam) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ(
-      std::string("1: Invalid parameter for ") + test_data.name + " command",
-      r.Error());
+  EXPECT_EQ(std::string("1: Invalid parameter for ") + test_data.name +
+                " command: 1.23",
+            r.Error());
 }
 
 TEST_P(CommandParserCompareOpTests, ExtraParam) {
@@ -2154,9 +2169,9 @@ TEST_P(CommandParserCompareOpTests, ExtraParam) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ(
-      std::string("1: Extra parameter for ") + test_data.name + " command",
-      r.Error());
+  EXPECT_EQ(std::string("1: Extra parameter for ") + test_data.name +
+                " command: EXTRA",
+            r.Error());
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -2291,9 +2306,9 @@ TEST_P(CommandParserStencilOpTests, IllegalParam) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ(
-      std::string("1: Invalid parameter for ") + test_data.name + " command",
-      r.Error());
+  EXPECT_EQ(std::string("1: Invalid parameter for ") + test_data.name +
+                " command: 1.23",
+            r.Error());
 }
 
 TEST_P(CommandParserStencilOpTests, ExtraParam) {
@@ -2305,9 +2320,9 @@ TEST_P(CommandParserStencilOpTests, ExtraParam) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ(
-      std::string("1: Extra parameter for ") + test_data.name + " command",
-      r.Error());
+  EXPECT_EQ(std::string("1: Extra parameter for ") + test_data.name +
+                " command: EXTRA",
+            r.Error());
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -2400,9 +2415,9 @@ TEST_P(CommandParserReferenceTests, FrontReferenceExtraParameters) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ(
-      std::string("1: Extra parameter for ") + test_data.name + " command",
-      r.Error());
+  EXPECT_EQ(std::string("1: Extra parameter for ") + test_data.name +
+                " command: EXTRA",
+            r.Error());
 }
 
 TEST_P(CommandParserReferenceTests, FrontReferenceInvalidParameters) {
@@ -2412,9 +2427,9 @@ TEST_P(CommandParserReferenceTests, FrontReferenceInvalidParameters) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ(
-      std::string("1: Invalid parameter for ") + test_data.name + " command",
-      r.Error());
+  EXPECT_EQ(std::string("1: Invalid parameter for ") + test_data.name +
+                " command: INVALID",
+            r.Error());
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -2462,7 +2477,8 @@ TEST_F(CommandParserTest, ColorWriteMaskInvalid) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Unknown parameter for colorWriteMask command", r.Error());
+  EXPECT_EQ("1: Unknown parameter for colorWriteMask command: INVALID",
+            r.Error());
 }
 
 TEST_F(CommandParserTest, ColorWriteMaskInvalidAfterValid) {
@@ -2471,7 +2487,8 @@ TEST_F(CommandParserTest, ColorWriteMaskInvalidAfterValid) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Unknown parameter for colorWriteMask command", r.Error());
+  EXPECT_EQ("1: Unknown parameter for colorWriteMask command: INVALID",
+            r.Error());
 }
 
 TEST_F(CommandParserTest, ColorWriteMaskMissingParam) {
@@ -2491,7 +2508,8 @@ TEST_F(CommandParserTest, ColorWriteMaskExtraParam) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Unknown parameter for colorWriteMask command", r.Error());
+  EXPECT_EQ("1: Unknown parameter for colorWriteMask command: EXTRA",
+            r.Error());
 }
 
 TEST_F(CommandParserTest, SSBO) {
@@ -2536,7 +2554,7 @@ TEST_F(CommandParserTest, SSBOExtraParameter) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Extra parameter for ssbo command", r.Error());
+  EXPECT_EQ("1: Extra parameter for ssbo command: EXTRA", r.Error());
 }
 
 TEST_F(CommandParserTest, SSBOInvalidFloatBinding) {
@@ -2563,7 +2581,7 @@ TEST_F(CommandParserTest, SSBOInvalidFloatSize) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid size value for ssbo command", r.Error());
+  EXPECT_EQ("1: Invalid size value for ssbo command: 40.0", r.Error());
 }
 
 TEST_F(CommandParserTest, SSBOInvalidSize) {
@@ -2572,7 +2590,7 @@ TEST_F(CommandParserTest, SSBOInvalidSize) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid value for ssbo command", r.Error());
+  EXPECT_EQ("1: Invalid value for ssbo command: abc", r.Error());
 }
 
 TEST_F(CommandParserTest, SSBOMissingSize) {
@@ -2581,7 +2599,7 @@ TEST_F(CommandParserTest, SSBOMissingSize) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Missing size value for ssbo command", r.Error());
+  EXPECT_EQ("1: Missing size value for ssbo command: ", r.Error());
 }
 
 TEST_F(CommandParserTest, SSBOMissingBinding) {
@@ -2745,7 +2763,7 @@ TEST_F(CommandParserTest, SSBOSubdataMissingSubdataCommand) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid value for ssbo command", r.Error());
+  EXPECT_EQ("1: Invalid value for ssbo command: INVALID", r.Error());
 }
 
 TEST_F(CommandParserTest, SSBOSubdataWithBadType) {
@@ -2763,7 +2781,7 @@ TEST_F(CommandParserTest, SSBOSubdataWithInvalidFloatOffset) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid offset for ssbo command", r.Error());
+  EXPECT_EQ("1: Invalid offset for ssbo command: 2.0", r.Error());
 }
 
 TEST_F(CommandParserTest, SSBOSubdataWithInvalidStringOffset) {
@@ -2772,7 +2790,7 @@ TEST_F(CommandParserTest, SSBOSubdataWithInvalidStringOffset) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid offset for ssbo command", r.Error());
+  EXPECT_EQ("1: Invalid offset for ssbo command: asdf", r.Error());
 }
 
 TEST_F(CommandParserTest, SSBOSubdataWithMissingData) {
@@ -2868,7 +2886,7 @@ TEST_F(CommandParserTest, UniformInvalidFloatOffset) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid offset value for uniform command", r.Error());
+  EXPECT_EQ("1: Invalid offset value for uniform command: 5.5", r.Error());
 }
 
 TEST_F(CommandParserTest, UniformInvalidStringOffset) {
@@ -2877,7 +2895,7 @@ TEST_F(CommandParserTest, UniformInvalidStringOffset) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid offset value for uniform command", r.Error());
+  EXPECT_EQ("1: Invalid offset value for uniform command: INVALID", r.Error());
 }
 
 TEST_F(CommandParserTest, UniformMissingValues) {
@@ -2958,7 +2976,7 @@ TEST_F(CommandParserTest, UniformUBOInvalidFloatBinding) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid binding value for uniform ubo command", r.Error());
+  EXPECT_EQ("1: Invalid binding value for uniform ubo command: 0.0", r.Error());
 }
 
 TEST_F(CommandParserTest, UniformUBOInvalidStringBinding) {
@@ -2967,7 +2985,8 @@ TEST_F(CommandParserTest, UniformUBOInvalidStringBinding) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid binding value for uniform ubo command", r.Error());
+  EXPECT_EQ("1: Invalid binding value for uniform ubo command: INVALID",
+            r.Error());
 }
 
 TEST_F(CommandParserTest, UniformUBOInvalidType) {
@@ -2985,7 +3004,7 @@ TEST_F(CommandParserTest, UniformUBOInvalidFloatOffset) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid offset value for uniform command", r.Error());
+  EXPECT_EQ("1: Invalid offset value for uniform command: 5.5", r.Error());
 }
 
 TEST_F(CommandParserTest, UniformUBOInvalidStringOffset) {
@@ -2994,7 +3013,7 @@ TEST_F(CommandParserTest, UniformUBOInvalidStringOffset) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid offset value for uniform command", r.Error());
+  EXPECT_EQ("1: Invalid offset value for uniform command: INVALID", r.Error());
 }
 
 TEST_F(CommandParserTest, UniformUBOMissingValues) {
@@ -3137,7 +3156,7 @@ TEST_F(CommandParserTest, ToleranceInvalidValue1) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid value for tolerance command", r.Error());
+  EXPECT_EQ("1: Invalid value for tolerance command: INVALID", r.Error());
 }
 
 TEST_F(CommandParserTest, ToleranceInvalidJustPercent) {
@@ -3146,7 +3165,7 @@ TEST_F(CommandParserTest, ToleranceInvalidJustPercent) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid value for tolerance command", r.Error());
+  EXPECT_EQ("1: Invalid value for tolerance command: %", r.Error());
 }
 
 TEST_F(CommandParserTest, ToleranceInvalidValue2) {
@@ -3155,7 +3174,7 @@ TEST_F(CommandParserTest, ToleranceInvalidValue2) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid value for tolerance command", r.Error());
+  EXPECT_EQ("1: Invalid value for tolerance command: INVALID", r.Error());
 }
 
 TEST_F(CommandParserTest, ToleranceInvalidValue3) {
@@ -3164,7 +3183,7 @@ TEST_F(CommandParserTest, ToleranceInvalidValue3) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid value for tolerance command", r.Error());
+  EXPECT_EQ("1: Invalid value for tolerance command: INVALID", r.Error());
 }
 
 TEST_F(CommandParserTest, ToleranceInvalidValue4) {
@@ -3173,7 +3192,7 @@ TEST_F(CommandParserTest, ToleranceInvalidValue4) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid value for tolerance command", r.Error());
+  EXPECT_EQ("1: Invalid value for tolerance command: INVALID", r.Error());
 }
 
 TEST_F(CommandParserTest, ToleranceMissingValues) {
@@ -3191,7 +3210,7 @@ TEST_F(CommandParserTest, ToleranceTooManyValues) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Extra parameter for tolerance command", r.Error());
+  EXPECT_EQ("1: Extra parameter for tolerance command: 5", r.Error());
 }
 
 TEST_F(CommandParserTest, ToleranceInvalidWithNumber) {
@@ -3200,7 +3219,7 @@ TEST_F(CommandParserTest, ToleranceInvalidWithNumber) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid value for tolerance command", r.Error());
+  EXPECT_EQ("1: Invalid value for tolerance command: INVALID", r.Error());
 }
 
 TEST_F(CommandParserTest, ToleranceInvalidWithMissingValue) {
@@ -3437,7 +3456,7 @@ TEST_F(CommandParserTest, ProbeSSBOMissingBinding) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid value for probe ssbo command", r.Error());
+  EXPECT_EQ("1: Invalid value for probe ssbo command: ==", r.Error());
 }
 
 TEST_F(CommandParserTest, ProbeSSBOWithInvalidBinding) {
@@ -3446,7 +3465,8 @@ TEST_F(CommandParserTest, ProbeSSBOWithInvalidBinding) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid binding value for probe ssbo command", r.Error());
+  EXPECT_EQ("1: Invalid binding value for probe ssbo command: INVALID",
+            r.Error());
 }
 
 TEST_F(CommandParserTest, ProbeSSBOWithBadType) {
@@ -3464,7 +3484,7 @@ TEST_F(CommandParserTest, ProbeSSBOWithInvalidFloatOffset) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid offset for probe ssbo command", r.Error());
+  EXPECT_EQ("1: Invalid offset for probe ssbo command: 2.0", r.Error());
 }
 
 TEST_F(CommandParserTest, ProbeSSBOWithInvalidStringOffset) {
@@ -3473,7 +3493,7 @@ TEST_F(CommandParserTest, ProbeSSBOWithInvalidStringOffset) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid value for probe ssbo command", r.Error());
+  EXPECT_EQ("1: Invalid value for probe ssbo command: INVALID", r.Error());
 }
 
 TEST_F(CommandParserTest, ProbeSSBOWithInvalidComparator) {
@@ -3482,7 +3502,7 @@ TEST_F(CommandParserTest, ProbeSSBOWithInvalidComparator) {
   CommandParser cp(1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("1: Invalid comparator", r.Error());
+  EXPECT_EQ("1: Invalid comparator: INVALID", r.Error());
 }
 
 TEST_F(CommandParserTest, ProbeSSBOWithMissingData) {
@@ -3540,7 +3560,7 @@ TEST_F(CommandParserTest, ComparatorInvalid) {
   ProbeSSBOCommand::Comparator result;
   Result r = cp.ParseComparatorForTesting("INVALID", &result);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("Invalid comparator", r.Error());
+  EXPECT_EQ("Invalid comparator: INVALID", r.Error());
 }
 
 }  // namespace vkscript

--- a/src/vkscript/parser_test.cc
+++ b/src/vkscript/parser_test.cc
@@ -289,7 +289,7 @@ TEST_F(VkScriptParserTest, IndicesBlockBadValue) {
   Parser parser;
   Result r = parser.ProcessSectionForTesting(section);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("0: Invalid value in indices block", r.Error());
+  EXPECT_EQ("0: Invalid value in indices block: a", r.Error());
 }
 
 TEST_F(VkScriptParserTest, IndicesBlockValueTooLarge) {
@@ -303,7 +303,7 @@ TEST_F(VkScriptParserTest, IndicesBlockValueTooLarge) {
   Parser parser;
   Result r = parser.ProcessSectionForTesting(section);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("0: Value too large in indices block", r.Error());
+  EXPECT_EQ("0: Value too large in indices block: 100000000000", r.Error());
 }
 
 TEST_F(VkScriptParserTest, VertexDataEmpty) {
@@ -500,7 +500,7 @@ TEST_F(VkScriptParserTest, VertexDataIncorrectValue) {
   Parser parser;
   Result r = parser.ProcessSectionForTesting(section);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("2: Invalid vertex data value", r.Error());
+  EXPECT_EQ("2: Invalid vertex data value: StringValue", r.Error());
 }
 
 TEST_F(VkScriptParserTest, VertexDataRowsWithHex) {
@@ -549,7 +549,7 @@ TEST_F(VkScriptParserTest, VertexDataRowsWithHexWrongColumn) {
   Parser parser;
   Result r = parser.ProcessSectionForTesting(section);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("2: Invalid vertex data value", r.Error());
+  EXPECT_EQ("2: Invalid vertex data value: 0xffff0000", r.Error());
 }
 
 }  // namespace vkscript


### PR DESCRIPTION
This CL extends the VkScript parser to also output the token when an
error is encounted.

Fixes #113