### PR TITLE
Print line number of failing probe command.

### DIFF
--- a/src/command.h
+++ b/src/command.h
@@ -96,7 +96,7 @@ class Command {
   explicit Command(Type type);
 
   Type command_type_;
-  size_t line_;
+  size_t line_ = 1;
 };
 
 class DrawRectCommand : public Command {

--- a/src/command.h
+++ b/src/command.h
@@ -89,10 +89,14 @@ class Command {
   ProbeSSBOCommand* AsProbeSSBO();
   BufferCommand* AsBuffer();
 
+  void SetLine(size_t line) { line_ = line; }
+  size_t GetLine() const { return line_; }
+
  protected:
   explicit Command(Type type);
 
   Type command_type_;
+  size_t line_;
 };
 
 class DrawRectCommand : public Command {

--- a/src/verifier.cc
+++ b/src/verifier.cc
@@ -59,7 +59,7 @@ Result CheckValue(const ProbeSSBOCommand* command,
       case ProbeSSBOCommand::Comparator::kEqual:
         if (values[i].IsInteger()) {
           if (static_cast<uint64_t>(*ptr) != static_cast<uint64_t>(val)) {
-            return Result("Line: " + std::to_string(command->GetLine()) +
+            return Result("Line " + std::to_string(command->GetLine()) +
                           ": Verifier failed: " + std::to_string(*ptr) +
                           " == " + std::to_string(val) + ", at index " +
                           std::to_string(i));
@@ -67,7 +67,7 @@ Result CheckValue(const ProbeSSBOCommand* command,
         } else {
           if (!IsEqualWithTolerance(static_cast<const double>(*ptr),
                                     static_cast<const double>(val), kEpsilon)) {
-            return Result("Line: " + std::to_string(command->GetLine()) +
+            return Result("Line " + std::to_string(command->GetLine()) +
                           ": Verifier failed: " + std::to_string(*ptr) +
                           " == " + std::to_string(val) + ", at index " +
                           std::to_string(i));
@@ -77,7 +77,7 @@ Result CheckValue(const ProbeSSBOCommand* command,
       case ProbeSSBOCommand::Comparator::kNotEqual:
         if (values[i].IsInteger()) {
           if (static_cast<uint64_t>(*ptr) == static_cast<uint64_t>(val)) {
-            return Result("Line: " + std::to_string(command->GetLine()) +
+            return Result("Line " + std::to_string(command->GetLine()) +
                           ": Verifier failed: " + std::to_string(*ptr) +
                           " != " + std::to_string(val) + ", at index " +
                           std::to_string(i));
@@ -85,7 +85,7 @@ Result CheckValue(const ProbeSSBOCommand* command,
         } else {
           if (IsEqualWithTolerance(static_cast<const double>(*ptr),
                                    static_cast<const double>(val), kEpsilon)) {
-            return Result("Line: " + std::to_string(command->GetLine()) +
+            return Result("Line " + std::to_string(command->GetLine()) +
                           ": Verifier failed: " + std::to_string(*ptr) +
                           " != " + std::to_string(val) + ", at index " +
                           std::to_string(i));
@@ -97,7 +97,7 @@ Result CheckValue(const ProbeSSBOCommand* command,
                 static_cast<const double>(*ptr), static_cast<const double>(val),
                 command->HasTolerances() ? tolerance[0].value : kEpsilon,
                 command->HasTolerances() ? tolerance[0].is_percent : true)) {
-          return Result("Line: " + std::to_string(command->GetLine()) +
+          return Result("Line " + std::to_string(command->GetLine()) +
                         ": Verifier failed: " + std::to_string(*ptr) +
                         " ~= " + std::to_string(val) + ", at index " +
                         std::to_string(i));
@@ -105,7 +105,7 @@ Result CheckValue(const ProbeSSBOCommand* command,
         break;
       case ProbeSSBOCommand::Comparator::kLess:
         if (*ptr >= val) {
-          return Result("Line: " + std::to_string(command->GetLine()) +
+          return Result("Line " + std::to_string(command->GetLine()) +
                         ": Verifier failed: " + std::to_string(*ptr) + " < " +
                         std::to_string(val) + ", at index " +
                         std::to_string(i));
@@ -113,7 +113,7 @@ Result CheckValue(const ProbeSSBOCommand* command,
         break;
       case ProbeSSBOCommand::Comparator::kLessOrEqual:
         if (*ptr > val) {
-          return Result("Line: " + std::to_string(command->GetLine()) +
+          return Result("Line " + std::to_string(command->GetLine()) +
                         ": Verifier failed: " + std::to_string(*ptr) +
                         " <= " + std::to_string(val) + ", at index " +
                         std::to_string(i));
@@ -121,7 +121,7 @@ Result CheckValue(const ProbeSSBOCommand* command,
         break;
       case ProbeSSBOCommand::Comparator::kGreater:
         if (*ptr <= val) {
-          return Result("Line: " + std::to_string(command->GetLine()) +
+          return Result("Line " + std::to_string(command->GetLine()) +
                         ": Verifier failed: " + std::to_string(*ptr) + " > " +
                         std::to_string(val) + ", at index " +
                         std::to_string(i));
@@ -129,7 +129,7 @@ Result CheckValue(const ProbeSSBOCommand* command,
         break;
       case ProbeSSBOCommand::Comparator::kGreaterOrEqual:
         if (*ptr < val) {
-          return Result("Line: " + std::to_string(command->GetLine()) +
+          return Result("Line " + std::to_string(command->GetLine()) +
                         ": Verifier failed: " + std::to_string(*ptr) +
                         " >= " + std::to_string(val) + ", at index " +
                         std::to_string(i));
@@ -215,13 +215,13 @@ Result Verifier::Probe(const ProbeCommand* command,
 
   if (x + width > frame_width || y + height > frame_height) {
     return Result(
-        "Line: " + std::to_string(command->GetLine()) +
+        "Line " + std::to_string(command->GetLine()) +
         ": Verifier::Probe Position(" + std::to_string(x + width - 1) + ", " +
         std::to_string(y + height - 1) + ") is out of framebuffer scope (" +
         std::to_string(frame_width) + "," + std::to_string(frame_height) + ")");
   }
   if (row_stride < frame_width * texel_stride) {
-    return Result("Line: " + std::to_string(command->GetLine()) +
+    return Result("Line " + std::to_string(command->GetLine()) +
                   ": Verifier::Probe Row stride of " +
                   std::to_string(row_stride) + " is too small for " +
                   std::to_string(frame_width) + " texels of " +
@@ -271,7 +271,7 @@ Result Verifier::Probe(const ProbeCommand* command,
     const uint8_t* p = ptr + row_stride * (first_invalid_j + y) +
                        texel_stride * (x + first_invalid_i);
     return Result(
-        "Line: " + std::to_string(command->GetLine()) +
+        "Line " + std::to_string(command->GetLine()) +
         ": Probe failed at: " + std::to_string(x + first_invalid_i) + ", " +
         std::to_string(first_invalid_j + y) + "\n" +
         "  Expected RGBA: " + std::to_string(command->GetR() * 255) + ", " +
@@ -303,13 +303,13 @@ Result Verifier::ProbeSSBO(const ProbeSSBOCommand* command,
 
   if (values.size() * bytes_per_elem + offset > size_in_bytes) {
     return Result(
-        "Line: " + std::to_string(command->GetLine()) +
+        "Line " + std::to_string(command->GetLine()) +
         ": Verifier::ProbeSSBO has more expected values than SSBO size");
   }
 
   if (offset % bytes_per_elem != 0) {
     return Result(
-        "Line: " + std::to_string(command->GetLine()) +
+        "Line " + std::to_string(command->GetLine()) +
         ": Verifier::ProbeSSBO given offset is not multiple of bytes_per_elem");
   }
 
@@ -335,7 +335,7 @@ Result Verifier::ProbeSSBO(const ProbeSSBOCommand* command,
   if (datum_type.IsDouble())
     return CheckValue<double>(command, ptr, values);
 
-  return Result("Line: " + std::to_string(command->GetLine()) +
+  return Result("Line " + std::to_string(command->GetLine()) +
                 ": Verifier::ProbeSSBO unknown datum type");
 }
 

--- a/src/verifier.cc
+++ b/src/verifier.cc
@@ -59,14 +59,16 @@ Result CheckValue(const ProbeSSBOCommand* command,
       case ProbeSSBOCommand::Comparator::kEqual:
         if (values[i].IsInteger()) {
           if (static_cast<uint64_t>(*ptr) != static_cast<uint64_t>(val)) {
-            return Result("Verifier failed: " + std::to_string(*ptr) +
+            return Result("Line: " + std::to_string(command->GetLine()) +
+                          ": Verifier failed: " + std::to_string(*ptr) +
                           " == " + std::to_string(val) + ", at index " +
                           std::to_string(i));
           }
         } else {
           if (!IsEqualWithTolerance(static_cast<const double>(*ptr),
                                     static_cast<const double>(val), kEpsilon)) {
-            return Result("Verifier failed: " + std::to_string(*ptr) +
+            return Result("Line: " + std::to_string(command->GetLine()) +
+                          ": Verifier failed: " + std::to_string(*ptr) +
                           " == " + std::to_string(val) + ", at index " +
                           std::to_string(i));
           }
@@ -75,14 +77,16 @@ Result CheckValue(const ProbeSSBOCommand* command,
       case ProbeSSBOCommand::Comparator::kNotEqual:
         if (values[i].IsInteger()) {
           if (static_cast<uint64_t>(*ptr) == static_cast<uint64_t>(val)) {
-            return Result("Verifier failed: " + std::to_string(*ptr) +
+            return Result("Line: " + std::to_string(command->GetLine()) +
+                          ": Verifier failed: " + std::to_string(*ptr) +
                           " != " + std::to_string(val) + ", at index " +
                           std::to_string(i));
           }
         } else {
           if (IsEqualWithTolerance(static_cast<const double>(*ptr),
                                    static_cast<const double>(val), kEpsilon)) {
-            return Result("Verifier failed: " + std::to_string(*ptr) +
+            return Result("Line: " + std::to_string(command->GetLine()) +
+                          ": Verifier failed: " + std::to_string(*ptr) +
                           " != " + std::to_string(val) + ", at index " +
                           std::to_string(i));
           }
@@ -93,35 +97,40 @@ Result CheckValue(const ProbeSSBOCommand* command,
                 static_cast<const double>(*ptr), static_cast<const double>(val),
                 command->HasTolerances() ? tolerance[0].value : kEpsilon,
                 command->HasTolerances() ? tolerance[0].is_percent : true)) {
-          return Result("Verifier failed: " + std::to_string(*ptr) +
+          return Result("Line: " + std::to_string(command->GetLine()) +
+                        ": Verifier failed: " + std::to_string(*ptr) +
                         " ~= " + std::to_string(val) + ", at index " +
                         std::to_string(i));
         }
         break;
       case ProbeSSBOCommand::Comparator::kLess:
         if (*ptr >= val) {
-          return Result("Verifier failed: " + std::to_string(*ptr) + " < " +
+          return Result("Line: " + std::to_string(command->GetLine()) +
+                        ": Verifier failed: " + std::to_string(*ptr) + " < " +
                         std::to_string(val) + ", at index " +
                         std::to_string(i));
         }
         break;
       case ProbeSSBOCommand::Comparator::kLessOrEqual:
         if (*ptr > val) {
-          return Result("Verifier failed: " + std::to_string(*ptr) +
+          return Result("Line: " + std::to_string(command->GetLine()) +
+                        ": Verifier failed: " + std::to_string(*ptr) +
                         " <= " + std::to_string(val) + ", at index " +
                         std::to_string(i));
         }
         break;
       case ProbeSSBOCommand::Comparator::kGreater:
         if (*ptr <= val) {
-          return Result("Verifier failed: " + std::to_string(*ptr) + " > " +
+          return Result("Line: " + std::to_string(command->GetLine()) +
+                        ": Verifier failed: " + std::to_string(*ptr) + " > " +
                         std::to_string(val) + ", at index " +
                         std::to_string(i));
         }
         break;
       case ProbeSSBOCommand::Comparator::kGreaterOrEqual:
         if (*ptr < val) {
-          return Result("Verifier failed: " + std::to_string(*ptr) +
+          return Result("Line: " + std::to_string(command->GetLine()) +
+                        ": Verifier failed: " + std::to_string(*ptr) +
                         " >= " + std::to_string(val) + ", at index " +
                         std::to_string(i));
         }
@@ -206,12 +215,14 @@ Result Verifier::Probe(const ProbeCommand* command,
 
   if (x + width > frame_width || y + height > frame_height) {
     return Result(
-        "Verifier::Probe Position(" + std::to_string(x + width - 1) + ", " +
+        "Line: " + std::to_string(command->GetLine()) +
+        ": Verifier::Probe Position(" + std::to_string(x + width - 1) + ", " +
         std::to_string(y + height - 1) + ") is out of framebuffer scope (" +
         std::to_string(frame_width) + "," + std::to_string(frame_height) + ")");
   }
   if (row_stride < frame_width * texel_stride) {
-    return Result("Verifier::Probe Row stride of " +
+    return Result("Line: " + std::to_string(command->GetLine()) +
+                  ": Verifier::Probe Row stride of " +
                   std::to_string(row_stride) + " is too small for " +
                   std::to_string(frame_width) + " texels of " +
                   std::to_string(texel_stride) + " bytes each");
@@ -260,7 +271,8 @@ Result Verifier::Probe(const ProbeCommand* command,
     const uint8_t* p = ptr + row_stride * (first_invalid_j + y) +
                        texel_stride * (x + first_invalid_i);
     return Result(
-        "Probe failed at: " + std::to_string(x + first_invalid_i) + ", " +
+        "Line: " + std::to_string(command->GetLine()) +
+        ": Probe failed at: " + std::to_string(x + first_invalid_i) + ", " +
         std::to_string(first_invalid_j + y) + "\n" +
         "  Expected RGBA: " + std::to_string(command->GetR() * 255) + ", " +
         std::to_string(command->GetG() * 255) + ", " +
@@ -291,12 +303,14 @@ Result Verifier::ProbeSSBO(const ProbeSSBOCommand* command,
 
   if (values.size() * bytes_per_elem + offset > size_in_bytes) {
     return Result(
-        "Verifier::ProbeSSBO has more expected values than SSBO size");
+        "Line: " + std::to_string(command->GetLine()) +
+        ": Verifier::ProbeSSBO has more expected values than SSBO size");
   }
 
   if (offset % bytes_per_elem != 0) {
     return Result(
-        "Verifier::ProbeSSBO given offset is not multiple of bytes_per_elem");
+        "Line: " + std::to_string(command->GetLine()) +
+        ": Verifier::ProbeSSBO given offset is not multiple of bytes_per_elem");
   }
 
   const uint8_t* ptr = static_cast<const uint8_t*>(cpu_memory) + offset;
@@ -321,7 +335,8 @@ Result Verifier::ProbeSSBO(const ProbeSSBOCommand* command,
   if (datum_type.IsDouble())
     return CheckValue<double>(command, ptr, values);
 
-  return Result("Verifier::ProbeSSBO unknown datum type");
+  return Result("Line: " + std::to_string(command->GetLine()) +
+                ": Verifier::ProbeSSBO unknown datum type");
 }
 
 }  // namespace amber

--- a/src/verifier_test.cc
+++ b/src/verifier_test.cc
@@ -108,9 +108,9 @@ TEST_F(VerifierTest, ProbeFrameBufferRelativeSmallExpectFail) {
   Result r = verifier.Probe(&probe, 4, 1000, 250, 250,
                             static_cast<const void*>(frame_buffer));
   EXPECT_STREQ(
-      "Probe failed at: 225, 225\n  Expected RGBA: 25.500000, 0.000000, "
-      "0.000000, 0.000000\n  Actual RGBA: 0, 0, 0, 0\nProbe failed in 625 "
-      "pixels",
+      "Line 1: Probe failed at: 225, 225\n  Expected RGBA: 25.500000, "
+      "0.000000, 0.000000, 0.000000\n  Actual RGBA: 0, 0, 0, 0\nProbe failed "
+      "in 625 pixels",
       r.Error().c_str());
 }
 
@@ -184,8 +184,8 @@ TEST_F(VerifierTest, ProbeFrameBufferBadRowStride) {
                             static_cast<const void*>(frame_buffer));
   EXPECT_FALSE(r.IsSuccess());
   EXPECT_STREQ(
-      "Verifier::Probe Row stride of 3 is too small for 1 texels of 4 bytes "
-      "each",
+      "Line 1: Verifier::Probe Row stride of 3 is too small for 1 texels of 4 "
+      "bytes each",
       r.Error().c_str());
 }
 
@@ -506,7 +506,8 @@ TEST_F(VerifierTest, ProbeSSBOEqualFail) {
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, sizeof(double) * 4, ssbo);
   EXPECT_FALSE(r.IsSuccess());
-  EXPECT_EQ("Verifier failed: 2.800000 == 2.900000, at index 0", r.Error());
+  EXPECT_EQ("Line 1: Verifier failed: 2.800000 == 2.900000, at index 0",
+            r.Error());
 }
 
 TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithAbsoluteTolerance) {
@@ -568,7 +569,8 @@ TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithAbsoluteToleranceFail) {
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, sizeof(double) * 4, ssbo);
   EXPECT_FALSE(r.IsSuccess());
-  EXPECT_EQ("Verifier failed: 3.001000 ~= 2.900000, at index 0", r.Error());
+  EXPECT_EQ("Line 1: Verifier failed: 3.001000 ~= 2.900000, at index 0",
+            r.Error());
 }
 
 TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithRelativeTolerance) {
@@ -630,7 +632,8 @@ TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithRelativeToleranceFail) {
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, sizeof(double) * 4, ssbo);
   EXPECT_FALSE(r.IsSuccess());
-  EXPECT_EQ("Verifier failed: 2.903000 ~= 2.900000, at index 0", r.Error());
+  EXPECT_EQ("Line 1: Verifier failed: 2.903000 ~= 2.900000, at index 0",
+            r.Error());
 }
 
 TEST_F(VerifierTest, ProbeSSBONotEqual) {
@@ -679,7 +682,8 @@ TEST_F(VerifierTest, ProbeSSBONotEqualFail) {
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, sizeof(double) * 4, ssbo);
   EXPECT_FALSE(r.IsSuccess());
-  EXPECT_EQ("Verifier failed: 2.900000 != 2.900000, at index 0", r.Error());
+  EXPECT_EQ("Line 1: Verifier failed: 2.900000 != 2.900000, at index 0",
+            r.Error());
 }
 
 TEST_F(VerifierTest, ProbeSSBOLess) {
@@ -728,7 +732,8 @@ TEST_F(VerifierTest, ProbeSSBOLessFail) {
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, sizeof(double) * 4, ssbo);
   EXPECT_FALSE(r.IsSuccess());
-  EXPECT_EQ("Verifier failed: 3.900000 < 2.900000, at index 0", r.Error());
+  EXPECT_EQ("Line 1: Verifier failed: 3.900000 < 2.900000, at index 0",
+            r.Error());
 }
 
 TEST_F(VerifierTest, ProbeSSBOLessOrEqual) {
@@ -777,7 +782,7 @@ TEST_F(VerifierTest, ProbeSSBOLessOrEqualFail) {
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, sizeof(double) * 4, ssbo);
   EXPECT_FALSE(r.IsSuccess());
-  EXPECT_EQ("Verifier failed: 1234.561000 <= 1234.560000, at index 3",
+  EXPECT_EQ("Line 1: Verifier failed: 1234.561000 <= 1234.560000, at index 3",
             r.Error());
 }
 
@@ -827,7 +832,8 @@ TEST_F(VerifierTest, ProbeSSBOGreaterFail) {
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, sizeof(double) * 4, ssbo);
   EXPECT_FALSE(r.IsSuccess());
-  EXPECT_EQ("Verifier failed: 0.730000 > 0.730000, at index 1", r.Error());
+  EXPECT_EQ("Line 1: Verifier failed: 0.730000 > 0.730000, at index 1",
+            r.Error());
 }
 
 TEST_F(VerifierTest, ProbeSSBOGreaterOrEqual) {
@@ -876,7 +882,7 @@ TEST_F(VerifierTest, ProbeSSBOGreaterOrEqualFail) {
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, sizeof(double) * 4, ssbo);
   EXPECT_FALSE(r.IsSuccess());
-  EXPECT_EQ("Verifier failed: 1234.559000 >= 1234.560000, at index 3",
+  EXPECT_EQ("Line 1: Verifier failed: 1234.559000 >= 1234.560000, at index 3",
             r.Error());
 }
 

--- a/src/vkscript/command_parser.cc
+++ b/src/vkscript/command_parser.cc
@@ -247,6 +247,7 @@ Result CommandParser::Parse() {
 
 Result CommandParser::ProcessDrawRect() {
   auto cmd = MakeUnique<DrawRectCommand>(pipeline_data_);
+  cmd->SetLine(tokenizer_->GetCurrentLine());
 
   auto token = tokenizer_->NextToken();
   while (token->IsString()) {
@@ -296,6 +297,7 @@ Result CommandParser::ProcessDrawRect() {
 
 Result CommandParser::ProcessDrawArrays() {
   auto cmd = MakeUnique<DrawArraysCommand>(pipeline_data_);
+  cmd->SetLine(tokenizer_->GetCurrentLine());
 
   auto token = tokenizer_->NextToken();
   while (token->IsString()) {
@@ -356,6 +358,7 @@ Result CommandParser::ProcessDrawArrays() {
 
 Result CommandParser::ProcessCompute() {
   auto cmd = MakeUnique<ComputeCommand>(pipeline_data_);
+  cmd->SetLine(tokenizer_->GetCurrentLine());
 
   auto token = tokenizer_->NextToken();
 
@@ -399,6 +402,7 @@ Result CommandParser::ProcessClear() {
     cmd_suffix = str + " ";
     if (str == "depth") {
       cmd = MakeUnique<ClearDepthCommand>();
+      cmd->SetLine(tokenizer_->GetCurrentLine());
 
       token = tokenizer_->NextToken();
       Result r = token->ConvertToDouble();
@@ -408,6 +412,7 @@ Result CommandParser::ProcessClear() {
       cmd->AsClearDepth()->SetValue(token->AsFloat());
     } else if (str == "stencil") {
       cmd = MakeUnique<ClearStencilCommand>();
+      cmd->SetLine(tokenizer_->GetCurrentLine());
 
       token = tokenizer_->NextToken();
       if (token->IsEOL() || token->IsEOS())
@@ -420,6 +425,7 @@ Result CommandParser::ProcessClear() {
       cmd->AsClearStencil()->SetValue(token->AsUint32());
     } else if (str == "color") {
       cmd = MakeUnique<ClearColorCommand>();
+      cmd->SetLine(tokenizer_->GetCurrentLine());
 
       token = tokenizer_->NextToken();
       Result r = token->ConvertToDouble();
@@ -452,6 +458,7 @@ Result CommandParser::ProcessClear() {
     token = tokenizer_->NextToken();
   } else {
     cmd = MakeUnique<ClearCommand>();
+    cmd->SetLine(tokenizer_->GetCurrentLine());
   }
   if (!token->IsEOS() && !token->IsEOL())
     return Result("Extra parameter to clear " + cmd_suffix +
@@ -508,6 +515,7 @@ Result CommandParser::ParseValues(const std::string& name,
 
 Result CommandParser::ProcessSSBO() {
   auto cmd = MakeUnique<BufferCommand>(BufferCommand::BufferType::kSSBO);
+  cmd->SetLine(tokenizer_->GetCurrentLine());
 
   auto token = tokenizer_->NextToken();
   if (token->IsEOL() || token->IsEOS())
@@ -600,6 +608,7 @@ Result CommandParser::ProcessUniform() {
   std::unique_ptr<BufferCommand> cmd;
   if (token->AsString() == "ubo") {
     cmd = MakeUnique<BufferCommand>(BufferCommand::BufferType::kUniform);
+    cmd->SetLine(tokenizer_->GetCurrentLine());
 
     token = tokenizer_->NextToken();
     if (!token->IsInteger())
@@ -635,6 +644,7 @@ Result CommandParser::ProcessUniform() {
 
   } else {
     cmd = MakeUnique<BufferCommand>(BufferCommand::BufferType::kPushConstant);
+    cmd->SetLine(tokenizer_->GetCurrentLine());
   }
 
   DatumTypeParser tp;
@@ -711,6 +721,7 @@ Result CommandParser::ProcessTolerance() {
 
 Result CommandParser::ProcessPatch() {
   auto cmd = MakeUnique<PatchParameterVerticesCommand>();
+  cmd->SetLine(tokenizer_->GetCurrentLine());
 
   auto token = tokenizer_->NextToken();
   if (!token->IsString() || token->AsString() != "parameter")
@@ -739,6 +750,7 @@ Result CommandParser::ProcessPatch() {
 
 Result CommandParser::ProcessEntryPoint(const std::string& name) {
   auto cmd = MakeUnique<EntryPointCommand>();
+  cmd->SetLine(tokenizer_->GetCurrentLine());
 
   auto token = tokenizer_->NextToken();
   if (token->IsEOL() || token->IsEOS())
@@ -772,6 +784,8 @@ Result CommandParser::ProcessProbe(bool relative) {
     return ProcessProbeSSBO();
 
   auto cmd = MakeUnique<ProbeCommand>();
+  cmd->SetLine(tokenizer_->GetCurrentLine());
+
   cmd->SetTolerances(current_tolerances_);
   if (relative)
     cmd->SetRelative();
@@ -1868,6 +1882,7 @@ Result CommandParser::ParseComparator(const std::string& name,
 
 Result CommandParser::ProcessProbeSSBO() {
   auto cmd = MakeUnique<ProbeSSBOCommand>();
+  cmd->SetLine(tokenizer_->GetCurrentLine());
   cmd->SetTolerances(current_tolerances_);
 
   auto token = tokenizer_->NextToken();

--- a/src/vkscript/parser.cc
+++ b/src/vkscript/parser.cc
@@ -451,7 +451,7 @@ Result Parser::ProcessVertexDataBlock(const SectionParser::Section& section) {
 }
 
 Result Parser::ProcessTestBlock(const SectionParser::Section& section) {
-  CommandParser cp(section.starting_line_number, section.contents);
+  CommandParser cp(section.starting_line_number + 1, section.contents);
   Result r = cp.Parse();
   if (!r.IsSuccess())
     return r;


### PR DESCRIPTION
This CL changes the verifier to output the line number of a failing
probe command. Each command now stores the line number from the
original script.

Fixes #219