### PR TITLE
Convert API to C++03 from C++11 for CTS compatibility

### DIFF
--- a/include/amber/amber.h
+++ b/include/amber/amber.h
@@ -15,8 +15,9 @@
 #ifndef AMBER_AMBER_H_
 #define AMBER_AMBER_H_
 
+#include <stdint.h>
+
 #include <map>
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -27,13 +28,13 @@ namespace amber {
 
 /// The shader map is a map from the name of a shader to the spirv-binary
 /// which is the compiled representation of that named shader.
-using ShaderMap = std::map<std::string, std::vector<uint32_t>>;
+typedef std::map<std::string, std::vector<uint32_t> > ShaderMap;
 
-enum class EngineType : uint8_t {
+enum EngineType {
   /// Use the Vulkan backend, if available
-  kVulkan = 0,
+  kEngineTypeVulkan = 0,
   /// Use the Dawn backend, if available
-  kDawn,
+  kEngineTypeDawn,
 };
 
 /// Override point of engines to add their own configuration.
@@ -41,9 +42,9 @@ struct EngineConfig {};
 
 struct Options {
   /// Sets the engine to be created. Default Vulkan.
-  EngineType engine = EngineType::kVulkan;
-  /// Holds engine specific configuration.
-  std::unique_ptr<EngineConfig> config;
+  EngineType engine;
+  /// Holds engine specific configuration. Ownership stays with the caller.
+  EngineConfig* config;
 };
 
 /// Main interface to the Amber environment.

--- a/include/amber/amber_vulkan.h
+++ b/include/amber/amber_vulkan.h
@@ -31,22 +31,22 @@ namespace amber {
 /// Configuration for the Vulkan Engine.
 struct VulkanEngineConfig : public EngineConfig {
   /// The VkPhysicalDevice to use.
-  VkPhysicalDevice physical_device = VK_NULL_HANDLE;
+  VkPhysicalDevice physical_device;
 
   /// Physical device features available for |physical_device|.
-  VkPhysicalDeviceFeatures available_features = {};
+  VkPhysicalDeviceFeatures available_features;
 
   /// Physical device extensions available for |physical_device|.
   std::vector<std::string> available_extensions;
 
   /// The given queue family index to use.
-  uint32_t queue_family_index = std::numeric_limits<uint32_t>::max();
+  uint32_t queue_family_index;
 
   /// The VkDevice to use.
-  VkDevice device = VK_NULL_HANDLE;
+  VkDevice device;
 
   /// The VkQueue to use.
-  VkQueue queue = VK_NULL_HANDLE;
+  VkQueue queue;
 };
 
 }  // namespace amber

--- a/include/amber/recipe.h
+++ b/include/amber/recipe.h
@@ -15,7 +15,6 @@
 #ifndef AMBER_RECIPE_H_
 #define AMBER_RECIPE_H_
 
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -51,8 +50,9 @@ class Recipe {
   /// Retrieves information on all the shaders in the recipe.
   std::vector<ShaderInfo> GetShaderInfo() const;
 
-  RecipeImpl* GetImpl() const { return impl_.get(); }
-  void SetImpl(std::unique_ptr<RecipeImpl> impl) { impl_ = std::move(impl); }
+  RecipeImpl* GetImpl() const { return impl_; }
+  /// Sets the recipe implementation. Ownership transfers to the recipe.
+  void SetImpl(RecipeImpl* impl) { impl_ = impl; }
 
   /// Returns required features in the given recipe.
   std::vector<std::string> GetRequiredFeatures() const;
@@ -61,7 +61,7 @@ class Recipe {
   std::vector<std::string> GetRequiredExtensions() const;
 
  private:
-  std::unique_ptr<RecipeImpl> impl_;
+  RecipeImpl* impl_;
 };
 
 }  // namespace amber

--- a/include/amber/shader_info.h
+++ b/include/amber/shader_info.h
@@ -20,21 +20,21 @@
 
 namespace amber {
 
-enum class ShaderFormat : uint8_t {
-  kDefault = 0,
-  kText,
-  kGlsl,
-  kSpirvAsm,
-  kSpirvHex,
+enum ShaderFormat {
+  kShaderFormatDefault = 0,
+  kShaderFormatText,
+  kShaderFormatGlsl,
+  kShaderFormatSpirvAsm,
+  kShaderFormatSpirvHex,
 };
 
-enum class ShaderType : uint8_t {
-  kCompute = 0,
-  kGeometry,
-  kFragment,
-  kVertex,
-  kTessellationControl,
-  kTessellationEvaluation,
+enum ShaderType {
+  kShaderTypeCompute = 0,
+  kShaderTypeGeometry,
+  kShaderTypeFragment,
+  kShaderTypeVertex,
+  kShaderTypeTessellationControl,
+  kShaderTypeTessellationEvaluation,
 };
 
 struct ShaderInfo {

--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -37,7 +37,7 @@ struct Options {
   bool show_summary = false;
   bool show_help = false;
   bool show_version_info = false;
-  amber::EngineType engine = amber::EngineType::kVulkan;
+  amber::EngineType engine = amber::kEngineTypeVulkan;
 };
 
 const char kUsage[] = R"(Usage: amber [options] SCRIPT [SCRIPTS...]
@@ -94,9 +94,9 @@ bool ParseArgs(const std::vector<std::string>& args, Options* opts) {
       }
       const std::string& engine = args[i];
       if (engine == "vulkan") {
-        opts->engine = amber::EngineType::kVulkan;
+        opts->engine = amber::kEngineTypeVulkan;
       } else if (engine == "dawn") {
-        opts->engine = amber::EngineType::kDawn;
+        opts->engine = amber::kEngineTypeDawn;
       } else {
         std::cerr
             << "Invalid value for -e argument. Must be one of: vulkan dawn"
@@ -238,12 +238,14 @@ int main(int argc, const char** argv) {
   }
 
   sample::ConfigHelper config_helper;
-  amber_options.config = config_helper.CreateConfig(
+  auto config = config_helper.CreateConfig(
       amber_options.engine,
       std::vector<std::string>(required_features.begin(),
                                required_features.end()),
       std::vector<std::string>(required_extensions.begin(),
                                required_extensions.end()));
+
+  amber_options.config = config.get();
 
   for (const auto& recipe_data_elem : recipe_data) {
     const auto* recipe = recipe_data_elem.recipe.get();

--- a/samples/config_helper.cc
+++ b/samples/config_helper.cc
@@ -38,7 +38,7 @@ std::unique_ptr<amber::EngineConfig> ConfigHelper::CreateConfig(
     amber::EngineType engine,
     const std::vector<std::string>& required_features,
     const std::vector<std::string>& required_extensions) {
-  if (engine == amber::EngineType::kDawn)
+  if (engine == amber::kEngineTypeDawn)
     return nullptr;
 
 #if AMBER_ENGINE_VULKAN

--- a/src/amber.cc
+++ b/src/amber.cc
@@ -44,7 +44,7 @@ amber::Result Amber::Parse(const std::string& input, amber::Recipe* recipe) {
   if (!r.IsSuccess())
     return r;
 
-  recipe->SetImpl(parser->GetScript());
+  recipe->SetImpl(parser->GetScript().release());
   return {};
 }
 
@@ -69,8 +69,7 @@ amber::Result Amber::ExecuteWithShaderData(const amber::Recipe* recipe,
 
   Result r;
   if (opts.config) {
-    r = engine->InitializeWithConfig(opts.config.get(),
-                                     script->RequiredFeatures(),
+    r = engine->InitializeWithConfig(opts.config, script->RequiredFeatures(),
                                      script->RequiredExtensions());
   } else {
     r = engine->Initialize(script->RequiredFeatures(),

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -66,17 +66,17 @@ Result Parser::ToShaderType(const std::string& str, ShaderType* type) {
   assert(type);
 
   if (str == "vertex")
-    *type = ShaderType::kVertex;
+    *type = kShaderTypeVertex;
   else if (str == "fragment")
-    *type = ShaderType::kFragment;
+    *type = kShaderTypeFragment;
   else if (str == "geometry")
-    *type = ShaderType::kGeometry;
+    *type = kShaderTypeGeometry;
   else if (str == "tessellation_evaluation")
-    *type = ShaderType::kTessellationEvaluation;
+    *type = kShaderTypeTessellationEvaluation;
   else if (str == "tessellation_control")
-    *type = ShaderType::kTessellationControl;
+    *type = kShaderTypeTessellationControl;
   else if (str == "compute")
-    *type = ShaderType::kCompute;
+    *type = kShaderTypeCompute;
   else
     return Result("unknown shader type: " + str);
   return {};
@@ -86,11 +86,11 @@ Result Parser::ToShaderFormat(const std::string& str, ShaderFormat* fmt) {
   assert(fmt);
 
   if (str == "GLSL")
-    *fmt = ShaderFormat::kGlsl;
+    *fmt = kShaderFormatGlsl;
   else if (str == "SPIRV-ASM")
-    *fmt = ShaderFormat::kSpirvAsm;
+    *fmt = kShaderFormatSpirvAsm;
   else if (str == "SPIRV-HEX")
-    *fmt = ShaderFormat::kSpirvHex;
+    *fmt = kShaderFormatSpirvHex;
   else
     return Result("unknown shader format: " + str);
   return {};
@@ -204,7 +204,7 @@ Result Parser::ParseShaderBlock() {
   if (!token->IsString())
     return Result("invalid token when looking for shader type");
 
-  ShaderType type = ShaderType::kVertex;
+  ShaderType type = kShaderTypeVertex;
   Result r = ToShaderType(token->AsString(), &type);
   if (!r.IsSuccess())
     return r;
@@ -223,12 +223,12 @@ Result Parser::ParseShaderBlock() {
 
   std::string fmt = token->AsString();
   if (fmt == "PASSTHROUGH") {
-    if (type != ShaderType::kVertex) {
+    if (type != kShaderTypeVertex) {
       return Result(
           "invalid shader type for PASSTHROUGH. Only vertex "
           "PASSTHROUGH allowed");
     }
-    shader->SetFormat(ShaderFormat::kSpirvAsm);
+    shader->SetFormat(kShaderFormatSpirvAsm);
     shader->SetData(kPassThroughShader);
 
     r = script_->AddShader(std::move(shader));
@@ -238,7 +238,7 @@ Result Parser::ParseShaderBlock() {
     return ValidateEndOfStatement("SHADER PASSTHROUGH");
   }
 
-  ShaderFormat format = ShaderFormat::kGlsl;
+  ShaderFormat format = kShaderFormatGlsl;
   r = ToShaderFormat(fmt, &format);
   if (!r.IsSuccess())
     return r;

--- a/src/amberscript/parser_test.cc
+++ b/src/amberscript/parser_test.cc
@@ -96,8 +96,8 @@ TEST_F(AmberScriptParserTest, ShaderPassThrough) {
 
   const auto* shader = shaders[0].get();
   EXPECT_EQ("my_shader1", shader->GetName());
-  EXPECT_EQ(ShaderType::kVertex, shader->GetType());
-  EXPECT_EQ(ShaderFormat::kSpirvAsm, shader->GetFormat());
+  EXPECT_EQ(kShaderTypeVertex, shader->GetType());
+  EXPECT_EQ(kShaderFormatSpirvAsm, shader->GetFormat());
   EXPECT_EQ(kPassThroughShader, shader->GetData());
 }
 
@@ -202,8 +202,8 @@ SHADER geometry shader_name GLSL
 
   const auto* shader = shaders[0].get();
   EXPECT_EQ("shader_name", shader->GetName());
-  EXPECT_EQ(ShaderType::kGeometry, shader->GetType());
-  EXPECT_EQ(ShaderFormat::kGlsl, shader->GetFormat());
+  EXPECT_EQ(kShaderTypeGeometry, shader->GetType());
+  EXPECT_EQ(kShaderFormatGlsl, shader->GetFormat());
   EXPECT_EQ(shader_result, shader->GetData());
 }
 
@@ -318,22 +318,21 @@ void main() {
   const auto* shader = shaders[0].get();
   EXPECT_EQ("my_shader", shader->GetName());
   EXPECT_EQ(test_data.type, shader->GetType());
-  EXPECT_EQ(ShaderFormat::kGlsl, shader->GetFormat());
+  EXPECT_EQ(kShaderFormatGlsl, shader->GetFormat());
   EXPECT_EQ(shader_result, shader->GetData());
 }
 INSTANTIATE_TEST_CASE_P(
     AmberScriptParserTestsShaderType,
     AmberScriptParserShaderTypeTest,
-    testing::Values(ShaderTypeData{"vertex", ShaderType::kVertex},
-                    ShaderTypeData{"fragment", ShaderType::kFragment},
-                    ShaderTypeData{"geometry", ShaderType::kGeometry},
-                    ShaderTypeData{"tessellation_evaluation",
-                                   ShaderType::kTessellationEvaluation},
-                    ShaderTypeData{"tessellation_control",
-                                   ShaderType::kTessellationControl},
-                    ShaderTypeData{
-                        "compute",
-                        ShaderType::kCompute}), );  // NOLINT(whitespace/parens)
+    testing::Values(
+        ShaderTypeData{"vertex", kShaderTypeVertex},
+        ShaderTypeData{"fragment", kShaderTypeFragment},
+        ShaderTypeData{"geometry", kShaderTypeGeometry},
+        ShaderTypeData{"tessellation_evaluation",
+                       kShaderTypeTessellationEvaluation},
+        ShaderTypeData{"tessellation_control", kShaderTypeTessellationControl},
+        ShaderTypeData{"compute",
+                       kShaderTypeCompute}), );  // NOLINT(whitespace/parens)
 
 using AmberScriptParserShaderFormatTest =
     testing::TestWithParam<ShaderFormatData>;
@@ -358,7 +357,7 @@ TEST_P(AmberScriptParserShaderFormatTest, ShaderFormats) {
 
   const auto* shader = shaders[0].get();
   EXPECT_EQ("my_shader", shader->GetName());
-  EXPECT_EQ(ShaderType::kVertex, shader->GetType());
+  EXPECT_EQ(kShaderTypeVertex, shader->GetType());
   EXPECT_EQ(test_data.format, shader->GetFormat());
   EXPECT_EQ(shader_result, shader->GetData());
 }
@@ -366,11 +365,11 @@ INSTANTIATE_TEST_CASE_P(
     AmberScriptParserTestsShaderFormat,
     AmberScriptParserShaderFormatTest,
     testing::Values(
-        ShaderFormatData{"GLSL", ShaderFormat::kGlsl},
-        ShaderFormatData{"SPIRV-ASM", ShaderFormat::kSpirvAsm},
+        ShaderFormatData{"GLSL", kShaderFormatGlsl},
+        ShaderFormatData{"SPIRV-ASM", kShaderFormatSpirvAsm},
         ShaderFormatData{
             "SPIRV-HEX",
-            ShaderFormat::kSpirvHex}), );  // NOLINT(whitespace/parens)
+            kShaderFormatSpirvHex}), );  // NOLINT(whitespace/parens)
 
 TEST_F(AmberScriptParserTest, DuplicateShaderName) {
   std::string in = R"(
@@ -419,13 +418,13 @@ END
 
   ASSERT_TRUE(shaders[0].GetShader() != nullptr);
   EXPECT_EQ("my_shader", shaders[0].GetShader()->GetName());
-  EXPECT_EQ(ShaderType::kVertex, shaders[0].GetShader()->GetType());
+  EXPECT_EQ(kShaderTypeVertex, shaders[0].GetShader()->GetType());
   EXPECT_EQ(static_cast<uint32_t>(0),
             shaders[0].GetShaderOptimizations().size());
 
   ASSERT_TRUE(shaders[1].GetShader() != nullptr);
   EXPECT_EQ("my_fragment", shaders[1].GetShader()->GetName());
-  EXPECT_EQ(ShaderType::kFragment, shaders[1].GetShader()->GetType());
+  EXPECT_EQ(kShaderTypeFragment, shaders[1].GetShader()->GetType());
   EXPECT_EQ(static_cast<uint32_t>(0),
             shaders[1].GetShaderOptimizations().size());
 }
@@ -640,14 +639,14 @@ INSTANTIATE_TEST_CASE_P(
     AmberScriptParserPipelineAttachTests,
     AmberScriptParserPipelineAttachTest,
     testing::Values(
-        ShaderTypeData{"vertex", ShaderType::kVertex},
-        ShaderTypeData{"fragment", ShaderType::kFragment},
-        ShaderTypeData{"geometry", ShaderType::kGeometry},
+        ShaderTypeData{"vertex", kShaderTypeVertex},
+        ShaderTypeData{"fragment", kShaderTypeFragment},
+        ShaderTypeData{"geometry", kShaderTypeGeometry},
         ShaderTypeData{"tessellation_evaluation",
-                       ShaderType::kTessellationEvaluation},
+                       kShaderTypeTessellationEvaluation},
         ShaderTypeData{
             "tessellation_control",
-            ShaderType::kTessellationControl}), );  // NOLINT(whitespace/parens)
+            kShaderTypeTessellationControl}), );  // NOLINT(whitespace/parens)
 
 TEST_F(AmberScriptParserTest, PipelineEntryPoint) {
   std::string in = R"(
@@ -677,11 +676,11 @@ END
   ASSERT_EQ(2U, shaders.size());
 
   ASSERT_TRUE(shaders[0].GetShader() != nullptr);
-  EXPECT_EQ(ShaderType::kVertex, shaders[0].GetShader()->GetType());
+  EXPECT_EQ(kShaderTypeVertex, shaders[0].GetShader()->GetType());
   EXPECT_EQ("green", shaders[0].GetEntryPoint());
 
   ASSERT_TRUE(shaders[1].GetShader() != nullptr);
-  EXPECT_EQ(ShaderType::kFragment, shaders[1].GetShader()->GetType());
+  EXPECT_EQ(kShaderTypeFragment, shaders[1].GetShader()->GetType());
   EXPECT_EQ("main", shaders[1].GetEntryPoint());
 }
 
@@ -823,17 +822,17 @@ END
   ASSERT_EQ(3U, shaders.size());
 
   ASSERT_TRUE(shaders[0].GetShader() != nullptr);
-  EXPECT_EQ(ShaderType::kVertex, shaders[0].GetShader()->GetType());
+  EXPECT_EQ(kShaderTypeVertex, shaders[0].GetShader()->GetType());
   std::vector<std::string> my_shader_opts = {"opt1", "opt_second"};
   EXPECT_EQ(my_shader_opts, shaders[0].GetShaderOptimizations());
 
   ASSERT_TRUE(shaders[1].GetShader() != nullptr);
-  EXPECT_EQ(ShaderType::kFragment, shaders[1].GetShader()->GetType());
+  EXPECT_EQ(kShaderTypeFragment, shaders[1].GetShader()->GetType());
   std::vector<std::string> my_fragment_opts = {"another_optimization", "third"};
   EXPECT_EQ(my_fragment_opts, shaders[1].GetShaderOptimizations());
 
   ASSERT_TRUE(shaders[2].GetShader() != nullptr);
-  EXPECT_EQ(ShaderType::kGeometry, shaders[2].GetShader()->GetType());
+  EXPECT_EQ(kShaderTypeGeometry, shaders[2].GetShader()->GetType());
   std::vector<std::string> my_geom_opts = {};
   EXPECT_EQ(my_geom_opts, shaders[2].GetShaderOptimizations());
 }

--- a/src/command.h
+++ b/src/command.h
@@ -443,7 +443,7 @@ class EntryPointCommand : public Command {
   std::string GetEntryPointName() const { return entry_point_name_; }
 
  private:
-  ShaderType shader_type_ = ShaderType::kVertex;
+  ShaderType shader_type_ = kShaderTypeVertex;
   std::string entry_point_name_;
 };
 

--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -209,7 +209,7 @@ Result EngineDawn::Shutdown() {
 Result EngineDawn::CreatePipeline(PipelineType type) {
   switch (type) {
     case PipelineType::kCompute: {
-      auto module = module_for_type_[ShaderType::kCompute];
+      auto module = module_for_type_[kShaderTypeCompute];
       if (!module)
         return Result("CreatePipeline: no compute shader provided");
       compute_pipeline_info_ = std::move(ComputePipelineInfo(module));
@@ -218,8 +218,8 @@ Result EngineDawn::CreatePipeline(PipelineType type) {
 
     case PipelineType::kGraphics: {
       // TODO(dneto): Handle other shader types as well.  They are optional.
-      auto vs = module_for_type_[ShaderType::kVertex];
-      auto fs = module_for_type_[ShaderType::kFragment];
+      auto vs = module_for_type_[kShaderTypeVertex];
+      auto fs = module_for_type_[kShaderTypeFragment];
       if (!vs) {
         return Result(
             "CreatePipeline: no vertex shader provided for graphics pipeline");

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -33,12 +33,12 @@ namespace amber {
 std::unique_ptr<Engine> Engine::Create(EngineType type) {
   std::unique_ptr<Engine> engine;
   switch (type) {
-    case EngineType::kVulkan:
+    case kEngineTypeVulkan:
 #if AMBER_ENGINE_VULKAN
       engine = MakeUnique<vulkan::EngineVulkan>();
 #endif  // AMBER_ENGINE_VULKAN
       break;
-    case EngineType::kDawn:
+    case kEngineTypeDawn:
 #if AMBER_ENGINE_DAWN
       engine = MakeUnique<dawn::EngineDawn>();
 #endif  // AMBER_ENGINE_DAWN

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -47,7 +47,7 @@ Result Executor::Execute(Engine* engine,
     if (!r.IsSuccess())
       return r;
 
-    if (shader->GetType() == ShaderType::kCompute)
+    if (shader->GetType() == kShaderTypeCompute)
       pipeline_type = PipelineType::kCompute;
   }
 

--- a/src/executor_test.cc
+++ b/src/executor_test.cc
@@ -457,8 +457,8 @@ void main() {}
 
   auto shader_types = ToStub(engine.get())->GetShaderTypesSeen();
   ASSERT_EQ(2U, shader_types.size());
-  EXPECT_EQ(ShaderType::kVertex, shader_types[0]);
-  EXPECT_EQ(ShaderType::kFragment, shader_types[1]);
+  EXPECT_EQ(kShaderTypeVertex, shader_types[0]);
+  EXPECT_EQ(kShaderTypeFragment, shader_types[1]);
 }
 
 TEST_F(VkScriptExecutorTest, ShaderFailure) {

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -35,11 +35,11 @@ Result Pipeline::AddShader(const Shader* shader) {
     return Result("shader can not be null when attached to pipeline");
 
   if (pipeline_type_ == PipelineType::kCompute &&
-      shader->GetType() != ShaderType::kCompute) {
+      shader->GetType() != kShaderTypeCompute) {
     return Result("only compute shaders allowed in a compute pipeline");
   }
   if (pipeline_type_ == PipelineType::kGraphics &&
-      shader->GetType() == ShaderType::kCompute) {
+      shader->GetType() == kShaderTypeCompute) {
     return Result("can not add a compute shader to a graphics pipeline");
   }
 
@@ -115,9 +115,9 @@ Result Pipeline::ValidateGraphics() const {
   bool found_fragment = false;
   for (const auto& info : shaders_) {
     const auto* is = info.GetShader();
-    if (is->GetType() == ShaderType::kVertex)
+    if (is->GetType() == kShaderTypeVertex)
       found_vertex = true;
-    if (is->GetType() == ShaderType::kFragment)
+    if (is->GetType() == kShaderTypeFragment)
       found_fragment = true;
     if (found_vertex && found_fragment)
       break;

--- a/src/pipeline_test.cc
+++ b/src/pipeline_test.cc
@@ -27,8 +27,8 @@ struct ShaderTypeData {
 using AmberScriptPipelineTest = testing::Test;
 
 TEST_F(AmberScriptPipelineTest, AddShader) {
-  Shader v(ShaderType::kVertex);
-  Shader f(ShaderType::kFragment);
+  Shader v(kShaderTypeVertex);
+  Shader f(kShaderTypeFragment);
 
   Pipeline p(PipelineType::kGraphics);
   Result r = p.AddShader(&v);
@@ -52,8 +52,8 @@ TEST_F(AmberScriptPipelineTest, MissingShader) {
 }
 
 TEST_F(AmberScriptPipelineTest, DuplicateShaders) {
-  Shader v(ShaderType::kVertex);
-  Shader f(ShaderType::kFragment);
+  Shader v(kShaderTypeVertex);
+  Shader f(kShaderTypeFragment);
 
   Pipeline p(PipelineType::kGraphics);
   Result r = p.AddShader(&v);
@@ -68,8 +68,8 @@ TEST_F(AmberScriptPipelineTest, DuplicateShaders) {
 }
 
 TEST_F(AmberScriptPipelineTest, DuplicateShaderType) {
-  Shader v(ShaderType::kVertex);
-  Shader f(ShaderType::kVertex);
+  Shader v(kShaderTypeVertex);
+  Shader f(kShaderTypeVertex);
 
   Pipeline p(PipelineType::kGraphics);
   Result r = p.AddShader(&v);
@@ -97,15 +97,15 @@ INSTANTIATE_TEST_CASE_P(
     AmberScriptPipelineComputePipelineTests,
     AmberScriptPipelineComputePipelineTest,
     testing::Values(
-        ShaderTypeData{ShaderType::kVertex},
-        ShaderTypeData{ShaderType::kFragment},
-        ShaderTypeData{ShaderType::kGeometry},
-        ShaderTypeData{ShaderType::kTessellationEvaluation},
+        ShaderTypeData{kShaderTypeVertex},
+        ShaderTypeData{kShaderTypeFragment},
+        ShaderTypeData{kShaderTypeGeometry},
+        ShaderTypeData{kShaderTypeTessellationEvaluation},
         ShaderTypeData{
-            ShaderType::kTessellationControl}), );  // NOLINT(whitespace/parens)
+            kShaderTypeTessellationControl}), );  // NOLINT(whitespace/parens)
 
 TEST_F(AmberScriptPipelineTest, SettingComputeShaderToGraphicsPipeline) {
-  Shader c(ShaderType::kCompute);
+  Shader c(kShaderTypeCompute);
 
   Pipeline p(PipelineType::kGraphics);
   Result r = p.AddShader(&c);
@@ -114,8 +114,8 @@ TEST_F(AmberScriptPipelineTest, SettingComputeShaderToGraphicsPipeline) {
 }
 
 TEST_F(AmberScriptPipelineTest, SetShaderOptimizations) {
-  Shader v(ShaderType::kVertex);
-  Shader f(ShaderType::kFragment);
+  Shader v(kShaderTypeVertex);
+  Shader f(kShaderTypeFragment);
 
   Pipeline p(PipelineType::kGraphics);
   Result r = p.AddShader(&v);
@@ -140,7 +140,7 @@ TEST_F(AmberScriptPipelineTest, SetShaderOptimizations) {
 }
 
 TEST_F(AmberScriptPipelineTest, DuplicateShaderOptimizations) {
-  Shader v(ShaderType::kVertex);
+  Shader v(kShaderTypeVertex);
 
   Pipeline p(PipelineType::kGraphics);
   Result r = p.AddShader(&v);
@@ -160,7 +160,7 @@ TEST_F(AmberScriptPipelineTest, SetOptimizationForMissingShader) {
 }
 
 TEST_F(AmberScriptPipelineTest, SetOptimizationForInvalidShader) {
-  Shader v(ShaderType::kVertex);
+  Shader v(kShaderTypeVertex);
   v.SetName("my_shader");
 
   Pipeline p(PipelineType::kGraphics);
@@ -171,9 +171,9 @@ TEST_F(AmberScriptPipelineTest, SetOptimizationForInvalidShader) {
 
 TEST_F(AmberScriptPipelineTest,
        GraphicsPipelineRequiresVertexAndFragmentShader) {
-  Shader v(ShaderType::kVertex);
-  Shader f(ShaderType::kFragment);
-  Shader g(ShaderType::kGeometry);
+  Shader v(kShaderTypeVertex);
+  Shader f(kShaderTypeFragment);
+  Shader g(kShaderTypeGeometry);
 
   Pipeline p(PipelineType::kGraphics);
   Result r = p.AddShader(&v);
@@ -190,8 +190,8 @@ TEST_F(AmberScriptPipelineTest,
 }
 
 TEST_F(AmberScriptPipelineTest, GraphicsPipelineMissingFragmentShader) {
-  Shader v(ShaderType::kVertex);
-  Shader g(ShaderType::kGeometry);
+  Shader v(kShaderTypeVertex);
+  Shader g(kShaderTypeGeometry);
 
   Pipeline p(PipelineType::kGraphics);
   Result r = p.AddShader(&v);
@@ -206,8 +206,8 @@ TEST_F(AmberScriptPipelineTest, GraphicsPipelineMissingFragmentShader) {
 }
 
 TEST_F(AmberScriptPipelineTest, GraphicsPipelineMissingVertexShader) {
-  Shader f(ShaderType::kFragment);
-  Shader g(ShaderType::kGeometry);
+  Shader f(kShaderTypeFragment);
+  Shader g(kShaderTypeGeometry);
 
   Pipeline p(PipelineType::kGraphics);
   Result r = p.AddShader(&g);
@@ -223,7 +223,7 @@ TEST_F(AmberScriptPipelineTest, GraphicsPipelineMissingVertexShader) {
 
 TEST_F(AmberScriptPipelineTest,
        GraphicsPipelineMissingVertexAndFragmentShader) {
-  Shader g(ShaderType::kGeometry);
+  Shader g(kShaderTypeGeometry);
 
   Pipeline p(PipelineType::kGraphics);
   Result r = p.AddShader(&g);
@@ -244,7 +244,7 @@ TEST_F(AmberScriptPipelineTest, GraphicsPipelineWihoutShaders) {
 }
 
 TEST_F(AmberScriptPipelineTest, ComputePipelineRequiresComputeShader) {
-  Shader c(ShaderType::kCompute);
+  Shader c(kShaderTypeCompute);
 
   Pipeline p(PipelineType::kCompute);
   Result r = p.AddShader(&c);
@@ -262,7 +262,7 @@ TEST_F(AmberScriptPipelineTest, ComputePipelineWithoutShader) {
 }
 
 TEST_F(AmberScriptPipelineTest, SetEntryPointForMissingShader) {
-  Shader c(ShaderType::kCompute);
+  Shader c(kShaderTypeCompute);
   c.SetName("my_shader");
 
   Pipeline p(PipelineType::kCompute);
@@ -279,7 +279,7 @@ TEST_F(AmberScriptPipelineTest, SetEntryPointForNullShader) {
 }
 
 TEST_F(AmberScriptPipelineTest, SetBlankEntryPoint) {
-  Shader c(ShaderType::kCompute);
+  Shader c(kShaderTypeCompute);
   Pipeline p(PipelineType::kCompute);
   Result r = p.AddShader(&c);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
@@ -290,7 +290,7 @@ TEST_F(AmberScriptPipelineTest, SetBlankEntryPoint) {
 }
 
 TEST_F(AmberScriptPipelineTest, ShaderDefaultEntryPoint) {
-  Shader c(ShaderType::kCompute);
+  Shader c(kShaderTypeCompute);
   Pipeline p(PipelineType::kCompute);
   Result r = p.AddShader(&c);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
@@ -301,7 +301,7 @@ TEST_F(AmberScriptPipelineTest, ShaderDefaultEntryPoint) {
 }
 
 TEST_F(AmberScriptPipelineTest, SetShaderEntryPoint) {
-  Shader c(ShaderType::kCompute);
+  Shader c(kShaderTypeCompute);
   Pipeline p(PipelineType::kCompute);
   Result r = p.AddShader(&c);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
@@ -315,7 +315,7 @@ TEST_F(AmberScriptPipelineTest, SetShaderEntryPoint) {
 }
 
 TEST_F(AmberScriptPipelineTest, SetEntryPointMulitpleTimes) {
-  Shader c(ShaderType::kCompute);
+  Shader c(kShaderTypeCompute);
   Pipeline p(PipelineType::kCompute);
   Result r = p.AddShader(&c);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();

--- a/src/recipe.cc
+++ b/src/recipe.cc
@@ -21,7 +21,9 @@ RecipeImpl::~RecipeImpl() = default;
 
 Recipe::Recipe() = default;
 
-Recipe::~Recipe() = default;
+Recipe::~Recipe() {
+  delete impl_;
+}
 
 std::vector<ShaderInfo> Recipe::GetShaderInfo() const {
   if (!impl_)

--- a/src/script_test.cc
+++ b/src/script_test.cc
@@ -36,15 +36,15 @@ using ScriptTest = testing::Test;
 TEST_F(ScriptTest, GetShaderInfo) {
   ScriptProxy sp;
 
-  auto shader = MakeUnique<Shader>(ShaderType::kVertex);
+  auto shader = MakeUnique<Shader>(kShaderTypeVertex);
   shader->SetName("Shader1");
-  shader->SetFormat(ShaderFormat::kGlsl);
+  shader->SetFormat(kShaderFormatGlsl);
   shader->SetData("This is my shader data");
   sp.AddShader(std::move(shader));
 
-  shader = MakeUnique<Shader>(ShaderType::kFragment);
+  shader = MakeUnique<Shader>(kShaderTypeFragment);
   shader->SetName("Shader2");
-  shader->SetFormat(ShaderFormat::kSpirvAsm);
+  shader->SetFormat(kShaderFormatSpirvAsm);
   shader->SetData("More shader data");
   sp.AddShader(std::move(shader));
 
@@ -52,14 +52,14 @@ TEST_F(ScriptTest, GetShaderInfo) {
   ASSERT_EQ(2U, info.size());
 
   EXPECT_EQ("Shader1", info[0].shader_name);
-  EXPECT_EQ(ShaderFormat::kGlsl, info[0].format);
-  EXPECT_EQ(ShaderType::kVertex, info[0].type);
+  EXPECT_EQ(kShaderFormatGlsl, info[0].format);
+  EXPECT_EQ(kShaderTypeVertex, info[0].type);
   EXPECT_EQ("This is my shader data", info[0].shader_source);
   EXPECT_TRUE(info[0].optimizations.empty());
 
   EXPECT_EQ("Shader2", info[1].shader_name);
-  EXPECT_EQ(ShaderFormat::kSpirvAsm, info[1].format);
-  EXPECT_EQ(ShaderType::kFragment, info[1].type);
+  EXPECT_EQ(kShaderFormatSpirvAsm, info[1].format);
+  EXPECT_EQ(kShaderTypeFragment, info[1].type);
   EXPECT_EQ("More shader data", info[1].shader_source);
   EXPECT_TRUE(info[1].optimizations.empty());
 }
@@ -71,7 +71,7 @@ TEST_F(ScriptTest, GetShaderInfoNoShaders) {
 }
 
 TEST_F(ScriptTest, AddShader) {
-  auto shader = MakeUnique<Shader>(ShaderType::kVertex);
+  auto shader = MakeUnique<Shader>(kShaderTypeVertex);
   shader->SetName("My Shader");
 
   Script s;
@@ -80,14 +80,14 @@ TEST_F(ScriptTest, AddShader) {
 }
 
 TEST_F(ScriptTest, AddDuplicateShader) {
-  auto shader1 = MakeUnique<Shader>(ShaderType::kVertex);
+  auto shader1 = MakeUnique<Shader>(kShaderTypeVertex);
   shader1->SetName("My Shader");
 
   Script s;
   Result r = s.AddShader(std::move(shader1));
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto shader2 = MakeUnique<Shader>(ShaderType::kFragment);
+  auto shader2 = MakeUnique<Shader>(kShaderTypeFragment);
   shader2->SetName("My Shader");
 
   r = s.AddShader(std::move(shader2));
@@ -96,7 +96,7 @@ TEST_F(ScriptTest, AddDuplicateShader) {
 }
 
 TEST_F(ScriptTest, GetShader) {
-  auto shader = MakeUnique<Shader>(ShaderType::kVertex);
+  auto shader = MakeUnique<Shader>(kShaderTypeVertex);
   shader->SetName("My Shader");
 
   auto* ptr = shader.get();
@@ -120,7 +120,7 @@ TEST_F(ScriptTest, GetShadersEmpty) {
 }
 
 TEST_F(ScriptTest, GetShaders) {
-  auto shader1 = MakeUnique<Shader>(ShaderType::kVertex);
+  auto shader1 = MakeUnique<Shader>(kShaderTypeVertex);
   shader1->SetName("My Shader");
 
   const auto* ptr1 = shader1.get();
@@ -129,7 +129,7 @@ TEST_F(ScriptTest, GetShaders) {
   Result r = s.AddShader(std::move(shader1));
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto shader2 = MakeUnique<Shader>(ShaderType::kFragment);
+  auto shader2 = MakeUnique<Shader>(kShaderTypeFragment);
   shader2->SetName("My Fragment");
 
   const auto* ptr2 = shader2.get();

--- a/src/shader_compiler.cc
+++ b/src/shader_compiler.cc
@@ -77,20 +77,20 @@ std::pair<Result, std::vector<uint32_t>> ShaderCompiler::Compile(
 
   std::vector<uint32_t> results;
 
-  if (shader->GetFormat() == ShaderFormat::kSpirvHex) {
+  if (shader->GetFormat() == kShaderFormatSpirvHex) {
     Result r = ParseHex(shader->GetData(), &results);
     if (!r.IsSuccess())
       return {Result("Unable to parse shader hex."), {}};
 
 #if AMBER_ENABLE_SHADERC
-  } else if (shader->GetFormat() == ShaderFormat::kGlsl) {
+  } else if (shader->GetFormat() == kShaderFormatGlsl) {
     Result r = CompileGlsl(shader, &results);
     if (!r.IsSuccess())
       return {r, {}};
 #endif  // AMBER_ENABLE_SHADERC
 
 #if AMBER_ENABLE_SPIRV_TOOLS
-  } else if (shader->GetFormat() == ShaderFormat::kSpirvAsm) {
+  } else if (shader->GetFormat() == kShaderFormatSpirvAsm) {
     if (!tools.Assemble(shader->GetData(), &results,
                         spvtools::SpirvTools::kDefaultAssembleOption)) {
       return {Result("Shader assembly failed: " + spv_errors), {}};
@@ -143,17 +143,17 @@ Result ShaderCompiler::CompileGlsl(Shader* shader,
   shaderc::CompileOptions options;
 
   shaderc_shader_kind kind;
-  if (shader->GetType() == ShaderType::kCompute)
+  if (shader->GetType() == kShaderTypeCompute)
     kind = shaderc_compute_shader;
-  else if (shader->GetType() == ShaderType::kFragment)
+  else if (shader->GetType() == kShaderTypeFragment)
     kind = shaderc_fragment_shader;
-  else if (shader->GetType() == ShaderType::kGeometry)
+  else if (shader->GetType() == kShaderTypeGeometry)
     kind = shaderc_geometry_shader;
-  else if (shader->GetType() == ShaderType::kVertex)
+  else if (shader->GetType() == kShaderTypeVertex)
     kind = shaderc_vertex_shader;
-  else if (shader->GetType() == ShaderType::kTessellationControl)
+  else if (shader->GetType() == kShaderTypeTessellationControl)
     kind = shaderc_tess_control_shader;
-  else if (shader->GetType() == ShaderType::kTessellationEvaluation)
+  else if (shader->GetType() == kShaderTypeTessellationEvaluation)
     kind = shaderc_tess_evaluation_shader;
   else
     return Result("Unknown shader type");

--- a/src/shader_compiler_test.cc
+++ b/src/shader_compiler_test.cc
@@ -92,9 +92,9 @@ void main() {
   gl_Position = position;
 })";
 
-  Shader shader(ShaderType::kVertex);
+  Shader shader(kShaderTypeVertex);
   shader.SetName("TestShader");
-  shader.SetFormat(ShaderFormat::kGlsl);
+  shader.SetFormat(kShaderFormatGlsl);
   shader.SetData(contents);
 
   ShaderCompiler sc;
@@ -109,9 +109,9 @@ void main() {
 
 #if AMBER_ENABLE_SPIRV_TOOLS
 TEST_F(ShaderCompilerTest, CompilesSpirvAsm) {
-  Shader shader(ShaderType::kVertex);
+  Shader shader(kShaderTypeVertex);
   shader.SetName("TestShader");
-  shader.SetFormat(ShaderFormat::kSpirvAsm);
+  shader.SetFormat(kShaderFormatSpirvAsm);
   shader.SetData(kPassThroughShader);
 
   ShaderCompiler sc;
@@ -127,9 +127,9 @@ TEST_F(ShaderCompilerTest, InvalidSpirvHex) {
   std::string contents = kHexShader;
   contents[3] = '0';
 
-  Shader shader(ShaderType::kVertex);
+  Shader shader(kShaderTypeVertex);
   shader.SetName("BadTestShader");
-  shader.SetFormat(ShaderFormat::kSpirvHex);
+  shader.SetFormat(kShaderFormatSpirvHex);
   shader.SetData(contents);
 
   ShaderCompiler sc;
@@ -142,9 +142,9 @@ TEST_F(ShaderCompilerTest, InvalidSpirvHex) {
 }
 
 TEST_F(ShaderCompilerTest, InvalidHex) {
-  Shader shader(ShaderType::kVertex);
+  Shader shader(kShaderTypeVertex);
   shader.SetName("BadTestShader");
-  shader.SetFormat(ShaderFormat::kSpirvHex);
+  shader.SetFormat(kShaderFormatSpirvHex);
   shader.SetData("aaaaaaaaaa");
 
   ShaderCompiler sc;
@@ -158,9 +158,9 @@ TEST_F(ShaderCompilerTest, InvalidHex) {
 #endif  // AMBER_ENABLE_SPIRV_TOOLS
 
 TEST_F(ShaderCompilerTest, CompilesSpirvHex) {
-  Shader shader(ShaderType::kVertex);
+  Shader shader(kShaderTypeVertex);
   shader.SetName("TestShader");
-  shader.SetFormat(ShaderFormat::kSpirvHex);
+  shader.SetFormat(kShaderFormatSpirvHex);
   shader.SetData(kHexShader);
 
   ShaderCompiler sc;
@@ -175,9 +175,9 @@ TEST_F(ShaderCompilerTest, CompilesSpirvHex) {
 TEST_F(ShaderCompilerTest, FailsOnInvalidShader) {
   std::string contents = "Just Random\nText()\nThat doesn't work.";
 
-  Shader shader(ShaderType::kVertex);
+  Shader shader(kShaderTypeVertex);
   shader.SetName("BadTestShader");
-  shader.SetFormat(ShaderFormat::kGlsl);
+  shader.SetFormat(kShaderFormatGlsl);
   shader.SetData(contents);
 
   ShaderCompiler sc;
@@ -193,9 +193,9 @@ TEST_F(ShaderCompilerTest, ReturnsCachedShader) {
   std::string contents = "Just Random\nText()\nThat doesn't work.";
 
   static const char kShaderName[] = "CachedShader";
-  Shader shader(ShaderType::kVertex);
+  Shader shader(kShaderTypeVertex);
   shader.SetName(kShaderName);
-  shader.SetFormat(ShaderFormat::kGlsl);
+  shader.SetFormat(kShaderFormatGlsl);
   shader.SetData(contents);
 
   std::vector<uint32_t> src_bytes = {1, 2, 3, 4, 5};

--- a/src/vkscript/command_parser.cc
+++ b/src/vkscript/command_parser.cc
@@ -32,17 +32,17 @@ namespace {
 
 ShaderType ShaderNameToType(const std::string& name) {
   if (name == "fragment")
-    return ShaderType::kFragment;
+    return kShaderTypeFragment;
   if (name == "compute")
-    return ShaderType::kCompute;
+    return kShaderTypeCompute;
   if (name == "geometry")
-    return ShaderType::kGeometry;
+    return kShaderTypeGeometry;
   if (name == "tessellation evaluation")
-    return ShaderType::kTessellationEvaluation;
+    return kShaderTypeTessellationEvaluation;
   if (name == "tessellation control")
-    return ShaderType::kTessellationControl;
+    return kShaderTypeTessellationControl;
 
-  return ShaderType::kVertex;
+  return kShaderTypeVertex;
 }
 
 }  // namespace

--- a/src/vkscript/command_parser_test.cc
+++ b/src/vkscript/command_parser_test.cc
@@ -618,12 +618,12 @@ struct EntryInfo {
   ShaderType type;
 };
 static const EntryInfo kEntryPoints[] = {
-    {"vertex", ShaderType::kVertex},
-    {"fragment", ShaderType::kFragment},
-    {"geometry", ShaderType::kGeometry},
-    {"compute", ShaderType::kCompute},
-    {"tessellation evaluation", ShaderType::kTessellationEvaluation},
-    {"tessellation control", ShaderType::kTessellationControl},
+    {"vertex", kShaderTypeVertex},
+    {"fragment", kShaderTypeFragment},
+    {"geometry", kShaderTypeGeometry},
+    {"compute", kShaderTypeCompute},
+    {"tessellation evaluation", kShaderTypeTessellationEvaluation},
+    {"tessellation control", kShaderTypeTessellationControl},
 };
 
 TEST_F(CommandParserTest, EntryPoint) {

--- a/src/vkscript/section_parser.cc
+++ b/src/vkscript/section_parser.cc
@@ -49,17 +49,17 @@ Result SectionParser::NameToNodeType(const std::string& data,
   assert(shader_type);
   assert(fmt);
 
-  *fmt = ShaderFormat::kText;
+  *fmt = kShaderFormatText;
 
   std::string name;
   size_t pos = data.rfind(" spirv hex");
   if (pos != std::string::npos) {
-    *fmt = ShaderFormat::kSpirvHex;
+    *fmt = kShaderFormatSpirvHex;
     name = data.substr(0, pos);
   } else {
     pos = data.rfind(" spirv");
     if (pos != std::string::npos) {
-      *fmt = ShaderFormat::kSpirvAsm;
+      *fmt = kShaderFormatSpirvAsm;
       name = data.substr(0, pos);
     } else {
       name = data;
@@ -68,7 +68,7 @@ Result SectionParser::NameToNodeType(const std::string& data,
 
   pos = data.rfind(" passthrough");
   if (pos != std::string::npos) {
-    *fmt = ShaderFormat::kDefault;
+    *fmt = kShaderFormatDefault;
     name = data.substr(0, pos);
   }
 
@@ -84,41 +84,41 @@ Result SectionParser::NameToNodeType(const std::string& data,
     *section_type = NodeType::kVertexData;
   } else if (name == "compute shader") {
     *section_type = NodeType::kShader;
-    *shader_type = ShaderType::kCompute;
-    if (*fmt == ShaderFormat::kText)
-      *fmt = ShaderFormat::kGlsl;
+    *shader_type = kShaderTypeCompute;
+    if (*fmt == kShaderFormatText)
+      *fmt = kShaderFormatGlsl;
   } else if (name == "fragment shader") {
     *section_type = NodeType::kShader;
-    *shader_type = ShaderType::kFragment;
-    if (*fmt == ShaderFormat::kText)
-      *fmt = ShaderFormat::kGlsl;
+    *shader_type = kShaderTypeFragment;
+    if (*fmt == kShaderFormatText)
+      *fmt = kShaderFormatGlsl;
   } else if (name == "geometry shader") {
     *section_type = NodeType::kShader;
-    *shader_type = ShaderType::kGeometry;
-    if (*fmt == ShaderFormat::kText)
-      *fmt = ShaderFormat::kGlsl;
+    *shader_type = kShaderTypeGeometry;
+    if (*fmt == kShaderFormatText)
+      *fmt = kShaderFormatGlsl;
   } else if (name == "tessellation control shader") {
     *section_type = NodeType::kShader;
-    *shader_type = ShaderType::kTessellationControl;
-    if (*fmt == ShaderFormat::kText)
-      *fmt = ShaderFormat::kGlsl;
+    *shader_type = kShaderTypeTessellationControl;
+    if (*fmt == kShaderFormatText)
+      *fmt = kShaderFormatGlsl;
   } else if (name == "tessellation evaluation shader") {
     *section_type = NodeType::kShader;
-    *shader_type = ShaderType::kTessellationEvaluation;
-    if (*fmt == ShaderFormat::kText)
-      *fmt = ShaderFormat::kGlsl;
+    *shader_type = kShaderTypeTessellationEvaluation;
+    if (*fmt == kShaderFormatText)
+      *fmt = kShaderFormatGlsl;
   } else if (name == "vertex shader") {
     *section_type = NodeType::kShader;
-    *shader_type = ShaderType::kVertex;
-    if (*fmt == ShaderFormat::kText)
-      *fmt = ShaderFormat::kGlsl;
+    *shader_type = kShaderTypeVertex;
+    if (*fmt == kShaderFormatText)
+      *fmt = kShaderFormatGlsl;
   } else {
     return Result("Invalid name: " + data);
   }
 
   if (!SectionParser::HasShader(*section_type) &&
-      (*fmt == ShaderFormat::kGlsl || *fmt == ShaderFormat::kSpirvAsm ||
-       *fmt == ShaderFormat::kSpirvHex)) {
+      (*fmt == kShaderFormatGlsl || *fmt == kShaderFormatSpirvAsm ||
+       *fmt == kShaderFormatSpirvHex)) {
     return Result("Invalid source format: " + data);
   }
 
@@ -133,8 +133,8 @@ void SectionParser::AddSection(NodeType section_type,
   if (section_type == NodeType::kComment)
     return;
 
-  if (fmt == ShaderFormat::kDefault) {
-    sections_.push_back({section_type, shader_type, ShaderFormat::kSpirvAsm,
+  if (fmt == kShaderFormatDefault) {
+    sections_.push_back({section_type, shader_type, kShaderFormatSpirvAsm,
                          line_count, kPassThroughShader});
     return;
   }
@@ -159,8 +159,8 @@ Result SectionParser::SplitSections(const std::string& data) {
   bool in_section = false;
 
   NodeType current_type = NodeType::kComment;
-  ShaderType current_shader = ShaderType::kVertex;
-  ShaderFormat current_fmt = ShaderFormat::kText;
+  ShaderType current_shader = kShaderTypeVertex;
+  ShaderFormat current_fmt = kShaderFormatText;
   std::string section_contents;
 
   for (std::string line; std::getline(ss, line);) {

--- a/src/vkscript/section_parser_test.cc
+++ b/src/vkscript/section_parser_test.cc
@@ -45,8 +45,8 @@ void main() {
   auto sections = p.Sections();
   ASSERT_EQ(1U, sections.size());
   EXPECT_EQ(NodeType::kShader, sections[0].section_type);
-  EXPECT_EQ(ShaderType::kVertex, sections[0].shader_type);
-  EXPECT_EQ(ShaderFormat::kGlsl, sections[0].format);
+  EXPECT_EQ(kShaderTypeVertex, sections[0].shader_type);
+  EXPECT_EQ(kShaderFormatGlsl, sections[0].format);
   EXPECT_EQ(shader, sections[0].contents);
 }
 
@@ -60,8 +60,8 @@ TEST_F(SectionParserTest, ParseShaderGlslVertexPassthrough) {
   auto sections = p.Sections();
   ASSERT_EQ(1U, sections.size());
   EXPECT_EQ(NodeType::kShader, sections[0].section_type);
-  EXPECT_EQ(ShaderType::kVertex, sections[0].shader_type);
-  EXPECT_EQ(ShaderFormat::kSpirvAsm, sections[0].format);
+  EXPECT_EQ(kShaderTypeVertex, sections[0].shader_type);
+  EXPECT_EQ(kShaderFormatSpirvAsm, sections[0].format);
   EXPECT_EQ(kPassThroughShader, sections[0].contents);
 }
 
@@ -97,30 +97,30 @@ test body.)";
 
   // Passthrough vertext shader
   EXPECT_EQ(NodeType::kShader, sections[0].section_type);
-  EXPECT_EQ(ShaderType::kVertex, sections[0].shader_type);
-  EXPECT_EQ(ShaderFormat::kSpirvAsm, sections[0].format);
+  EXPECT_EQ(kShaderTypeVertex, sections[0].shader_type);
+  EXPECT_EQ(kShaderFormatSpirvAsm, sections[0].format);
   EXPECT_EQ(kPassThroughShader, sections[0].contents);
 
   // fragment shader
   EXPECT_EQ(NodeType::kShader, sections[1].section_type);
-  EXPECT_EQ(ShaderType::kFragment, sections[1].shader_type);
-  EXPECT_EQ(ShaderFormat::kGlsl, sections[1].format);
+  EXPECT_EQ(kShaderTypeFragment, sections[1].shader_type);
+  EXPECT_EQ(kShaderFormatGlsl, sections[1].format);
   EXPECT_EQ("#version 430\nvoid main() {}", sections[1].contents);
 
   // geometry shader
   EXPECT_EQ(NodeType::kShader, sections[2].section_type);
-  EXPECT_EQ(ShaderType::kGeometry, sections[2].shader_type);
-  EXPECT_EQ(ShaderFormat::kGlsl, sections[2].format);
+  EXPECT_EQ(kShaderTypeGeometry, sections[2].shader_type);
+  EXPECT_EQ(kShaderFormatGlsl, sections[2].format);
   EXPECT_EQ("float4 main() {}", sections[2].contents);
 
   // indices
   EXPECT_EQ(NodeType::kIndices, sections[3].section_type);
-  EXPECT_EQ(ShaderFormat::kText, sections[3].format);
+  EXPECT_EQ(kShaderFormatText, sections[3].format);
   EXPECT_EQ("1 2 3 4\n5 6 7 8", sections[3].contents);
 
   // test
   EXPECT_EQ(NodeType::kTest, sections[4].section_type);
-  EXPECT_EQ(ShaderFormat::kText, sections[4].format);
+  EXPECT_EQ(kShaderFormatText, sections[4].format);
   EXPECT_EQ("test body.", sections[4].contents);
 }
 
@@ -134,8 +134,8 @@ TEST_F(SectionParserTest, SkipCommentLinesOutsideSections) {
   auto sections = p.Sections();
   ASSERT_EQ(1U, sections.size());
   EXPECT_EQ(NodeType::kShader, sections[0].section_type);
-  EXPECT_EQ(ShaderType::kVertex, sections[0].shader_type);
-  EXPECT_EQ(ShaderFormat::kGlsl, sections[0].format);
+  EXPECT_EQ(kShaderTypeVertex, sections[0].shader_type);
+  EXPECT_EQ(kShaderFormatGlsl, sections[0].format);
   EXPECT_EQ("", sections[0].contents);
 }
 
@@ -149,8 +149,8 @@ TEST_F(SectionParserTest, SkipBlankLinesOutsideSections) {
   auto sections = p.Sections();
   ASSERT_EQ(1U, sections.size());
   EXPECT_EQ(NodeType::kShader, sections[0].section_type);
-  EXPECT_EQ(ShaderType::kVertex, sections[0].shader_type);
-  EXPECT_EQ(ShaderFormat::kGlsl, sections[0].format);
+  EXPECT_EQ(kShaderTypeVertex, sections[0].shader_type);
+  EXPECT_EQ(kShaderFormatGlsl, sections[0].format);
   EXPECT_EQ("", sections[0].contents);
 }
 
@@ -188,56 +188,56 @@ TEST_F(SectionParserTest, NameToNodeType) {
     ShaderType shader_type;
     ShaderFormat fmt;
   } name_cases[] = {
-      {"comment", NodeType::kComment, ShaderType::kVertex, ShaderFormat::kText},
-      {"indices", NodeType::kIndices, ShaderType::kVertex, ShaderFormat::kText},
-      {"require", NodeType::kRequire, ShaderType::kVertex, ShaderFormat::kText},
-      {"test", NodeType::kTest, ShaderType::kVertex, ShaderFormat::kText},
-      {"vertex data", NodeType::kVertexData, ShaderType::kVertex,
-       ShaderFormat::kText},
+      {"comment", NodeType::kComment, kShaderTypeVertex, kShaderFormatText},
+      {"indices", NodeType::kIndices, kShaderTypeVertex, kShaderFormatText},
+      {"require", NodeType::kRequire, kShaderTypeVertex, kShaderFormatText},
+      {"test", NodeType::kTest, kShaderTypeVertex, kShaderFormatText},
+      {"vertex data", NodeType::kVertexData, kShaderTypeVertex,
+       kShaderFormatText},
 
-      {"compute shader", NodeType::kShader, ShaderType::kCompute,
-       ShaderFormat::kGlsl},
-      {"fragment shader", NodeType::kShader, ShaderType::kFragment,
-       ShaderFormat::kGlsl},
-      {"geometry shader", NodeType::kShader, ShaderType::kGeometry,
-       ShaderFormat::kGlsl},
+      {"compute shader", NodeType::kShader, kShaderTypeCompute,
+       kShaderFormatGlsl},
+      {"fragment shader", NodeType::kShader, kShaderTypeFragment,
+       kShaderFormatGlsl},
+      {"geometry shader", NodeType::kShader, kShaderTypeGeometry,
+       kShaderFormatGlsl},
       {"tessellation control shader", NodeType::kShader,
-       ShaderType::kTessellationControl, ShaderFormat::kGlsl},
+       kShaderTypeTessellationControl, kShaderFormatGlsl},
       {"tessellation evaluation shader", NodeType::kShader,
-       ShaderType::kTessellationEvaluation, ShaderFormat::kGlsl},
-      {"vertex shader", NodeType::kShader, ShaderType::kVertex,
-       ShaderFormat::kGlsl},
-      {"compute shader spirv", NodeType::kShader, ShaderType::kCompute,
-       ShaderFormat::kSpirvAsm},
-      {"fragment shader spirv", NodeType::kShader, ShaderType::kFragment,
-       ShaderFormat::kSpirvAsm},
-      {"geometry shader spirv", NodeType::kShader, ShaderType::kGeometry,
-       ShaderFormat::kSpirvAsm},
+       kShaderTypeTessellationEvaluation, kShaderFormatGlsl},
+      {"vertex shader", NodeType::kShader, kShaderTypeVertex,
+       kShaderFormatGlsl},
+      {"compute shader spirv", NodeType::kShader, kShaderTypeCompute,
+       kShaderFormatSpirvAsm},
+      {"fragment shader spirv", NodeType::kShader, kShaderTypeFragment,
+       kShaderFormatSpirvAsm},
+      {"geometry shader spirv", NodeType::kShader, kShaderTypeGeometry,
+       kShaderFormatSpirvAsm},
       {"tessellation control shader spirv", NodeType::kShader,
-       ShaderType::kTessellationControl, ShaderFormat::kSpirvAsm},
+       kShaderTypeTessellationControl, kShaderFormatSpirvAsm},
       {"tessellation evaluation shader spirv", NodeType::kShader,
-       ShaderType::kTessellationEvaluation, ShaderFormat::kSpirvAsm},
-      {"vertex shader spirv", NodeType::kShader, ShaderType::kVertex,
-       ShaderFormat::kSpirvAsm},
-      {"compute shader spirv hex", NodeType::kShader, ShaderType::kCompute,
-       ShaderFormat::kSpirvHex},
-      {"fragment shader spirv hex", NodeType::kShader, ShaderType::kFragment,
-       ShaderFormat::kSpirvHex},
-      {"geometry shader spirv hex", NodeType::kShader, ShaderType::kGeometry,
-       ShaderFormat::kSpirvHex},
+       kShaderTypeTessellationEvaluation, kShaderFormatSpirvAsm},
+      {"vertex shader spirv", NodeType::kShader, kShaderTypeVertex,
+       kShaderFormatSpirvAsm},
+      {"compute shader spirv hex", NodeType::kShader, kShaderTypeCompute,
+       kShaderFormatSpirvHex},
+      {"fragment shader spirv hex", NodeType::kShader, kShaderTypeFragment,
+       kShaderFormatSpirvHex},
+      {"geometry shader spirv hex", NodeType::kShader, kShaderTypeGeometry,
+       kShaderFormatSpirvHex},
       {"tessellation control shader spirv hex", NodeType::kShader,
-       ShaderType::kTessellationControl, ShaderFormat::kSpirvHex},
+       kShaderTypeTessellationControl, kShaderFormatSpirvHex},
       {"tessellation evaluation shader spirv hex", NodeType::kShader,
-       ShaderType::kTessellationEvaluation, ShaderFormat::kSpirvHex},
-      {"vertex shader spirv hex", NodeType::kShader, ShaderType::kVertex,
-       ShaderFormat::kSpirvHex},
-      {"vertex shader passthrough", NodeType::kShader, ShaderType::kVertex,
-       ShaderFormat::kDefault}};
+       kShaderTypeTessellationEvaluation, kShaderFormatSpirvHex},
+      {"vertex shader spirv hex", NodeType::kShader, kShaderTypeVertex,
+       kShaderFormatSpirvHex},
+      {"vertex shader passthrough", NodeType::kShader, kShaderTypeVertex,
+       kShaderFormatDefault}};
 
   for (auto name_case : name_cases) {
     NodeType section_type = NodeType::kTest;
-    ShaderType shader_type = ShaderType::kVertex;
-    ShaderFormat fmt = ShaderFormat::kText;
+    ShaderType shader_type = kShaderTypeVertex;
+    ShaderFormat fmt = kShaderFormatText;
     SectionParser p;
     Result r = p.NameToNodeTypeForTesting(name_case.name, &section_type,
                                           &shader_type, &fmt);
@@ -251,8 +251,8 @@ TEST_F(SectionParserTest, NameToNodeType) {
 
 TEST_F(SectionParserTest, NameToNodeTypeInvalidName) {
   NodeType section_type = NodeType::kTest;
-  ShaderType shader_type = ShaderType::kVertex;
-  ShaderFormat fmt = ShaderFormat::kText;
+  ShaderType shader_type = kShaderTypeVertex;
+  ShaderFormat fmt = kShaderFormatText;
   SectionParser p;
   Result r = p.NameToNodeTypeForTesting("InvalidName", &section_type,
                                         &shader_type, &fmt);
@@ -271,8 +271,8 @@ TEST_F(SectionParserTest, NameToSectionInvalidSuffix) {
 
   for (auto name_case : cases) {
     NodeType section_type = NodeType::kTest;
-    ShaderType shader_type = ShaderType::kVertex;
-    ShaderFormat fmt = ShaderFormat::kText;
+    ShaderType shader_type = kShaderTypeVertex;
+    ShaderFormat fmt = kShaderFormatText;
     SectionParser p;
 
     Result r = p.NameToNodeTypeForTesting(name_case.name, &section_type,

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -33,17 +33,17 @@ const uint32_t kFramebufferHeight = 250;
 
 VkShaderStageFlagBits ToVkShaderStage(ShaderType type) {
   switch (type) {
-    case ShaderType::kGeometry:
+    case kShaderTypeGeometry:
       return VK_SHADER_STAGE_GEOMETRY_BIT;
-    case ShaderType::kFragment:
+    case kShaderTypeFragment:
       return VK_SHADER_STAGE_FRAGMENT_BIT;
-    case ShaderType::kVertex:
+    case kShaderTypeVertex:
       return VK_SHADER_STAGE_VERTEX_BIT;
-    case ShaderType::kTessellationControl:
+    case kShaderTypeTessellationControl:
       return VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
-    case ShaderType::kTessellationEvaluation:
+    case kShaderTypeTessellationEvaluation:
       return VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
-    case ShaderType::kCompute:
+    case kShaderTypeCompute:
       return VK_SHADER_STAGE_COMPUTE_BIT;
   }
 


### PR DESCRIPTION
The CTS requires code to not use c++11. This CL converts the various
c++11-ism's in the Amber API to C++03.