### PR TITLE
Remove PipelineData from ComputeCommand

### DIFF
--- a/src/command.cc
+++ b/src/command.cc
@@ -78,8 +78,7 @@ DrawArraysCommand::DrawArraysCommand(PipelineData data)
 
 DrawArraysCommand::~DrawArraysCommand() = default;
 
-ComputeCommand::ComputeCommand(PipelineData data)
-    : Command(Type::kCompute), data_(data) {}
+ComputeCommand::ComputeCommand() : Command(Type::kCompute) {}
 
 ComputeCommand::~ComputeCommand() = default;
 

--- a/src/command.h
+++ b/src/command.h
@@ -171,10 +171,8 @@ class DrawArraysCommand : public Command {
 
 class ComputeCommand : public Command {
  public:
-  explicit ComputeCommand(PipelineData data);
+  ComputeCommand();
   ~ComputeCommand() override;
-
-  const PipelineData* GetPipelineData() const { return &data_; }
 
   void SetX(uint32_t x) { x_ = x; }
   uint32_t GetX() const { return x_; }
@@ -186,8 +184,6 @@ class ComputeCommand : public Command {
   uint32_t GetZ() const { return z_; }
 
  private:
-  PipelineData data_;
-
   uint32_t x_ = 0;
   uint32_t y_ = 0;
   uint32_t z_ = 0;

--- a/src/vkscript/command_parser.cc
+++ b/src/vkscript/command_parser.cc
@@ -357,7 +357,7 @@ Result CommandParser::ProcessDrawArrays() {
 }
 
 Result CommandParser::ProcessCompute() {
-  auto cmd = MakeUnique<ComputeCommand>(pipeline_data_);
+  auto cmd = MakeUnique<ComputeCommand>();
   cmd->SetLine(tokenizer_->GetCurrentLine());
 
   auto token = tokenizer_->NextToken();


### PR DESCRIPTION
Compute pipeline does not need PipelineData. This commit removes
PipelineData from ComputeCommand.

Fixes #64