### PR TITLE
Fix tokenizer on windows

### DIFF
--- a/src/tokenizer.cc
+++ b/src/tokenizer.cc
@@ -87,7 +87,7 @@ std::unique_ptr<Token> Tokenizer::NextToken() {
 
   size_t end_pos = current_position_;
   while (end_pos < data_.length()) {
-    if (data_[end_pos] == ' ' || data_[end_pos] == '\n' ||
+    if (data_[end_pos] == ' ' || data_[end_pos] == '\r' || data_[end_pos] == '\n' ||
         data_[end_pos] == ')' || data_[end_pos] == ',' ||
         data_[end_pos] == '(') {
       break;

--- a/src/tokenizer.cc
+++ b/src/tokenizer.cc
@@ -88,8 +88,8 @@ std::unique_ptr<Token> Tokenizer::NextToken() {
   size_t end_pos = current_position_;
   while (end_pos < data_.length()) {
     if (data_[end_pos] == ' ' || data_[end_pos] == '\r' ||
-	    data_[end_pos] == '\n' || data_[end_pos] == ')' ||
-	    data_[end_pos] == ',' || data_[end_pos] == '(') {
+        data_[end_pos] == '\n' || data_[end_pos] == ')' ||
+        data_[end_pos] == ',' || data_[end_pos] == '(') {
       break;
     }
     ++end_pos;

--- a/src/tokenizer.cc
+++ b/src/tokenizer.cc
@@ -88,8 +88,8 @@ std::unique_ptr<Token> Tokenizer::NextToken() {
   size_t end_pos = current_position_;
   while (end_pos < data_.length()) {
     if (data_[end_pos] == ' ' || data_[end_pos] == '\r' ||
-		data_[end_pos] == '\n' || data_[end_pos] == ')' ||
-		data_[end_pos] == ',' || data_[end_pos] == '(') {
+	    data_[end_pos] == '\n' || data_[end_pos] == ')' ||
+	    data_[end_pos] == ',' || data_[end_pos] == '(') {
       break;
     }
     ++end_pos;

--- a/src/tokenizer.cc
+++ b/src/tokenizer.cc
@@ -87,9 +87,9 @@ std::unique_ptr<Token> Tokenizer::NextToken() {
 
   size_t end_pos = current_position_;
   while (end_pos < data_.length()) {
-    if (data_[end_pos] == ' ' || data_[end_pos] == '\r' || data_[end_pos] == '\n' ||
-        data_[end_pos] == ')' || data_[end_pos] == ',' ||
-        data_[end_pos] == '(') {
+    if (data_[end_pos] == ' ' || data_[end_pos] == '\r' ||
+		data_[end_pos] == '\n' || data_[end_pos] == ')' ||
+		data_[end_pos] == ',' || data_[end_pos] == '(') {
       break;
     }
     ++end_pos;

--- a/src/vulkan/vertex_buffer.cc
+++ b/src/vulkan/vertex_buffer.cc
@@ -177,7 +177,7 @@ Result CopyBitsOfValueToBuffer(uint8_t* dst,
   uint64_t* dst64 = reinterpret_cast<uint64_t*>(dst);
   uint64_t dst_lower_bits = *dst64 & ((1UL << dst_bit_offset) - 1UL);
   uint64_t dst_upper_bits =
-      *dst64 & ~(((1UL << (dst_bit_offset + bits)) - 1UL));
+      *dst64 & ~(((1ULL << (dst_bit_offset + bits)) - 1ULL));
 
   *dst64 = dst_lower_bits | data | dst_upper_bits;
   return {};


### PR DESCRIPTION
* Tokenizer wasn't properly setting endpos in the presence of carriage
returns
* Fix type conversion error for MSVC 2017