### PR TITLE
Add a test case with default memory layouts

### DIFF
--- a/tests/cases/compute_ubo_and_ssbo_layouts.amber
+++ b/tests/cases/compute_ubo_and_ssbo_layouts.amber
@@ -24,7 +24,7 @@ layout(set = 0, binding = 0) buffer block00 {
   float e;      //        84
 } b0;
 
-// UBO compiled as std430 by glslang
+// UBO compiled as std140 by glslang
 layout(set = 0, binding = 1) uniform block01 {
   float a[3];   // Offset: 0, array stride:  16
   int b;        //        48

--- a/tests/cases/compute_ubo_and_ssbo_layouts.amber
+++ b/tests/cases/compute_ubo_and_ssbo_layouts.amber
@@ -1,0 +1,129 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[compute shader]
+#version 430
+
+// SSBO compiled as std430 by glslang
+layout(set = 0, binding = 0) buffer block00 {
+  float a[3];   // Offset: 0, array stride:   4
+  int b;        //        12
+  mat3 c;       //        16, matrix stride: 16
+  int d[5];     //        64, array stride:   4
+  float e;      //        84
+} b0;
+
+// UBO compiled as std430 by glslang
+layout(set = 0, binding = 1) uniform block01 {
+  float a[3];   // Offset: 0, array stride:  16
+  int b;        //        48
+  mat3 c;       //        64, matrix stride: 16
+  int d[5];     //       112, array stride:  16
+  float e;      //       192
+} b1;
+
+// SSBO compiled as std430 by glslang
+layout(set = 1, binding = 0) buffer block10 {
+  float b0_result[];
+};
+
+// SSBO compiled as std430 by glslang
+layout(set = 1, binding = 1) buffer block11 {
+  float b1_result[];
+};
+
+void main() {
+  // Test SSBO layout
+  int offset = 0;
+  for (int i = 0; i < 3; ++i)
+    b0_result[offset++] = b0.a[i];
+
+  b0_result[offset++] = b0.b;
+
+  for (int i = 0; i < 3; ++i)
+    for (int j = 0; j < 3; ++j)
+      b0_result[offset++] = b0.c[i][j];
+
+  for (int i = 0; i < 5; ++i)
+    b0_result[offset++] = b0.d[i];
+
+  b0_result[offset++] = b0.e;
+
+  // Test UBO layout
+  offset = 0;
+  for (int i = 0; i < 3; ++i)
+    b1_result[offset++] = b1.a[i];
+
+  b1_result[offset++] = b1.b;
+
+  for (int i = 0; i < 3; ++i)
+    for (int j = 0; j < 3; ++j)
+      b1_result[offset++] = b1.c[i][j];
+
+  for (int i = 0; i < 5; ++i)
+    b1_result[offset++] = b1.d[i];
+
+  b1_result[offset++] = b1.e;
+}
+
+[test]
+# SSBO 0:0
+ssbo 0:0 subdata float  0  1  2  3
+ssbo 0:0 subdata int   12  4
+ssbo 0:0 subdata float 16  5  6  7  0 \
+                           8  9 10  0 \
+                          11 12 13      # Zeros for matrix stride 16
+ssbo 0:0 subdata int   64 14 15 16 17 18
+ssbo 0:0 subdata float 84 19
+
+# UBO 0:1
+uniform ubo 0:1 float   0  1  0  0  0 \
+                           2  0  0  0 \
+                           3            # Zeros for array stride 16
+uniform ubo 0:1 int    48  4
+uniform ubo 0:1 float  64  5  6  7  0 \
+                           8  9 10  0 \
+                          11 12 13      # Zeros for matrix stride 16
+uniform ubo 0:1 int   112 14  0  0  0 \
+                          15  0  0  0 \
+                          16  0  0  0 \
+                          17  0  0  0 \
+                          18            # Zeros for array stride 16
+uniform ubo 0:1 float 192 19
+
+# SSBO 1:0
+ssbo 1:0 256
+
+# SSBO 1:1
+ssbo 1:1 256
+
+compute 1 1 1
+
+# Check SSBO memory layout
+probe ssbo float 1:0  0 ~=  1  2  3
+probe ssbo float 1:0 12 ~=  4
+probe ssbo float 1:0 16 ~=  5  6  7 \
+                            8  9 10 \
+                           11 12 13
+probe ssbo float 1:0 52 ~= 14 15 16 17 18
+probe ssbo float 1:0 72 ~= 19
+
+# Check UBO memory layout
+probe ssbo float 1:1  0 ~=  1  2  3
+probe ssbo float 1:1 12 ~=  4
+probe ssbo float 1:1 16 ~=  5  6  7 \
+                            8  9 10 \
+                           11 12 13
+probe ssbo float 1:1 52 ~= 14 15 16 17 18
+probe ssbo float 1:1 72 ~= 19


### PR DESCRIPTION
glslang uses `std430` for SSBO and push constant and `std140` for UBO.
However, all `ssbo`, `uniform ubo`, `probe ssbo` commands must not have
any specific layouts. They must simply conduct memory copies for given
offset, type, and values or size.