### PR TITLE
Fixup various build warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ option(AMBER_SKIP_SPIRV_TOOLS
   "Skip building spirv-tools into the library" ${AMBER_SKIP_SPIRV_TOOLS})
 option(AMBER_SKIP_SHADERC
   "Skip building Shaderc into the library" ${AMBER_SKIP_SHADERC})
+option(AMBER_SKIP_SAMPLES
+  "Skip building sample application" ${AMBER_SKIP_SAMPLES})
 
 if (${AMBER_SKIP_SPIRV_TOOLS})
   set(AMBER_ENABLE_SPIRV_TOOLS FALSE)
@@ -57,10 +59,16 @@ if (${AMBER_SKIP_TESTS})
 else()
   set(AMBER_ENABLE_TESTS TRUE)
 endif()
+if (${AMBER_SKIP_SAMPLES})
+  set(AMBER_ENABLE_SAMPLES FALSE)
+else()
+  set(AMBER_ENABLE_SAMPLES TRUE)
+endif()
 
 message(STATUS "Amber enable SPIRV-Tools: ${AMBER_ENABLE_SPIRV_TOOLS}")
 message(STATUS "Amber enable Shaderc: ${AMBER_ENABLE_SHADERC}")
 message(STATUS "Amber enable tests: ${AMBER_ENABLE_TESTS}")
+message(STATUS "Amber enable samples: ${AMBER_ENABLE_SAMPLES}")
 
 include_directories("${PROJECT_SOURCE_DIR}/include")
 include_directories("${PROJECT_SOURCE_DIR}")
@@ -178,4 +186,7 @@ endfunction()
 
 add_subdirectory(third_party)
 add_subdirectory(src)
-add_subdirectory(samples)
+
+if (${AMBER_ENABLE_SAMPLES})
+  add_subdirectory(samples)
+endif()

--- a/src/verifier.cc
+++ b/src/verifier.cc
@@ -189,10 +189,10 @@ Result Verifier::Probe(const ProbeCommand* command,
     width = frame_width;
     height = frame_height;
   } else if (command->IsRelative()) {
-    x = static_cast<uint32_t>(frame_width * command->GetX());
-    y = static_cast<uint32_t>(frame_height * command->GetY());
-    width = static_cast<uint32_t>(frame_width * command->GetWidth());
-    height = static_cast<uint32_t>(frame_height * command->GetHeight());
+    x = frame_width * static_cast<uint32_t>(command->GetX());
+    y = frame_height * static_cast<uint32_t>(command->GetY());
+    width = frame_width * static_cast<uint32_t>(command->GetWidth());
+    height = frame_height * static_cast<uint32_t>(command->GetHeight());
   } else {
     x = static_cast<uint32_t>(command->GetX());
     y = static_cast<uint32_t>(command->GetY());

--- a/src/vulkan/bit_copy.cc
+++ b/src/vulkan/bit_copy.cc
@@ -32,7 +32,7 @@ void BitCopy::ShiftBufferBits(uint8_t* buffer,
   uint8_t carry = 0;
   for (uint32_t i = 0; i < length_bytes; ++i) {
     uint8_t new_value = static_cast<uint8_t>(buffer[i] << shift_bits) | carry;
-    carry = buffer[i] >> (8 - shift_bits);
+    carry = static_cast<uint8_t>(buffer[i] >> (8 - shift_bits));
     buffer[i] = new_value;
   }
 }
@@ -85,10 +85,11 @@ void BitCopy::CopyValueToBuffer(uint8_t* dst,
 
   while (bit_offset > 7) {
     ++dst;
-    bit_offset -= 8;
+    bit_offset = static_cast<uint8_t>(bit_offset - 8);
   }
 
-  ShiftBufferBits(data, ((bit_offset + bits - 1) / 8) + 1, bit_offset);
+  ShiftBufferBits(data, static_cast<uint8_t>(((bit_offset + bits - 1) / 8) + 1),
+                  bit_offset);
   CopyBits(dst, data, bit_offset, bits);
 }
 
@@ -100,14 +101,14 @@ void BitCopy::CopyBits(uint8_t* dst,
   while (bit_offset + bits > 0) {
     uint8_t target_bits = bits;
     if (bit_offset + target_bits > 8)
-      target_bits = 8 - bit_offset;
+      target_bits = static_cast<uint8_t>(8 - bit_offset);
 
     uint8_t bit_mask =
         static_cast<uint8_t>(((1U << target_bits) - 1U) << bit_offset);
-    *dst = (*src & bit_mask) | (*dst & ~bit_mask);
+    *dst = static_cast<uint8_t>((*src & bit_mask) | (*dst & ~bit_mask));
 
     bit_offset -= bit_offset;
-    bits -= target_bits;
+    bits = static_cast<uint8_t>(bits - target_bits);
     ++dst;
     ++src;
   }

--- a/src/vulkan/buffer_descriptor.cc
+++ b/src/vulkan/buffer_descriptor.cc
@@ -31,7 +31,8 @@ template <typename T>
 void SetValueForBuffer(void* memory, const std::vector<Value>& values) {
   T* ptr = static_cast<T*>(memory);
   for (const auto& v : values) {
-    *ptr = static_cast<T>(v.IsInteger() ? v.AsUint64() : v.AsDouble());
+    *ptr = v.IsInteger() ? static_cast<T>(v.AsUint64())
+                         : static_cast<T>(v.AsDouble());
     ++ptr;
   }
 }

--- a/src/vulkan/vertex_buffer.cc
+++ b/src/vulkan/vertex_buffer.cc
@@ -72,7 +72,7 @@ void VertexBuffer::FillVertexBufferWithData(VkCommandBuffer command) {
         assert(k == components.size() - 1 ||
                static_cast<uint32_t>(bit_offset) + static_cast<uint32_t>(bits) <
                    256);
-        bit_offset += bits;
+        bit_offset = static_cast<uint8_t>(bit_offset + bits);
       }
 
       ptr += formats_[j].GetByteSize();


### PR DESCRIPTION
This CL fixes a series of build errors due to uint8_t conversions. An
option to disable building the sample app is also added.