### PR TITLE
Allow CTS to provide alternate vulkan.h file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ if (NOT ANDROID)
   include(src/vulkan/find_vulkan.cmake)
 endif()
 
+add_definitions(-DAMBER_CTS_VULKAN_HEADER=$<BOOL:${VULKAN_CTS_HEADER}>)
 add_definitions(-DAMBER_ENGINE_VULKAN=$<BOOL:${Vulkan_FOUND}>)
 add_definitions(-DAMBER_ENGINE_DAWN=$<BOOL:${Dawn_FOUND}>)
 add_definitions(-DAMBER_ENABLE_SPIRV_TOOLS=$<BOOL:${AMBER_ENABLE_SPIRV_TOOLS}>)

--- a/include/amber/amber_vulkan.h
+++ b/include/amber/amber_vulkan.h
@@ -20,11 +20,7 @@
 #include <vector>
 
 #include "amber/amber.h"
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
-#include "vulkan/vulkan.h"
-#pragma clang diagnostic pop
+#include "amber/vulkan_header.h"
 
 namespace amber {
 

--- a/include/amber/vulkan_header.h
+++ b/include/amber/vulkan_header.h
@@ -1,4 +1,4 @@
-// Copyright 2018 The Amber Authors.
+// Copyright 2019 The Amber Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,19 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SRC_VULKAN_FORMAT_DATA_H_
-#define SRC_VULKAN_FORMAT_DATA_H_
+#ifndef AMBER_VULKAN_HEADER_H_
+#define AMBER_VULKAN_HEADER_H_
 
-#include "amber/vulkan_header.h"
-#include "src/format_data.h"
+#if AMBER_CTS_VULKAN_HEADER
+#include "vkDefs.h"
+#else  // DAMBER_CTS_VULKAN_HEADER
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#include "vulkan/vulkan.h"
+#pragma clang diagnostic pop
+#endif  // AMBER_CTS_VULKAN_HEADER
 
-namespace amber {
-namespace vulkan {
-
-VkFormat ToVkFormat(FormatType type);
-uint32_t VkFormatToByteSize(VkFormat format);
-
-}  // namespace vulkan
-}  // namespace amber
-
-#endif  // SRC_VULKAN_FORMAT_DATA_H_
+#endif  // AMBER_VULKAN_HEADER_H_

--- a/src/vulkan/buffer.h
+++ b/src/vulkan/buffer.h
@@ -16,8 +16,8 @@
 #define SRC_VULKAN_BUFFER_H_
 
 #include "amber/result.h"
+#include "amber/vulkan_header.h"
 #include "src/vulkan/resource.h"
-#include "vulkan/vulkan.h"
 
 namespace amber {
 namespace vulkan {

--- a/src/vulkan/buffer_descriptor.h
+++ b/src/vulkan/buffer_descriptor.h
@@ -19,12 +19,12 @@
 #include <vector>
 
 #include "amber/result.h"
+#include "amber/vulkan_header.h"
 #include "src/datum_type.h"
 #include "src/engine.h"
 #include "src/value.h"
 #include "src/vulkan/buffer.h"
 #include "src/vulkan/descriptor.h"
-#include "vulkan/vulkan.h"
 
 namespace amber {
 namespace vulkan {

--- a/src/vulkan/command.h
+++ b/src/vulkan/command.h
@@ -16,7 +16,7 @@
 #define SRC_VULKAN_COMMAND_H_
 
 #include "amber/result.h"
-#include "vulkan/vulkan.h"
+#include "amber/vulkan_header.h"
 
 namespace amber {
 

--- a/src/vulkan/compute_pipeline.h
+++ b/src/vulkan/compute_pipeline.h
@@ -18,8 +18,8 @@
 #include <vector>
 
 #include "amber/result.h"
+#include "amber/vulkan_header.h"
 #include "src/vulkan/pipeline.h"
-#include "vulkan/vulkan.h"
 
 namespace amber {
 namespace vulkan {

--- a/src/vulkan/descriptor.h
+++ b/src/vulkan/descriptor.h
@@ -19,10 +19,10 @@
 #include <vector>
 
 #include "amber/result.h"
+#include "amber/vulkan_header.h"
 #include "src/datum_type.h"
 #include "src/engine.h"
 #include "src/vulkan/resource.h"
-#include "vulkan/vulkan.h"
 
 namespace amber {
 namespace vulkan {

--- a/src/vulkan/device.h
+++ b/src/vulkan/device.h
@@ -20,8 +20,8 @@
 #include <vector>
 
 #include "amber/result.h"
+#include "amber/vulkan_header.h"
 #include "src/feature.h"
-#include "vulkan/vulkan.h"
 
 namespace amber {
 

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -20,13 +20,13 @@
 #include <unordered_map>
 #include <vector>
 
+#include "amber/vulkan_header.h"
 #include "src/cast_hash.h"
 #include "src/engine.h"
 #include "src/vulkan/command.h"
 #include "src/vulkan/device.h"
 #include "src/vulkan/pipeline.h"
 #include "src/vulkan/vertex_buffer.h"
-#include "vulkan/vulkan.h"
 
 namespace amber {
 namespace vulkan {

--- a/src/vulkan/find_vulkan.cmake
+++ b/src/vulkan/find_vulkan.cmake
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 # Include this file to find Vulkan and and set up compilation and linking.
-
 
 # Export these settings to the includer.
 set(Vulkan_FOUND FALSE)
+set(VULKAN_CTS_HEADER FALSE)
 set(VULKAN_LIB "")
-
 
 # Our first choice is to pick up the Vulkan headers from an enclosing project.
 # And if that's the case, then use Vulkan libraries as specified by
@@ -28,6 +26,7 @@ set(X "${Vulkan-Headers_SOURCE_DIR}/include")
 if (IS_DIRECTORY "${X}")
   message(STATUS "Amber: Using Vulkan header dir ${X}")
   list(APPEND CMAKE_REQUIRED_INCLUDES "${X}")
+
   # Add the directory to the list of include paths, before any others.
   include_directories(BEFORE "${X}")
   CHECK_INCLUDE_FILE(vulkan/vulkan.h HAVE_VULKAN_HEADER)
@@ -40,6 +39,7 @@ if (IS_DIRECTORY "${X}")
       message(STATUS "Amber: Using specified Vulkan libraries: ${Vulkan_LIBRARIES}")
       set(VULKAN_LIB "${Vulkan_LIBRARIES}")
     endif()
+
     # For now assume we have Vulkan.  We have its header, but we haven't checked
     # for the library.
     # TODO(dneto): Actually check for the libraries.
@@ -47,6 +47,26 @@ if (IS_DIRECTORY "${X}")
   endif()
 endif()
 unset(X)
+
+# Check if we're in the CTS
+if (NOT ${Vulkan_FOUND})
+  message(STATUS "Amber: Checking for CTS Vulkan header")
+  set(X "${Vulkan-Headers_SOURCE_DIR}")
+  if (IS_DIRECTORY "${X}")
+    message(STATUS "Amber: Using Vulkan header dir ${X}")
+    list(APPEND CMAKE_REQUIRED_INCLUDES "${X}")
+
+    # Add the directory to the list of include paths, before any others.
+    include_directories(BEFORE "${X}")
+
+    if (EXISTS "${X}/vkDefs.h")
+      set(VULKAN_CTS_HEADER TRUE)
+      set(Vulkan_FOUND TRUE)
+      set(VULKAN_LIB vulkan)
+    endif()
+  endif()
+  unset(X)
+endif()
 
 if (NOT ${Vulkan_FOUND})
   # If we aren't already building a Vulkan library, then use CMake to find it.

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -19,13 +19,13 @@
 #include <vector>
 
 #include "amber/result.h"
+#include "amber/vulkan_header.h"
 #include "src/buffer_data.h"
 #include "src/format.h"
 #include "src/value.h"
 #include "src/vulkan/frame_buffer.h"
 #include "src/vulkan/pipeline.h"
 #include "src/vulkan/vertex_buffer.h"
-#include "vulkan/vulkan.h"
 
 namespace amber {
 

--- a/src/vulkan/image.h
+++ b/src/vulkan/image.h
@@ -16,8 +16,8 @@
 #define SRC_VULKAN_IMAGE_H_
 
 #include "amber/result.h"
+#include "amber/vulkan_header.h"
 #include "src/vulkan/resource.h"
-#include "vulkan/vulkan.h"
 
 namespace amber {
 namespace vulkan {

--- a/src/vulkan/pipeline.h
+++ b/src/vulkan/pipeline.h
@@ -21,12 +21,12 @@
 #include <vector>
 
 #include "amber/result.h"
+#include "amber/vulkan_header.h"
 #include "src/cast_hash.h"
 #include "src/engine.h"
 #include "src/vulkan/command.h"
 #include "src/vulkan/descriptor.h"
 #include "src/vulkan/push_constant.h"
-#include "vulkan/vulkan.h"
 
 namespace amber {
 

--- a/src/vulkan/push_constant.h
+++ b/src/vulkan/push_constant.h
@@ -19,9 +19,9 @@
 #include <vector>
 
 #include "amber/result.h"
+#include "amber/vulkan_header.h"
 #include "src/command.h"
 #include "src/vulkan/resource.h"
-#include "vulkan/vulkan.h"
 
 namespace amber {
 namespace vulkan {

--- a/src/vulkan/resource.h
+++ b/src/vulkan/resource.h
@@ -19,9 +19,9 @@
 #include <vector>
 
 #include "amber/result.h"
+#include "amber/vulkan_header.h"
 #include "src/datum_type.h"
 #include "src/value.h"
-#include "vulkan/vulkan.h"
 
 namespace amber {
 namespace vulkan {

--- a/src/vulkan/vertex_buffer.h
+++ b/src/vulkan/vertex_buffer.h
@@ -19,10 +19,10 @@
 #include <vector>
 
 #include "amber/result.h"
+#include "amber/vulkan_header.h"
 #include "src/format.h"
 #include "src/value.h"
 #include "src/vulkan/buffer.h"
-#include "vulkan/vulkan.h"
 
 namespace amber {
 namespace vulkan {


### PR DESCRIPTION
This CL changes the includes to allow the CTS to use vkDefs.h instead of
vulkan/vulkan.h