### PR TITLE
Consolidate Initialize methods in Engine.

### DIFF
--- a/src/amber.cc
+++ b/src/amber.cc
@@ -67,14 +67,8 @@ amber::Result Amber::ExecuteWithShaderData(const amber::Recipe* recipe,
   if (!engine)
     return Result("Failed to create engine");
 
-  Result r;
-  if (opts.config) {
-    r = engine->InitializeWithConfig(opts.config, script->RequiredFeatures(),
-                                     script->RequiredExtensions());
-  } else {
-    r = engine->Initialize(script->RequiredFeatures(),
-                           script->RequiredExtensions());
-  }
+  Result r = engine->Initialize(opts.config, script->RequiredFeatures(),
+                                script->RequiredExtensions());
   if (!r.IsSuccess())
     return r;
 

--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -173,29 +173,24 @@ EngineDawn::EngineDawn() : Engine() {}
 
 EngineDawn::~EngineDawn() = default;
 
-Result EngineDawn::Initialize(const std::vector<Feature>&,
+Result EngineDawn::Initialize(EngineConfig* config,
+                              const std::vector<Feature>&,
                               const std::vector<std::string>&) {
   if (device_)
     return Result("Dawn:Initialize device_ already exists");
 
+  if (config) {
+    DawnEngineConfig* dawn_config = static_cast<DawnEngineConfig*>(config);
+    if (dawn_config->device == nullptr)
+      return Result("Dawn:Initialize device is a null pointer");
+
+    device_ = *dawn_config->device;
 #if AMBER_DAWN_METAL
-  return CreateMetalDevice(&device_);
+  } else {
+    return CreateMetalDevice(&device_);
 #endif  // AMBER_DAWN_METAL
+  }
 
-  return Result("Dawn::Initialize: Can't make a device: Unknown backend");
-}
-
-Result EngineDawn::InitializeWithConfig(EngineConfig* config,
-                                        const std::vector<Feature>&,
-                                        const std::vector<std::string>&) {
-  if (device_)
-    return Result("Dawn:InitializeWithconfig device_ already exists");
-
-  DawnEngineConfig* dawn_config = static_cast<DawnEngineConfig*>(config);
-  if (dawn_config->device == nullptr)
-    return Result("Dawn:InitializeWithConfig device is a null pointer");
-
-  device_ = *dawn_config->device;
   return {};
 }
 

--- a/src/dawn/engine_dawn.h
+++ b/src/dawn/engine_dawn.h
@@ -35,14 +35,10 @@ class EngineDawn : public Engine {
   ~EngineDawn() override;
 
   // Engine
-  // Initialize with a default device.
-  Result Initialize(const std::vector<Feature>& features,
-                    const std::vector<std::string>& extensions) override;
   // Initialize with given configuration data.
-  Result InitializeWithConfig(
-      EngineConfig* config,
-      const std::vector<Feature>& features,
-      const std::vector<std::string>& extensions) override;
+  Result Initialize(EngineConfig* config,
+                    const std::vector<Feature>& features,
+                    const std::vector<std::string>& extensions) override;
 
   Result Shutdown() override;
   // Record info for a pipeline.  The Dawn render pipeline will be created

--- a/src/engine.h
+++ b/src/engine.h
@@ -78,21 +78,14 @@ class Engine {
 
   virtual ~Engine();
 
-  /// Initialize the engine. The |features| list is a set of required features
-  /// for the device. The |extensions| list is a list of required extensions.
-  virtual Result Initialize(const std::vector<Feature>& features,
+  /// Initialize the engine with the provided config. The config is _not_ owned
+  /// by the engine and will not be destroyed. The |features| and |extensions|
+  /// are for validation purposes only. If possible the engine should verify
+  /// that the constraints in |features| and |extensions| are valid and fail
+  /// otherwise.
+  virtual Result Initialize(EngineConfig* config,
+                            const std::vector<Feature>& features,
                             const std::vector<std::string>& extensions) = 0;
-
-  /// Initialize the engine with the provided device. The device is _not_ owned
-  /// by the engine and should not be destroyed. The |features| and |extensions|
-  /// are passed into InitializeWithConfig for validation purposes only. If
-  /// possible the engine should verify the provided config specifies the
-  /// constraints in |features| and |extensions| and fail if those constrains
-  /// are not met.
-  virtual Result InitializeWithConfig(
-      EngineConfig* config,
-      const std::vector<Feature>& features,
-      const std::vector<std::string>& extensions) = 0;
 
   /// Shutdown the engine and cleanup any resources.
   virtual Result Shutdown() = 0;

--- a/src/executor_test.cc
+++ b/src/executor_test.cc
@@ -33,16 +33,11 @@ class EngineStub : public Engine {
   ~EngineStub() override = default;
 
   // Engine
-  Result Initialize(const std::vector<Feature>& features,
+  Result Initialize(EngineConfig*,
+                    const std::vector<Feature>& features,
                     const std::vector<std::string>& extensions) override {
     features_ = features;
     extensions_ = extensions;
-    return {};
-  }
-
-  Result InitializeWithConfig(EngineConfig*,
-                              const std::vector<Feature>&,
-                              const std::vector<std::string>&) override {
     return {};
   }
 
@@ -258,7 +253,7 @@ class VkScriptExecutorTest : public testing::Test {
       const std::vector<Feature>& features,
       const std::vector<std::string>& extensions) {
     auto engine = MakeUnique<EngineStub>();
-    engine->Initialize(features, extensions);
+    engine->Initialize(nullptr, features, extensions);
     return std::move(engine);
   }
   EngineStub* ToStub(Engine* engine) {

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -37,12 +37,9 @@ class EngineVulkan : public Engine {
   ~EngineVulkan() override;
 
   // Engine
-  Result Initialize(const std::vector<Feature>& features,
+  Result Initialize(EngineConfig* config,
+                    const std::vector<Feature>& features,
                     const std::vector<std::string>& extensions) override;
-  Result InitializeWithConfig(
-      EngineConfig* config,
-      const std::vector<Feature>& features,
-      const std::vector<std::string>& extensions) override;
   Result Shutdown() override;
   Result CreatePipeline(PipelineType type) override;
   Result SetShader(ShaderType type, const std::vector<uint32_t>& data) override;
@@ -68,9 +65,6 @@ class EngineVulkan : public Engine {
                            ResourceInfo* info) override;
 
  private:
-  Result InitDeviceAndCreateCommand(const std::vector<Feature>& features,
-                                    const std::vector<std::string>& extensions);
-
   std::vector<VkPipelineShaderStageCreateInfo> GetShaderStageInfo();
 
   std::unique_ptr<Device> device_;


### PR DESCRIPTION
This CL consolidates the two Initialize and InitializeWithConfig methods
to just Initialize. The method is now responsible for checking the
config object provided.