### PR TITLE
Lower cmake version for CTS compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 2.8)
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()


### PR DESCRIPTION
The CTS build bots have CMake 2.8. Lower our min version to 2.8.