### PR TITLE
Vulkan: fix draw array after draw rect bug

### DIFF
--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -192,12 +192,15 @@ Result EngineVulkan::SetBuffer(BufferType type,
   if (!pipeline_->IsGraphics())
     return Result("Vulkan::SetBuffer for Non-Graphics Pipeline");
 
-  if (!vertex_buffer_)
-    vertex_buffer_ = MakeUnique<VertexBuffer>(device_->GetDevice());
+  if (type == BufferType::kVertex) {
+    if (!vertex_buffer_)
+      vertex_buffer_ = MakeUnique<VertexBuffer>(device_->GetDevice());
 
-  pipeline_->AsGraphics()->SetVertexBuffer(type, location, format, values,
-                                           vertex_buffer_.get());
-  return {};
+    pipeline_->AsGraphics()->SetVertexBuffer(location, format, values,
+                                             vertex_buffer_.get());
+  }
+
+  return Result("Vulkan::SetBuffer non-vertex buffer type not implemented");
 }
 
 Result EngineVulkan::DoClearColor(const ClearColorCommand* command) {

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -25,6 +25,7 @@
 #include "src/vulkan/command.h"
 #include "src/vulkan/device.h"
 #include "src/vulkan/pipeline.h"
+#include "src/vulkan/vertex_buffer.h"
 #include "vulkan/vulkan.h"
 
 namespace amber {
@@ -75,6 +76,7 @@ class EngineVulkan : public Engine {
   std::unique_ptr<Device> device_;
   std::unique_ptr<CommandPool> pool_;
   std::unique_ptr<Pipeline> pipeline_;
+  std::unique_ptr<VertexBuffer> vertex_buffer_;
 
   std::unordered_map<ShaderType, VkShaderModule, CastHash<ShaderType>> modules_;
 

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -328,19 +328,11 @@ Result GraphicsPipeline::Initialize(uint32_t width,
   return {};
 }
 
-Result GraphicsPipeline::SetVertexBuffer(BufferType type,
-                                         uint8_t location,
+Result GraphicsPipeline::SetVertexBuffer(uint8_t location,
                                          const Format& format,
                                          const std::vector<Value>& values,
                                          VertexBuffer* vertex_buffer) {
-  // TODO(jaebaek): Handle indices data.
-  if (type != BufferType::kVertex) {
-    return Result(
-        "GraphicsPipeline::SetVertexBuffer: non-vertex buffer type not "
-        "implemented");
-  }
-
-  if (vertex_buffer == nullptr) {
+  if (!vertex_buffer) {
     return Result(
         "GraphicsPipeline::SetVertexBuffer: vertex buffer is nullptr");
   }
@@ -355,8 +347,9 @@ Result GraphicsPipeline::SetVertexBuffer(BufferType type,
   return {};
 }
 
-Result GraphicsPipeline::SendBufferDataIfNeeded(VertexBuffer* vertex_buffer) {
-  if (vertex_buffer == nullptr)
+Result GraphicsPipeline::SendVertexBufferDataIfNeeded(
+    VertexBuffer* vertex_buffer) {
+  if (!vertex_buffer)
     return {};
 
   if (vertex_buffer->VertexDataSent())
@@ -552,7 +545,7 @@ Result GraphicsPipeline::Draw(const DrawArraysCommand* command,
   if (!r.IsSuccess())
     return r;
 
-  r = SendBufferDataIfNeeded(vertex_buffer);
+  r = SendVertexBufferDataIfNeeded(vertex_buffer);
   if (!r.IsSuccess())
     return r;
 

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -48,8 +48,7 @@ class GraphicsPipeline : public Pipeline {
                     VkCommandPool pool,
                     VkQueue queue);
 
-  Result SetVertexBuffer(BufferType type,
-                         uint8_t location,
+  Result SetVertexBuffer(uint8_t location,
                          const Format& format,
                          const std::vector<Value>& values,
                          VertexBuffer* vertex_buffer);
@@ -90,8 +89,7 @@ class GraphicsPipeline : public Pipeline {
   Result ActivateRenderPassIfNeeded();
   void DeactivateRenderPassIfNeeded();
 
-  // Send vertex and index buffers.
-  Result SendBufferDataIfNeeded(VertexBuffer* vertex_buffer);
+  Result SendVertexBufferDataIfNeeded(VertexBuffer* vertex_buffer);
 
   // TODO(jaebaek): Implement image/ssbo probe.
   Result SubmitProbeCommand();

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -48,10 +48,11 @@ class GraphicsPipeline : public Pipeline {
                     VkCommandPool pool,
                     VkQueue queue);
 
-  Result SetBuffer(BufferType type,
-                   uint8_t location,
-                   const Format& format,
-                   const std::vector<Value>& values);
+  Result SetVertexBuffer(BufferType type,
+                         uint8_t location,
+                         const Format& format,
+                         const std::vector<Value>& values,
+                         VertexBuffer* vertex_buffer);
 
   Result Clear();
   Result ClearBuffer(const VkClearValue& clear_value,
@@ -63,11 +64,11 @@ class GraphicsPipeline : public Pipeline {
   Result SetClearStencil(uint32_t stencil);
   Result SetClearDepth(float depth);
 
-  Result Draw(const DrawArraysCommand* command);
+  Result Draw(const DrawArraysCommand* command, VertexBuffer* vertex_buffer);
 
   const FrameBuffer* GetFrame() const { return frame_.get(); }
 
-  Result ResetPipelineAndVertexBuffer();
+  Result ResetPipeline();
 
   uint32_t GetWidth() const { return frame_width_; }
   uint32_t GetHeight() const { return frame_height_; }
@@ -82,14 +83,15 @@ class GraphicsPipeline : public Pipeline {
     kInactive,
   };
 
-  Result CreateVkGraphicsPipeline(VkPrimitiveTopology topology);
+  Result CreateVkGraphicsPipeline(VkPrimitiveTopology topology,
+                                  const VertexBuffer* vertex_buffer);
 
   Result CreateRenderPass();
   Result ActivateRenderPassIfNeeded();
   void DeactivateRenderPassIfNeeded();
 
   // Send vertex and index buffers.
-  Result SendBufferDataIfNeeded();
+  Result SendBufferDataIfNeeded(VertexBuffer* vertex_buffer);
 
   // TODO(jaebaek): Implement image/ssbo probe.
   Result SubmitProbeCommand();
@@ -120,8 +122,6 @@ class GraphicsPipeline : public Pipeline {
   float clear_color_a_ = 0;
   uint32_t clear_stencil_ = 0;
   float clear_depth_ = 1.0f;
-
-  std::unique_ptr<VertexBuffer> vertex_buffer_;
 };
 
 }  // namespace vulkan

--- a/src/vulkan/vertex_buffer.cc
+++ b/src/vulkan/vertex_buffer.cc
@@ -29,7 +29,8 @@ VertexBuffer::VertexBuffer(VkDevice device) : device_(device) {}
 VertexBuffer::~VertexBuffer() = default;
 
 void VertexBuffer::Shutdown() {
-  buffer_->Shutdown();
+  if (buffer_)
+    buffer_->Shutdown();
 }
 
 void VertexBuffer::SetData(uint8_t location,

--- a/src/vulkan/vertex_buffer.h
+++ b/src/vulkan/vertex_buffer.h
@@ -36,7 +36,7 @@ class VertexBuffer {
 
   Result SendVertexData(VkCommandBuffer command,
                         const VkPhysicalDeviceMemoryProperties& properties);
-  bool VertexDataSent() { return !is_vertex_data_pending_; }
+  bool VertexDataSent() const { return !is_vertex_data_pending_; }
 
   void SetData(uint8_t location,
                const Format& format,

--- a/tests/cases/draw_array_after_draw_rect.amber
+++ b/tests/cases/draw_array_after_draw_rect.amber
@@ -1,0 +1,127 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[require]
+vertexPipelineStoresAndAtomics
+
+[vertex shader]
+#version 430
+
+layout(location = 0) in vec4 position;
+layout(location = 0) out vec4 frag_color;
+
+layout(set = 0, binding = 0) buffer block1 {
+  vec4 in_color;
+};
+
+void main() {
+  gl_Position = position;
+  frag_color = in_color;
+}
+
+[fragment shader]
+#version 430
+
+layout(location = 0) in vec4 frag_color;
+layout(location = 0) out vec4 final_color;
+
+void main() {
+  final_color = frag_color;
+}
+
+[vertex data]
+#        position
+     0/R8G8_SNORM
+
+#    Entire frame
+#         R8   G8
+        -128 -128
+         127  127
+        -128  127
+
+        -128 -128
+         127  127
+         127 -128
+
+#      Half frame
+#         R8   G8
+           0 -128
+         127  127
+           0  127
+
+           0 -128
+         127  127
+         127 -128
+
+#   Quarter frame
+#         R8   G8
+        -128    0
+           0  127
+        -128  127
+
+        -128    0
+           0  127
+           0    0
+
+#   Quarter frame
+#         R8   G8
+           0    0
+         127  127
+           0  127
+
+           0    0
+         127  127
+         127    0
+
+[test]
+clear
+
+ssbo 0 subdata vec4 0 1.0 0.0 0.0 1.0
+draw rect -1 -1 1 1
+
+ssbo 0 subdata vec4 0 0.0 1.0 0.0 1.0
+draw rect -1  0 1 1
+
+ssbo 0 subdata vec4 0 0.0 0.0 1.0 1.0
+draw rect  0 -1 1 1
+
+ssbo 0 subdata vec4 0 0.5 0.0 0.5 1.0
+draw rect  0  0 1 1
+
+relative probe rect rgba (0.0, 0.0, 0.5, 0.5) (1.0,   0,   0, 1.0)
+relative probe rect rgba (0.0, 0.5, 0.5, 0.5) (  0, 1.0,   0, 1.0)
+relative probe rect rgba (0.5, 0.0, 0.5, 0.5) (  0,   0, 1.0, 1.0)
+relative probe rect rgba (0.5, 0.5, 0.5, 0.5) (0.5,   0, 0.5, 1.0)
+
+ssbo 0 subdata vec4 0 1.0 0.0 0.0 1.0
+draw arrays TRIANGLE_LIST 0 6
+relative probe rect rgb (0.0, 0.0, 1.0, 1.0) (1.0, 0, 0)
+
+ssbo 0 subdata vec4 0 0.0 1.0 0.0 1.0
+draw arrays TRIANGLE_LIST 6 6
+relative probe rect rgb (0.0, 0.0, 0.5, 1.0) (1.0, 0, 0)
+relative probe rect rgb (0.5, 0.0, 0.5, 1.0) (0, 1.0, 0)
+
+ssbo 0 subdata vec4 0 0.0 0.0 1.0 1.0
+draw arrays TRIANGLE_LIST 12 6
+relative probe rect rgb (0.0, 0.0, 0.5, 0.5) (1.0, 0, 0)
+relative probe rect rgb (0.5, 0.0, 0.5, 1.0) (0, 1.0, 0)
+relative probe rect rgb (0.0, 0.5, 0.5, 0.5) (0, 0, 1.0)
+
+ssbo 0 subdata vec4 0 0.5 0.5 0.5 1.0
+draw arrays TRIANGLE_LIST 18 6
+relative probe rect rgb (0.0, 0.0, 0.5, 0.5) (1.0, 0, 0)
+relative probe rect rgb (0.5, 0.0, 0.5, 0.5) (0, 1.0, 0)
+relative probe rect rgb (0.0, 0.5, 0.5, 0.5) (0, 0, 1.0)
+relative probe rect rgb (0.5, 0.5, 0.5, 0.5) (0.5, 0.5, 0.5)

--- a/tests/cases/draw_rect_after_draw_array.amber
+++ b/tests/cases/draw_rect_after_draw_array.amber
@@ -1,0 +1,127 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[require]
+vertexPipelineStoresAndAtomics
+
+[vertex shader]
+#version 430
+
+layout(location = 0) in vec4 position;
+layout(location = 0) out vec4 frag_color;
+
+layout(set = 0, binding = 0) buffer block1 {
+  vec4 in_color;
+};
+
+void main() {
+  gl_Position = position;
+  frag_color = in_color;
+}
+
+[fragment shader]
+#version 430
+
+layout(location = 0) in vec4 frag_color;
+layout(location = 0) out vec4 final_color;
+
+void main() {
+  final_color = frag_color;
+}
+
+[vertex data]
+#        position
+     0/R8G8_SNORM
+
+#    Entire frame
+#         R8   G8
+        -128 -128
+         127  127
+        -128  127
+
+        -128 -128
+         127  127
+         127 -128
+
+#      Half frame
+#         R8   G8
+           0 -128
+         127  127
+           0  127
+
+           0 -128
+         127  127
+         127 -128
+
+#   Quarter frame
+#         R8   G8
+        -128    0
+           0  127
+        -128  127
+
+        -128    0
+           0  127
+           0    0
+
+#   Quarter frame
+#         R8   G8
+           0    0
+         127  127
+           0  127
+
+           0    0
+         127  127
+         127    0
+
+[test]
+clear
+
+ssbo 0 subdata vec4 0 1.0 0.0 0.0 1.0
+draw arrays TRIANGLE_LIST 0 6
+relative probe rect rgb (0.0, 0.0, 1.0, 1.0) (1.0, 0, 0)
+
+ssbo 0 subdata vec4 0 0.0 1.0 0.0 1.0
+draw arrays TRIANGLE_LIST 6 6
+relative probe rect rgb (0.0, 0.0, 0.5, 1.0) (1.0, 0, 0)
+relative probe rect rgb (0.5, 0.0, 0.5, 1.0) (0, 1.0, 0)
+
+ssbo 0 subdata vec4 0 0.0 0.0 1.0 1.0
+draw arrays TRIANGLE_LIST 12 6
+relative probe rect rgb (0.0, 0.0, 0.5, 0.5) (1.0, 0, 0)
+relative probe rect rgb (0.5, 0.0, 0.5, 1.0) (0, 1.0, 0)
+relative probe rect rgb (0.0, 0.5, 0.5, 0.5) (0, 0, 1.0)
+
+ssbo 0 subdata vec4 0 0.5 0.5 0.5 1.0
+draw arrays TRIANGLE_LIST 18 6
+relative probe rect rgb (0.0, 0.0, 0.5, 0.5) (1.0, 0, 0)
+relative probe rect rgb (0.5, 0.0, 0.5, 0.5) (0, 1.0, 0)
+relative probe rect rgb (0.0, 0.5, 0.5, 0.5) (0, 0, 1.0)
+relative probe rect rgb (0.5, 0.5, 0.5, 0.5) (0.5, 0.5, 0.5)
+
+ssbo 0 subdata vec4 0 1.0 0.0 0.0 1.0
+draw rect -1 -1 1 1
+
+ssbo 0 subdata vec4 0 0.0 1.0 0.0 1.0
+draw rect -1  0 1 1
+
+ssbo 0 subdata vec4 0 0.0 0.0 1.0 1.0
+draw rect  0 -1 1 1
+
+ssbo 0 subdata vec4 0 0.5 0.0 0.5 1.0
+draw rect  0  0 1 1
+
+relative probe rect rgba (0.0, 0.0, 0.5, 0.5) (1.0,   0,   0, 1.0)
+relative probe rect rgba (0.0, 0.5, 0.5, 0.5) (  0, 1.0,   0, 1.0)
+relative probe rect rgba (0.5, 0.0, 0.5, 0.5) (  0,   0, 1.0, 1.0)
+relative probe rect rgba (0.5, 0.5, 0.5, 0.5) (0.5,   0, 0.5, 1.0)

--- a/tests/cases/draw_rect_and_draw_array_mixed.amber
+++ b/tests/cases/draw_rect_and_draw_array_mixed.amber
@@ -1,0 +1,124 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[require]
+vertexPipelineStoresAndAtomics
+
+[vertex shader]
+#version 430
+
+layout(location = 0) in vec4 position;
+layout(location = 0) out vec4 frag_color;
+
+layout(set = 0, binding = 0) buffer block1 {
+  vec4 in_color;
+};
+
+void main() {
+  gl_Position = position;
+  frag_color = in_color;
+}
+
+[fragment shader]
+#version 430
+
+layout(location = 0) in vec4 frag_color;
+layout(location = 0) out vec4 final_color;
+
+void main() {
+  final_color = frag_color;
+}
+
+[vertex data]
+#        position
+     0/R8G8_SNORM
+
+#    Entire frame
+#         R8   G8
+        -128 -128
+         127  127
+        -128  127
+
+        -128 -128
+         127  127
+         127 -128
+
+#      Half frame
+#         R8   G8
+           0 -128
+         127  127
+           0  127
+
+           0 -128
+         127  127
+         127 -128
+
+#   Quarter frame
+#         R8   G8
+        -128    0
+           0  127
+        -128  127
+
+        -128    0
+           0  127
+           0    0
+
+#   Quarter frame
+#         R8   G8
+           0    0
+         127  127
+           0  127
+
+           0    0
+         127  127
+         127    0
+
+[test]
+clear
+
+ssbo 0 subdata vec4 0 1.0 0.0 0.0 1.0
+draw rect -1 -1 1 1
+relative probe rect rgba (0.0, 0.0, 0.5, 0.5) (1.0,   0,   0, 1.0)
+
+ssbo 0 subdata vec4 0 0.0 1.0 0.0 1.0
+draw arrays TRIANGLE_LIST 0 6
+relative probe rect rgb (0.0, 0.0, 1.0, 1.0) (0, 1.0, 0)
+
+ssbo 0 subdata vec4 0 0.0 1.0 0.0 1.0
+draw rect -1  0 1 1
+relative probe rect rgba (0.0, 0.5, 0.5, 0.5) (  0, 1.0,   0, 1.0)
+
+ssbo 0 subdata vec4 0 0.0 0.0 1.0 1.0
+draw arrays TRIANGLE_LIST 6 6
+relative probe rect rgb (0.5, 0.0, 0.5, 1.0) (0, 0, 1.0)
+
+ssbo 0 subdata vec4 0 0.0 0.0 1.0 1.0
+draw rect  0 -1 1 1
+relative probe rect rgba (0.5, 0.0, 0.5, 0.5) (  0,   0, 1.0, 1.0)
+
+ssbo 0 subdata vec4 0 0.5 0.0 0.5 1.0
+draw arrays TRIANGLE_LIST 12 6
+relative probe rect rgb (0.0, 0.5, 0.5, 0.5) (0.5, 0, 0.5)
+
+ssbo 0 subdata vec4 0 0.5 0.0 0.5 1.0
+draw rect  0  0 1 1
+relative probe rect rgba (0.5, 0.5, 0.5, 0.5) (0.5,   0, 0.5, 1.0)
+
+ssbo 0 subdata vec4 0 1.0 0.0 0.0 1.0
+draw arrays TRIANGLE_LIST 18 6
+
+relative probe rect rgba (0.0, 0.0, 0.5, 0.5) (  0, 1.0,   0, 1.0)
+relative probe rect rgba (0.5, 0.0, 0.5, 0.5) (  0,   0, 1.0, 1.0)
+relative probe rect rgba (0.0, 0.5, 0.5, 0.5) (0.5,   0, 0.5, 1.0)
+relative probe rect rgba (0.5, 0.5, 0.5, 0.5) (1.0,   0,   0, 1.0)


### PR DESCRIPTION
`draw rect` command generates a new vertex buffer for its target
rectangle. Without this commit, GraphicsPipeline just destroys the
existing vertex buffer and creates new one. As a result, draw array
after draw rect looses its vertex buffer and has errors.

Fixes #169