### PR TITLE
Change initializers to make GCC happy.

### DIFF
--- a/src/verifier.cc
+++ b/src/verifier.cc
@@ -228,8 +228,8 @@ Result Verifier::Probe(const ProbeCommand* command,
                   std::to_string(texel_stride) + " bytes each");
   }
 
-  double tolerance[4] = {};
-  bool is_tolerance_percent[4] = {};
+  double tolerance[4] = {0, 0, 0, 0};
+  bool is_tolerance_percent[4] = {0, 0, 0, 0};
   SetupToleranceForTexels(command, tolerance, is_tolerance_percent);
 
   // TODO(jaebaek): Support all VkFormat

--- a/src/vulkan/bit_copy.cc
+++ b/src/vulkan/bit_copy.cc
@@ -42,7 +42,7 @@ void BitCopy::CopyValueToBuffer(uint8_t* dst,
                                 const Value& src,
                                 uint8_t bit_offset,
                                 uint8_t bits) {
-  uint8_t data[9] = {};
+  uint8_t data[9] = {0, 0, 0, 0, 0, 0, 0, 0, 0};
   if (src.IsInteger()) {
     if (bits <= 8) {
       uint8_t data_uint8 = src.AsUint8();

--- a/src/vulkan/buffer.cc
+++ b/src/vulkan/buffer.cc
@@ -46,7 +46,7 @@ Result Buffer::Initialize(const VkBufferUsageFlags usage) {
 }
 
 Result Buffer::CreateVkBufferView(VkFormat format) {
-  VkBufferViewCreateInfo buffer_view_info = {};
+  VkBufferViewCreateInfo buffer_view_info = VkBufferViewCreateInfo();
   buffer_view_info.sType = VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO;
   buffer_view_info.buffer = buffer_;
   buffer_view_info.format = format;
@@ -64,7 +64,7 @@ Result Buffer::CopyToDevice(VkCommandBuffer command) {
   if (is_buffer_host_accessible_)
     return FlushMemoryIfNeeded();
 
-  VkBufferCopy region = {};
+  VkBufferCopy region = VkBufferCopy();
   region.srcOffset = 0;
   region.dstOffset = 0;
   region.size = GetSizeInBytes();
@@ -78,7 +78,7 @@ Result Buffer::CopyToHost(VkCommandBuffer command) {
   if (is_buffer_host_accessible_)
     return InvalidateMemoryIfNeeded();
 
-  VkBufferCopy region = {};
+  VkBufferCopy region = VkBufferCopy();
   region.srcOffset = 0;
   region.dstOffset = 0;
   region.size = GetSizeInBytes();
@@ -89,7 +89,7 @@ Result Buffer::CopyToHost(VkCommandBuffer command) {
 }
 
 void Buffer::CopyFromBuffer(VkCommandBuffer command, const Buffer& src) {
-  VkBufferCopy region = {};
+  VkBufferCopy region = VkBufferCopy();
   region.srcOffset = 0;
   region.dstOffset = 0;
   region.size = src.GetSizeInBytes();
@@ -120,7 +120,7 @@ Result Buffer::InvalidateMemoryIfNeeded() {
   if (is_buffer_host_coherent_)
     return {};
 
-  VkMappedMemoryRange range = {};
+  VkMappedMemoryRange range = VkMappedMemoryRange();
   range.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
   range.memory = GetHostAccessMemory();
   range.offset = 0;
@@ -135,7 +135,7 @@ Result Buffer::FlushMemoryIfNeeded() {
   if (is_buffer_host_coherent_)
     return {};
 
-  VkMappedMemoryRange range = {};
+  VkMappedMemoryRange range = VkMappedMemoryRange();
   range.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
   range.memory = GetHostAccessMemory();
   range.offset = 0;

--- a/src/vulkan/buffer_descriptor.cc
+++ b/src/vulkan/buffer_descriptor.cc
@@ -115,7 +115,7 @@ Result BufferDescriptor::UpdateDescriptorSetIfNeeded(
   if (!IsDescriptorSetUpdateNeeded())
     return {};
 
-  VkDescriptorBufferInfo buffer_info = {};
+  VkDescriptorBufferInfo buffer_info = VkDescriptorBufferInfo();
   buffer_info.buffer = buffer_->GetVkBuffer();
   buffer_info.offset = 0;
   buffer_info.range = VK_WHOLE_SIZE;
@@ -125,7 +125,7 @@ Result BufferDescriptor::UpdateDescriptorSetIfNeeded(
 }
 
 ResourceInfo BufferDescriptor::GetResourceInfo() {
-  ResourceInfo info = {};
+  ResourceInfo info = ResourceInfo();
   info.type = ResourceInfoType::kBuffer;
   info.size_in_bytes = buffer_->GetSizeInBytes();
   info.cpu_memory = buffer_->HostAccessibleMemoryPtr();

--- a/src/vulkan/command.cc
+++ b/src/vulkan/command.cc
@@ -27,7 +27,7 @@ CommandPool::CommandPool(VkDevice device) : device_(device) {}
 CommandPool::~CommandPool() = default;
 
 Result CommandPool::Initialize(uint32_t queue_family_index) {
-  VkCommandPoolCreateInfo pool_info = {};
+  VkCommandPoolCreateInfo pool_info = VkCommandPoolCreateInfo();
   pool_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
   pool_info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
   pool_info.queueFamilyIndex = queue_family_index;
@@ -49,7 +49,7 @@ CommandBuffer::CommandBuffer(VkDevice device, VkCommandPool pool, VkQueue queue)
 CommandBuffer::~CommandBuffer() = default;
 
 Result CommandBuffer::Initialize() {
-  VkCommandBufferAllocateInfo command_info = {};
+  VkCommandBufferAllocateInfo command_info = VkCommandBufferAllocateInfo();
   command_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
   command_info.commandPool = pool_;
   command_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
@@ -58,7 +58,7 @@ Result CommandBuffer::Initialize() {
   if (vkAllocateCommandBuffers(device_, &command_info, &command_) != VK_SUCCESS)
     return Result("Vulkan::Calling vkAllocateCommandBuffers Fail");
 
-  VkFenceCreateInfo fence_info = {};
+  VkFenceCreateInfo fence_info = VkFenceCreateInfo();
   fence_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
   if (vkCreateFence(device_, &fence_info, nullptr, &fence_) != VK_SUCCESS)
     return Result("Vulkan::Calling vkCreateFence Fail");
@@ -73,7 +73,7 @@ Result CommandBuffer::BeginIfNotInRecording() {
   if (state_ != CommandBufferState::kInitial)
     return Result("Vulkan::Begin CommandBuffer from Not Valid State");
 
-  VkCommandBufferBeginInfo command_begin_info = {};
+  VkCommandBufferBeginInfo command_begin_info = VkCommandBufferBeginInfo();
   command_begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
   command_begin_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
   if (vkBeginCommandBuffer(command_, &command_begin_info) != VK_SUCCESS)
@@ -101,7 +101,7 @@ Result CommandBuffer::SubmitAndReset(uint32_t timeout_ms) {
   if (vkResetFences(device_, 1, &fence_) != VK_SUCCESS)
     return Result("Vulkan::Calling vkResetFences Fail");
 
-  VkSubmitInfo submit_info = {};
+  VkSubmitInfo submit_info = VkSubmitInfo();
   submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
   submit_info.commandBufferCount = 1;
   submit_info.pCommandBuffers = &command_;

--- a/src/vulkan/compute_pipeline.cc
+++ b/src/vulkan/compute_pipeline.cc
@@ -53,7 +53,7 @@ Result ComputePipeline::CreateVkComputePipeline() {
   if (!r.IsSuccess())
     return r;
 
-  VkComputePipelineCreateInfo pipeline_info = {};
+  VkComputePipelineCreateInfo pipeline_info = VkComputePipelineCreateInfo();
   pipeline_info.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
   pipeline_info.stage = shader_stage_info[0];
   pipeline_info.layout = pipeline_layout_;

--- a/src/vulkan/descriptor.cc
+++ b/src/vulkan/descriptor.cc
@@ -63,7 +63,7 @@ Descriptor::~Descriptor() = default;
 VkWriteDescriptorSet Descriptor::GetWriteDescriptorSet(
     VkDescriptorSet descriptor_set,
     VkDescriptorType descriptor_type) const {
-  VkWriteDescriptorSet write = {};
+  VkWriteDescriptorSet write = VkWriteDescriptorSet();
   write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
   write.dstSet = descriptor_set;
   write.dstBinding = binding_;

--- a/src/vulkan/device.cc
+++ b/src/vulkan/device.cc
@@ -71,7 +71,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(VkDebugReportFlagsEXT flag,
 
 VkPhysicalDeviceFeatures RequestedFeatures(
     const std::vector<Feature>& required_features) {
-  VkPhysicalDeviceFeatures requested_features = {};
+  VkPhysicalDeviceFeatures requested_features = VkPhysicalDeviceFeatures();
   for (const auto& feature : required_features) {
     switch (feature) {
       case Feature::kRobustBufferAccess:
@@ -691,7 +691,7 @@ bool Device::ChooseQueueFamilyIndex(const VkPhysicalDevice& physical_device) {
 }
 
 Result Device::CreateInstance() {
-  VkApplicationInfo app_info = {};
+  VkApplicationInfo app_info = VkApplicationInfo();
   app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
   app_info.apiVersion = VK_MAKE_VERSION(1, 0, 0);
 
@@ -702,7 +702,7 @@ Result Device::CreateInstance() {
   if (!AreAllValidationExtensionsSupported())
     return Result("Vulkan: extensions of validation layers are not supported");
 
-  VkInstanceCreateInfo instance_info = {};
+  VkInstanceCreateInfo instance_info = VkInstanceCreateInfo();
   instance_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
   instance_info.pApplicationInfo = &app_info;
   instance_info.enabledLayerCount = kNumberOfRequiredValidationLayers;
@@ -717,7 +717,8 @@ Result Device::CreateInstance() {
 }
 
 Result Device::CreateDebugReportCallback() {
-  VkDebugReportCallbackCreateInfoEXT info = {};
+  VkDebugReportCallbackCreateInfoEXT info =
+      VkDebugReportCallbackCreateInfoEXT();
   info.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT;
   info.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT;
   info.pfnCallback = debugCallback;
@@ -749,7 +750,7 @@ Result Device::ChoosePhysicalDevice(
     return Result("Vulkan::Calling vkEnumeratePhysicalDevices Fail");
 
   for (uint32_t i = 0; i < count; ++i) {
-    VkPhysicalDeviceFeatures available_features = {};
+    VkPhysicalDeviceFeatures available_features = VkPhysicalDeviceFeatures();
     vkGetPhysicalDeviceFeatures(physical_devices[i], &available_features);
     if (!AreAllRequiredFeaturesSupported(available_features,
                                          required_features)) {
@@ -773,14 +774,14 @@ Result Device::ChoosePhysicalDevice(
 Result Device::CreateDevice(
     const std::vector<Feature>& required_features,
     const std::vector<std::string>& required_extensions) {
-  VkDeviceQueueCreateInfo queue_info = {};
+  VkDeviceQueueCreateInfo queue_info = VkDeviceQueueCreateInfo();
   const float priorities[] = {1.0f};
   queue_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
   queue_info.queueFamilyIndex = queue_family_index_;
   queue_info.queueCount = 1;
   queue_info.pQueuePriorities = priorities;
 
-  VkDeviceCreateInfo info = {};
+  VkDeviceCreateInfo info = VkDeviceCreateInfo();
   info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
   info.pQueueCreateInfos = &queue_info;
   info.queueCreateInfoCount = 1;

--- a/src/vulkan/device.h
+++ b/src/vulkan/device.h
@@ -83,9 +83,9 @@ class Device {
   VkInstance instance_ = VK_NULL_HANDLE;
   VkDebugReportCallbackEXT callback_ = VK_NULL_HANDLE;
   VkPhysicalDevice physical_device_ = VK_NULL_HANDLE;
-  VkPhysicalDeviceProperties physical_device_properties_ = {};
-  VkPhysicalDeviceMemoryProperties physical_memory_properties_ = {};
-  VkPhysicalDeviceFeatures available_physical_device_features_ = {};
+  VkPhysicalDeviceProperties physical_device_properties_;
+  VkPhysicalDeviceMemoryProperties physical_memory_properties_;
+  VkPhysicalDeviceFeatures available_physical_device_features_;
   std::vector<std::string> available_physical_device_extensions_;
   uint32_t queue_family_index_ = 0;
   VkDevice device_ = VK_NULL_HANDLE;

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -54,7 +54,7 @@ VkShaderStageFlagBits ToVkShaderStage(ShaderType type) {
 bool IsFormatSupportedByPhysicalDevice(BufferType type,
                                        VkPhysicalDevice physical_device,
                                        VkFormat format) {
-  VkFormatProperties properties = {};
+  VkFormatProperties properties = VkFormatProperties();
   vkGetPhysicalDeviceFormatProperties(physical_device, format, &properties);
 
   VkFormatFeatureFlagBits flag = VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT;
@@ -80,7 +80,7 @@ bool IsFormatSupportedByPhysicalDevice(BufferType type,
 
 bool IsDescriptorSetInBounds(VkPhysicalDevice physical_device,
                              uint32_t descriptor_set) {
-  VkPhysicalDeviceProperties properties = {};
+  VkPhysicalDeviceProperties properties = VkPhysicalDeviceProperties();
   vkGetPhysicalDeviceProperties(physical_device, &properties);
   return properties.limits.maxBoundDescriptorSets > descriptor_set;
 }
@@ -190,7 +190,7 @@ Result EngineVulkan::CreatePipeline(PipelineType type) {
 
 Result EngineVulkan::SetShader(ShaderType type,
                                const std::vector<uint32_t>& data) {
-  VkShaderModuleCreateInfo info = {};
+  VkShaderModuleCreateInfo info = VkShaderModuleCreateInfo();
   info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
   info.codeSize = data.size() * sizeof(uint32_t);
   info.pCode = data.data();
@@ -214,7 +214,7 @@ EngineVulkan::GetShaderStageInfo() {
   std::vector<VkPipelineShaderStageCreateInfo> stage_info(modules_.size());
   uint32_t stage_count = 0;
   for (auto it : modules_) {
-    stage_info[stage_count] = {};
+    stage_info[stage_count] = VkPipelineShaderStageCreateInfo();
     stage_info[stage_count].sType =
         VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stage_info[stage_count].stage = ToVkShaderStage(it.first);

--- a/src/vulkan/frame_buffer.cc
+++ b/src/vulkan/frame_buffer.cc
@@ -56,7 +56,7 @@ Result FrameBuffer::Initialize(
     attachments.push_back(depth_image_->GetVkImageView());
   }
 
-  VkFramebufferCreateInfo frame_buffer_info = {};
+  VkFramebufferCreateInfo frame_buffer_info = VkFramebufferCreateInfo();
   frame_buffer_info.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
   frame_buffer_info.renderPass = render_pass;
   frame_buffer_info.attachmentCount = static_cast<uint32_t>(attachments.size());

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -122,13 +122,13 @@ GraphicsPipeline::GraphicsPipeline(
 GraphicsPipeline::~GraphicsPipeline() = default;
 
 Result GraphicsPipeline::CreateRenderPass() {
-  VkSubpassDescription subpass_desc = {};
+  VkSubpassDescription subpass_desc = VkSubpassDescription();
   subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
 
   std::vector<VkAttachmentDescription> attachment_desc;
 
-  VkAttachmentReference color_refer = {};
-  VkAttachmentReference depth_refer = {};
+  VkAttachmentReference color_refer = VkAttachmentReference();
+  VkAttachmentReference depth_refer = VkAttachmentReference();
 
   if (color_format_ != VK_FORMAT_UNDEFINED) {
     attachment_desc.push_back(kDefaultAttachmentDesc);
@@ -159,7 +159,7 @@ Result GraphicsPipeline::CreateRenderPass() {
     subpass_desc.pDepthStencilAttachment = &depth_refer;
   }
 
-  VkRenderPassCreateInfo render_pass_info = {};
+  VkRenderPassCreateInfo render_pass_info = VkRenderPassCreateInfo();
   render_pass_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
   render_pass_info.attachmentCount =
       static_cast<uint32_t>(attachment_desc.size());
@@ -177,7 +177,8 @@ Result GraphicsPipeline::CreateRenderPass() {
 
 VkPipelineDepthStencilStateCreateInfo
 GraphicsPipeline::GetPipelineDepthStencilInfo() {
-  VkPipelineDepthStencilStateCreateInfo depthstencil_info = {};
+  VkPipelineDepthStencilStateCreateInfo depthstencil_info =
+      VkPipelineDepthStencilStateCreateInfo();
   // TODO(jaebaek): Depth/stencil test setup should be come from the
   // PipelineData.
   depthstencil_info.depthTestEnable = VK_TRUE;
@@ -190,7 +191,8 @@ GraphicsPipeline::GetPipelineDepthStencilInfo() {
 
 VkPipelineColorBlendAttachmentState
 GraphicsPipeline::GetPipelineColorBlendAttachmentState() {
-  VkPipelineColorBlendAttachmentState colorblend_attachment = {};
+  VkPipelineColorBlendAttachmentState colorblend_attachment =
+      VkPipelineColorBlendAttachmentState();
   // TODO(jaebaek): Update blend state should be come from the PipelineData.
   colorblend_attachment.blendEnable = VK_FALSE;
   colorblend_attachment.srcColorBlendFactor = VK_BLEND_FACTOR_ZERO;
@@ -215,12 +217,14 @@ Result GraphicsPipeline::CreateVkGraphicsPipeline(
   if (!r.IsSuccess())
     return r;
 
-  VkPipelineVertexInputStateCreateInfo vertex_input_info = {};
+  VkPipelineVertexInputStateCreateInfo vertex_input_info =
+      VkPipelineVertexInputStateCreateInfo();
   vertex_input_info.sType =
       VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
   vertex_input_info.vertexBindingDescriptionCount = 1;
 
-  VkVertexInputBindingDescription vertex_binding_desc = {};
+  VkVertexInputBindingDescription vertex_binding_desc =
+      VkVertexInputBindingDescription();
   if (vertex_buffer != nullptr) {
     vertex_binding_desc = vertex_buffer->GetVertexInputBinding();
     const auto& vertex_attr_desc = vertex_buffer->GetVertexInputAttr();
@@ -239,7 +243,8 @@ Result GraphicsPipeline::CreateVkGraphicsPipeline(
     vertex_input_info.pVertexAttributeDescriptions = nullptr;
   }
 
-  VkPipelineInputAssemblyStateCreateInfo input_assembly_info = {};
+  VkPipelineInputAssemblyStateCreateInfo input_assembly_info =
+      VkPipelineInputAssemblyStateCreateInfo();
   input_assembly_info.sType =
       VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
   // TODO(jaebaek): Handle the given index if exists.
@@ -255,7 +260,8 @@ Result GraphicsPipeline::CreateVkGraphicsPipeline(
 
   VkRect2D scissor = {{0, 0}, {frame_->GetWidth(), frame_->GetHeight()}};
 
-  VkPipelineViewportStateCreateInfo viewport_info = {};
+  VkPipelineViewportStateCreateInfo viewport_info =
+      VkPipelineViewportStateCreateInfo();
   viewport_info.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
   viewport_info.viewportCount = 1;
   viewport_info.pViewports = &viewport;
@@ -266,7 +272,7 @@ Result GraphicsPipeline::CreateVkGraphicsPipeline(
   for (auto& info : shader_stage_info)
     info.pName = GetEntryPointName(info.stage);
 
-  VkGraphicsPipelineCreateInfo pipeline_info = {};
+  VkGraphicsPipelineCreateInfo pipeline_info = VkGraphicsPipelineCreateInfo();
   pipeline_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
   pipeline_info.stageCount = static_cast<uint32_t>(shader_stage_info.size());
   pipeline_info.pStages = shader_stage_info.data();
@@ -282,7 +288,8 @@ Result GraphicsPipeline::CreateVkGraphicsPipeline(
     pipeline_info.pDepthStencilState = &depthstencil_info;
   }
 
-  VkPipelineColorBlendStateCreateInfo colorblend_info = {};
+  VkPipelineColorBlendStateCreateInfo colorblend_info =
+      VkPipelineColorBlendStateCreateInfo();
   VkPipelineColorBlendAttachmentState colorblend_attachment;
   if (color_format_ != VK_FORMAT_UNDEFINED) {
     colorblend_attachment = GetPipelineColorBlendAttachmentState();
@@ -379,7 +386,7 @@ Result GraphicsPipeline::ActivateRenderPassIfNeeded() {
   if (!r.IsSuccess())
     return r;
 
-  VkRenderPassBeginInfo render_begin_info = {};
+  VkRenderPassBeginInfo render_begin_info = VkRenderPassBeginInfo();
   render_begin_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
   render_begin_info.renderPass = render_pass_;
   render_begin_info.framebuffer = frame_->GetFrameBuffer();
@@ -469,7 +476,7 @@ Result GraphicsPipeline::ClearBuffer(const VkClearValue& clear_value,
   if (!r.IsSuccess())
     return r;
 
-  VkClearAttachment clear_attachment = {};
+  VkClearAttachment clear_attachment = VkClearAttachment();
   clear_attachment.aspectMask = aspect;
   clear_attachment.colorAttachment = 0;
   clear_attachment.clearValue = clear_value;

--- a/src/vulkan/image.cc
+++ b/src/vulkan/image.cc
@@ -83,7 +83,7 @@ Result Image::Initialize(VkImageUsageFlags usage) {
 }
 
 Result Image::CreateVkImageView() {
-  VkImageViewCreateInfo image_view_info = {};
+  VkImageViewCreateInfo image_view_info = VkImageViewCreateInfo();
   image_view_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
   image_view_info.image = image_;
   // TODO(jaebaek): Set .viewType correctly
@@ -125,7 +125,7 @@ void Image::Shutdown() {
 }
 
 Result Image::CopyToHost(VkCommandBuffer command) {
-  VkBufferImageCopy copy_region = {};
+  VkBufferImageCopy copy_region = VkBufferImageCopy();
   copy_region.bufferOffset = 0;
   // Row length of 0 results in tight packing of rows, so the row stride
   // is the number of texels times the texel stride.
@@ -153,7 +153,7 @@ void Image::ChangeLayout(VkCommandBuffer command,
                          VkImageLayout new_layout,
                          VkPipelineStageFlags from,
                          VkPipelineStageFlags to) {
-  VkImageMemoryBarrier barrier = {};
+  VkImageMemoryBarrier barrier = VkImageMemoryBarrier();
   barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
   barrier.oldLayout = old_layout;
   barrier.newLayout = new_layout;

--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -112,7 +112,8 @@ void Pipeline::ResetVkPipelineRelatedObjects() {
 
 Result Pipeline::CreateDescriptorSetLayouts() {
   for (auto& info : descriptor_set_info_) {
-    VkDescriptorSetLayoutCreateInfo desc_info = {};
+    VkDescriptorSetLayoutCreateInfo desc_info =
+        VkDescriptorSetLayoutCreateInfo();
     desc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
 
     // If there are no descriptors for this descriptor set we only
@@ -159,7 +160,7 @@ Result Pipeline::CreateDescriptorPools() {
       pool_sizes.back().descriptorCount = 1;
     }
 
-    VkDescriptorPoolCreateInfo pool_info = {};
+    VkDescriptorPoolCreateInfo pool_info = VkDescriptorPoolCreateInfo();
     pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
     pool_info.maxSets = 1;
     pool_info.poolSizeCount = static_cast<uint32_t>(pool_sizes.size());
@@ -179,7 +180,7 @@ Result Pipeline::CreateDescriptorSets() {
     if (descriptor_set_info_[i].empty)
       continue;
 
-    VkDescriptorSetAllocateInfo desc_set_info = {};
+    VkDescriptorSetAllocateInfo desc_set_info = VkDescriptorSetAllocateInfo();
     desc_set_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
     desc_set_info.descriptorPool = descriptor_set_info_[i].pool;
     desc_set_info.descriptorSetCount = 1;
@@ -201,7 +202,8 @@ Result Pipeline::CreatePipelineLayout() {
   for (const auto& desc_set : descriptor_set_info_)
     descriptor_set_layouts.push_back(desc_set.layout);
 
-  VkPipelineLayoutCreateInfo pipeline_layout_info = {};
+  VkPipelineLayoutCreateInfo pipeline_layout_info =
+      VkPipelineLayoutCreateInfo();
   pipeline_layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
   pipeline_layout_info.setLayoutCount =
       static_cast<uint32_t>(descriptor_set_layouts.size());

--- a/src/vulkan/push_constant.cc
+++ b/src/vulkan/push_constant.cc
@@ -54,7 +54,7 @@ VkPushConstantRange PushConstant::GetPushConstantRange() {
   uint32_t size_in_bytes =
       it->offset + static_cast<uint32_t>(it->size_in_bytes) - first_offset;
 
-  VkPushConstantRange range = {};
+  VkPushConstantRange range = VkPushConstantRange();
   range.stageFlags = VK_SHADER_STAGE_ALL;
 
   // Based on Vulkan spec, range.offset must be multiple of 4.

--- a/src/vulkan/resource.cc
+++ b/src/vulkan/resource.cc
@@ -149,7 +149,7 @@ Result Resource::CreateVkBuffer(VkBuffer* buffer, VkBufferUsageFlags usage) {
   if (buffer == nullptr)
     return Result("Vulkan::Given VkBuffer pointer is nullptr");
 
-  VkBufferCreateInfo buffer_info = {};
+  VkBufferCreateInfo buffer_info = VkBufferCreateInfo();
   buffer_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
   buffer_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
   buffer_info.size = size_in_bytes_;
@@ -235,7 +235,7 @@ Resource::AllocateResult Resource::AllocateAndBindMemoryToVkBuffer(
 Result Resource::AllocateMemory(VkDeviceMemory* memory,
                                 VkDeviceSize size,
                                 uint32_t memory_type_index) {
-  VkMemoryAllocateInfo alloc_info = {};
+  VkMemoryAllocateInfo alloc_info = VkMemoryAllocateInfo();
   alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
   alloc_info.allocationSize = size;
   alloc_info.memoryTypeIndex = memory_type_index;

--- a/src/vulkan/vertex_buffer.h
+++ b/src/vulkan/vertex_buffer.h
@@ -48,7 +48,8 @@ class VertexBuffer {
   }
 
   VkVertexInputBindingDescription GetVertexInputBinding() const {
-    VkVertexInputBindingDescription vertex_binding_desc = {};
+    VkVertexInputBindingDescription vertex_binding_desc =
+        VkVertexInputBindingDescription();
     vertex_binding_desc.binding = 0;
     vertex_binding_desc.stride = stride_in_bytes_;
     vertex_binding_desc.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;


### PR DESCRIPTION
Using the = {} initializer syntax causes missing-field-initializers
warnings for some versions of GCC. This CL converts all uses of = {} to
construct the actual object desired instead.