### PR TITLE
Vulkan: support push constant

### DIFF
--- a/src/vulkan/CMakeLists.txt
+++ b/src/vulkan/CMakeLists.txt
@@ -23,10 +23,11 @@ set(VULKAN_ENGINE_SOURCES
     engine_vulkan.cc
     format_data.cc
     frame_buffer.cc
-    resource.cc
+    graphics_pipeline.cc
+    handle_value_with_memory.cc
     image.cc
     pipeline.cc
-    graphics_pipeline.cc
+    resource.cc
     vertex_buffer.cc
 )
 

--- a/src/vulkan/buffer_descriptor.cc
+++ b/src/vulkan/buffer_descriptor.cc
@@ -24,19 +24,6 @@
 
 namespace amber {
 namespace vulkan {
-namespace {
-
-// TODO(jaebaek): Make this as a protected method of Descriptor.
-template <typename T>
-void SetValueForBuffer(void* memory, const std::vector<Value>& values) {
-  T* ptr = static_cast<T*>(memory);
-  for (const auto& v : values) {
-    *ptr = static_cast<T>(v.IsInteger() ? v.AsUint64() : v.AsDouble());
-    ++ptr;
-  }
-}
-
-}  // namespace
 
 BufferDescriptor::BufferDescriptor(DescriptorType type,
                                    VkDevice device,
@@ -48,36 +35,6 @@ BufferDescriptor::BufferDescriptor(DescriptorType type,
 }
 
 BufferDescriptor::~BufferDescriptor() = default;
-
-// TODO(jaebaek): Add unittests for this method.
-void BufferDescriptor::FillBufferWithData(const BufferData& data) {
-  uint8_t* ptr =
-      static_cast<uint8_t*>(buffer_->HostAccessibleMemoryPtr()) + data.offset;
-  switch (data.type) {
-    case DataType::kInt8:
-    case DataType::kUint8:
-      SetValueForBuffer<uint8_t>(ptr, data.values);
-      break;
-    case DataType::kInt16:
-    case DataType::kUint16:
-      SetValueForBuffer<uint16_t>(ptr, data.values);
-      break;
-    case DataType::kInt32:
-    case DataType::kUint32:
-      SetValueForBuffer<uint32_t>(ptr, data.values);
-      break;
-    case DataType::kInt64:
-    case DataType::kUint64:
-      SetValueForBuffer<uint64_t>(ptr, data.values);
-      break;
-    case DataType::kFloat:
-      SetValueForBuffer<float>(ptr, data.values);
-      break;
-    case DataType::kDouble:
-      SetValueForBuffer<double>(ptr, data.values);
-      break;
-  }
-}
 
 Result BufferDescriptor::CreateOrResizeIfNeeded(
     VkCommandBuffer command,
@@ -135,8 +92,10 @@ void BufferDescriptor::UpdateResourceIfNeeded(VkCommandBuffer command) {
   if (buffer_data_queue.empty())
     return;
 
+  HandleValueWithMemory memory_updater;
   for (const auto& data : buffer_data_queue) {
-    FillBufferWithData(data);
+    memory_updater.UpdateMemoryWithData(buffer_->HostAccessibleMemoryPtr(),
+                                        data);
   }
   ClearBufferDataQueue();
 

--- a/src/vulkan/buffer_descriptor.h
+++ b/src/vulkan/buffer_descriptor.h
@@ -39,10 +39,6 @@ class BufferDescriptor : public Descriptor {
                    uint32_t binding);
   ~BufferDescriptor() override;
 
-  // |data| contains information of what parts of |buffer_| must be
-  // updated as what values. This method conducts the update.
-  void FillBufferWithData(const BufferData& data);
-
   // Descriptor
   Result CreateOrResizeIfNeeded(
       VkCommandBuffer command,

--- a/src/vulkan/compute_pipeline.cc
+++ b/src/vulkan/compute_pipeline.cc
@@ -101,6 +101,8 @@ Result ComputePipeline::Compute(uint32_t x, uint32_t y, uint32_t z) {
   BindVkDescriptorSets();
   BindVkPipeline();
 
+  PushConstants();
+
   vkCmdDispatch(command_->GetCommandBuffer(), x, y, z);
   return {};
 }

--- a/src/vulkan/descriptor.h
+++ b/src/vulkan/descriptor.h
@@ -21,6 +21,7 @@
 #include "amber/result.h"
 #include "src/datum_type.h"
 #include "src/engine.h"
+#include "src/vulkan/handle_value_with_memory.h"
 #include "vulkan/vulkan.h"
 
 namespace amber {
@@ -41,13 +42,6 @@ enum class DescriptorType : uint8_t {
 };
 
 VkDescriptorType ToVkDescriptorType(DescriptorType type);
-
-struct BufferData {
-  DataType type;
-  uint32_t offset;
-  size_t size_in_bytes;
-  std::vector<Value> values;
-};
 
 class Descriptor {
  public:

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -375,8 +375,8 @@ Result EngineVulkan::GetDescriptorInfo(const uint32_t descriptor_set,
 }
 
 Result EngineVulkan::DoBuffer(const BufferCommand* command) {
-  if (!command->IsSSBO() && !command->IsUniform())
-    return Result("Vulkan::DoBuffer not supported buffer type");
+  if (command->IsPushConstant())
+    return pipeline_->AddPushConstant(command);
 
   return pipeline_->AddDescriptor(command);
 }

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -558,6 +558,8 @@ Result GraphicsPipeline::Draw(const DrawArraysCommand* command,
   BindVkDescriptorSets();
   BindVkPipeline();
 
+  PushConstants();
+
   if (vertex_buffer != nullptr)
     vertex_buffer->BindToCommandBuffer(command_->GetCommandBuffer());
 

--- a/src/vulkan/handle_value_with_memory.cc
+++ b/src/vulkan/handle_value_with_memory.cc
@@ -1,0 +1,66 @@
+// Copyright 2018 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/vulkan/handle_value_with_memory.h"
+
+namespace amber {
+namespace vulkan {
+namespace {
+
+template <typename T>
+void SetValueForBuffer(void* memory, const std::vector<Value>& values) {
+  T* ptr = static_cast<T*>(memory);
+  for (const auto& v : values) {
+    *ptr = static_cast<T>(v.IsInteger() ? v.AsUint64() : v.AsDouble());
+    ++ptr;
+  }
+}
+
+}  // namespace
+
+HandleValueWithMemory::HandleValueWithMemory() = default;
+
+HandleValueWithMemory::~HandleValueWithMemory() = default;
+
+void HandleValueWithMemory::UpdateMemoryWithData(void* memory,
+                                                 const BufferData& data) {
+  uint8_t* ptr = static_cast<uint8_t*>(memory) + data.offset;
+  switch (data.type) {
+    case DataType::kInt8:
+    case DataType::kUint8:
+      SetValueForBuffer<uint8_t>(ptr, data.values);
+      break;
+    case DataType::kInt16:
+    case DataType::kUint16:
+      SetValueForBuffer<uint16_t>(ptr, data.values);
+      break;
+    case DataType::kInt32:
+    case DataType::kUint32:
+      SetValueForBuffer<uint32_t>(ptr, data.values);
+      break;
+    case DataType::kInt64:
+    case DataType::kUint64:
+      SetValueForBuffer<uint64_t>(ptr, data.values);
+      break;
+    case DataType::kFloat:
+      SetValueForBuffer<float>(ptr, data.values);
+      break;
+    case DataType::kDouble:
+      SetValueForBuffer<double>(ptr, data.values);
+      break;
+  }
+}
+
+}  // namespace vulkan
+}  // namespace amber

--- a/src/vulkan/handle_value_with_memory.h
+++ b/src/vulkan/handle_value_with_memory.h
@@ -1,0 +1,49 @@
+// Copyright 2018 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SRC_VULKAN_HANDLE_VALUE_WITH_MEMORY_H_
+#define SRC_VULKAN_HANDLE_VALUE_WITH_MEMORY_H_
+
+#include <vector>
+
+#include "src/datum_type.h"
+#include "src/value.h"
+
+namespace amber {
+namespace vulkan {
+
+// Contain information of updating memory
+// [|offset|, |offset| + |size_in_bytes|) with |values| whose data
+// type is |type|.
+struct BufferData {
+  DataType type;
+  uint32_t offset;
+  size_t size_in_bytes;
+  std::vector<Value> values;
+};
+
+class HandleValueWithMemory {
+ public:
+  HandleValueWithMemory();
+  ~HandleValueWithMemory();
+
+  // Update |memory| from |offset| of |data| to |offset| + |size_in_bytes| of
+  // |data| with |values| of |data|.
+  void UpdateMemoryWithData(void* memory, const BufferData& data);
+};
+
+}  // namespace vulkan
+}  // namespace amber
+
+#endif  // SRC_VULKAN_HANDLE_VALUE_WITH_MEMORY_H_

--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -172,6 +172,45 @@ Result Pipeline::CreateDescriptorSets() {
   return {};
 }
 
+VkPushConstantRange Pipeline::GetPushConstantRange() {
+  if (push_constant_data_.empty())
+    return {};
+
+  auto it =
+      std::min_element(push_constant_data_.begin(), push_constant_data_.end(),
+                       [](const BufferData& a, const BufferData& b) {
+                         return a.offset < b.offset;
+                       });
+  if (it == push_constant_data_.end())
+    return {};
+
+  uint32_t first_offset = it->offset;
+
+  it = std::max_element(
+      push_constant_data_.begin(), push_constant_data_.end(),
+      [](const BufferData& a, const BufferData& b) {
+        return a.offset + static_cast<uint32_t>(a.size_in_bytes) <
+               b.offset + static_cast<uint32_t>(b.size_in_bytes);
+      });
+  if (it == push_constant_data_.end())
+    return {};
+
+  uint32_t size_in_bytes =
+      it->offset + static_cast<uint32_t>(it->size_in_bytes) - first_offset;
+
+  VkPushConstantRange range = {};
+  range.stageFlags = VK_SHADER_STAGE_ALL;
+
+  // Based on Vulkan spec, range.offset must be multiple of 4.
+  range.offset = (first_offset / 4U) * 4U;
+
+  // Based on Vulkan spec, range.size must be multiple of 4.
+  assert(size_in_bytes + 3U <= std::numeric_limits<uint32_t>::max());
+  range.size = ((size_in_bytes + 3U) / 4U) * 4U;
+
+  return range;
+}
+
 Result Pipeline::CreatePipelineLayout() {
   std::vector<VkDescriptorSetLayout> descriptor_set_layouts;
   for (const auto& desc_set : descriptor_set_info_)
@@ -182,7 +221,13 @@ Result Pipeline::CreatePipelineLayout() {
   pipeline_layout_info.setLayoutCount =
       static_cast<uint32_t>(descriptor_set_layouts.size());
   pipeline_layout_info.pSetLayouts = descriptor_set_layouts.data();
-  // TODO(jaebaek): Push constant for pipeline_layout_info.
+
+  VkPushConstantRange push_const_range = {};
+  if (!push_constant_data_.empty()) {
+    push_const_range = GetPushConstantRange();
+    pipeline_layout_info.pushConstantRangeCount = 1U;
+    pipeline_layout_info.pPushConstantRanges = &push_const_range;
+  }
 
   if (vkCreatePipelineLayout(device_, &pipeline_layout_info, nullptr,
                              &pipeline_layout_) != VK_SUCCESS) {
@@ -224,6 +269,58 @@ Result Pipeline::UpdateDescriptorSetsIfNeeded() {
         return r;
     }
   }
+
+  return {};
+}
+
+void Pipeline::PushConstants() {
+  if (push_constant_data_.empty())
+    return;
+
+  auto push_const_range = GetPushConstantRange();
+
+  HandleValueWithMemory memory_updater;
+  std::vector<uint8_t> memory(push_const_range.offset + push_const_range.size);
+  for (const auto& data : push_constant_data_) {
+    memory_updater.UpdateMemoryWithData(memory.data(), data);
+  }
+
+  // Based on spec, offset and size in bytes of push constant must
+  // be multiple of 4.
+  assert(push_const_range.offset % 4U == 0 && push_const_range.size % 4U == 0);
+
+  vkCmdPushConstants(command_->GetCommandBuffer(), pipeline_layout_,
+                     VK_SHADER_STAGE_ALL, push_const_range.offset,
+                     push_const_range.size, &memory[push_const_range.offset]);
+}
+
+Result Pipeline::AddPushConstant(const BufferCommand* command) {
+  if (!command->IsPushConstant())
+    return Result(
+        "Pipeline::AddPushConstant BufferCommand type is not push constant");
+
+  // TODO(jaebaek): push constant -> compute -> push constant -> compute
+  //                The second compute maybe have different push constant
+  //                ranges. Doublecheck if we update |pipeline_layout_| properly
+  //                in that case.
+  if (descriptor_related_objects_already_created_) {
+    for (auto& info : descriptor_set_info_) {
+      vkDestroyDescriptorSetLayout(device_, info.layout, nullptr);
+      if (info.empty)
+        continue;
+
+      vkDestroyDescriptorPool(device_, info.pool, nullptr);
+    }
+
+    vkDestroyPipelineLayout(device_, pipeline_layout_, nullptr);
+    vkDestroyPipeline(device_, pipeline_, nullptr);
+
+    descriptor_related_objects_already_created_ = false;
+  }
+
+  push_constant_data_.push_back({command->GetDatumType().GetType(),
+                                 command->GetOffset(), command->GetSize(),
+                                 command->GetValues()});
 
   return {};
 }

--- a/src/vulkan/pipeline.h
+++ b/src/vulkan/pipeline.h
@@ -25,6 +25,7 @@
 #include "src/engine.h"
 #include "src/vulkan/command.h"
 #include "src/vulkan/descriptor.h"
+#include "src/vulkan/handle_value_with_memory.h"
 #include "vulkan/vulkan.h"
 
 namespace amber {
@@ -47,6 +48,10 @@ class Pipeline {
   ComputePipeline* AsCompute();
 
   Result AddDescriptor(const BufferCommand*);
+
+  // Add information of how and what to do with push constant to
+  // |push_constant_data_|.
+  Result AddPushConstant(const BufferCommand* command);
 
   // Copy the contents of the resource bound to the given descriptor
   // to host memory.
@@ -80,6 +85,7 @@ class Pipeline {
   Result SendDescriptorDataToDeviceIfNeeded();
   void BindVkPipeline();
   void BindVkDescriptorSets();
+  void PushConstants();
 
   const std::vector<VkPipelineShaderStageCreateInfo>& GetShaderStageInfo()
       const {
@@ -105,6 +111,7 @@ class Pipeline {
     std::vector<std::unique_ptr<Descriptor>> descriptors_;
   };
 
+  VkPushConstantRange GetPushConstantRange();
   Result CreatePipelineLayout();
 
   Result CreateDescriptorSetLayouts();
@@ -114,6 +121,10 @@ class Pipeline {
   PipelineType pipeline_type_;
   std::vector<DescriptorSetInfo> descriptor_set_info_;
   std::vector<VkPipelineShaderStageCreateInfo> shader_stage_info_;
+
+  // Keep the information of what and how to conduct push constant.
+  std::vector<BufferData> push_constant_data_;
+
   uint32_t fence_timeout_ms_ = 100;
   bool descriptor_related_objects_already_created_ = false;
   std::unordered_map<VkShaderStageFlagBits,

--- a/tests/cases/compute_push_constant_and_ssbo.amber
+++ b/tests/cases/compute_push_constant_and_ssbo.amber
@@ -1,0 +1,61 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[compute shader]
+#version 430
+
+layout(set = 0, binding = 0) buffer block0 {
+  float data_set0_binding0[];
+};
+
+// push_constant compiled as std430 by glslang
+layout(push_constant) uniform block1 {
+  float constant0[3];  // Offset:  0, array stride:  4
+  uint constant1;      //         12
+  vec3 constant2[3];   //         16, array stride: 16
+  uint constant3;      //         64
+};
+
+void main() {
+  int offset = 0;
+  for (int i = 0; i < 3; ++i)
+    data_set0_binding0[offset++] = constant0[i];
+
+  data_set0_binding0[offset++] = constant1;
+
+  for (int i = 0; i < 3; ++i)
+    for (int j = 0; j < 3; ++j)
+      data_set0_binding0[offset++] = constant2[i][j];
+
+  data_set0_binding0[offset++] = constant3;
+}
+
+[test]
+ssbo 0:0 128
+
+uniform float  0  1  2  3
+uniform uint  12  4
+uniform float 16  5  6  7  0 \
+                  8  9 10  0 \
+                 11 12 13
+uniform uint  64 14
+
+compute 3 1 1
+
+probe ssbo float 0:0  0 ~=  1  2  3
+probe ssbo float 0:0 12 ~=  4
+probe ssbo float 0:0 16 ~=  5  6  7 \
+                            8  9 10 \
+                           11 12 13
+probe ssbo float 0:0 52 ~= 14


### PR DESCRIPTION
When executor calls `DoBuffer()` of Vulkan engine for push constant,
Vulkan engine keeps the information of what values and at which
offset it must put constants in |push_constant_data_| of Pipeline
class. Vulkan engine conducts push constant i.e., vkCmdPushConstants
when executing `draw` or `compute` based on information in
|push_constant_data_|.

Fixes #149