### PR TITLE
[vulkan] Inline setting data into vertex buffer.

### DIFF
--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -232,8 +232,7 @@ Result EngineVulkan::SetBuffer(BufferType type,
     if (!vertex_buffer_)
       vertex_buffer_ = MakeUnique<VertexBuffer>(device_.get());
 
-    pipeline_->AsGraphics()->SetVertexBuffer(location, format, values,
-                                             vertex_buffer_.get());
+    vertex_buffer_->SetData(location, format, values);
     return {};
   }
 
@@ -321,10 +320,7 @@ Result EngineVulkan::DoDrawRect(const DrawRectCommand* command) {
   values[7].SetDoubleValue(static_cast<double>(y));
 
   auto vertex_buffer = MakeUnique<VertexBuffer>(device_.get());
-
-  r = graphics->SetVertexBuffer(0, format, values, vertex_buffer.get());
-  if (!r.IsSuccess())
-    return r;
+  vertex_buffer->SetData(0, format, values);
 
   DrawArraysCommand draw(*command->GetPipelineData());
   draw.SetTopology(command->IsPatch() ? Topology::kPatchList

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -673,19 +673,6 @@ Result GraphicsPipeline::Initialize(uint32_t width,
   return {};
 }
 
-Result GraphicsPipeline::SetVertexBuffer(uint8_t location,
-                                         const Format& format,
-                                         const std::vector<Value>& values,
-                                         VertexBuffer* vertex_buffer) {
-  if (!vertex_buffer) {
-    return Result(
-        "GraphicsPipeline::SetVertexBuffer: vertex buffer is nullptr");
-  }
-
-  vertex_buffer->SetData(location, format, values);
-  return {};
-}
-
 Result GraphicsPipeline::SendVertexBufferDataIfNeeded(
     VertexBuffer* vertex_buffer) {
   if (!vertex_buffer)

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -50,11 +50,6 @@ class GraphicsPipeline : public Pipeline {
                     VkCommandPool pool,
                     VkQueue queue);
 
-  Result SetVertexBuffer(uint8_t location,
-                         const Format& format,
-                         const std::vector<Value>& values,
-                         VertexBuffer* vertex_buffer);
-
   Result SetIndexBuffer(const std::vector<Value>& values);
 
   Result Clear();


### PR DESCRIPTION
The SetVertexData on the graphics pipeline just calls SetData on the vertex
buffer. This CL inlines the SetData and removes the SetVertexData method.