### PR TITLE
Vulkan: fix stride issue in MoltenVK

### DIFF
--- a/src/vulkan/vertex_buffer.h
+++ b/src/vulkan/vertex_buffer.h
@@ -50,7 +50,7 @@ class VertexBuffer {
   VkVertexInputBindingDescription GetVertexInputBinding() const {
     VkVertexInputBindingDescription vertex_binding_desc = {};
     vertex_binding_desc.binding = 0;
-    vertex_binding_desc.stride = stride_in_bytes_;
+    vertex_binding_desc.stride = Get4BytesAlignedStride();
     vertex_binding_desc.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
     return vertex_binding_desc;
   }
@@ -66,6 +66,9 @@ class VertexBuffer {
 
  private:
   void FillVertexBufferWithData(VkCommandBuffer command);
+  uint32_t Get4BytesAlignedStride() const {
+    return ((stride_in_bytes_ + 3) / 4) * 4;
+  }
 
   VkDevice device_ = VK_NULL_HANDLE;
 

--- a/src/vulkan/vertex_buffer.h
+++ b/src/vulkan/vertex_buffer.h
@@ -66,6 +66,8 @@ class VertexBuffer {
 
  private:
   void FillVertexBufferWithData(VkCommandBuffer command);
+
+  // Return |stride_in_bytes_| rounded up by 4.
   uint32_t Get4BytesAlignedStride() const {
     return ((stride_in_bytes_ + 3) / 4) * 4;
   }


### PR DESCRIPTION
MoltenVK does not allow that `stride` of
`VkVertexInputBindingDescription` is not multiple of 4. This commit
makes it as 4-bytes aligned even on non-MoltenVK SDK.

Related to #216