### PR TITLE
Allow setting SPIR-V target environment.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,8 +8,8 @@ vars = {
   'glslang_revision': 'f44b17ee135d5e153ce000e88b806b5377812b11',
   'googletest_revision': 'd5932506d6eed73ac80b9bcc47ed723c8c74eb1e',
   'shaderc_revision': '53c776f776821bc037b31b8b3b79db2fa54b4ce7',
-  'spirv_headers_revision': '282879ca34563020dbe73fd8f7d45bed6755626a',
-  'spirv_tools_revision': '703305b1a5a2a06ea75510b954dea1dd2489fa46',
+  'spirv_headers_revision': '8bea0a266ac9b718aa0818d9e3a47c0b77c2cb23',
+  'spirv_tools_revision': '39bfb6b978e937487a9cedfd964d61a3ac4384b8',
 }
 
 deps = {

--- a/include/amber/amber.h
+++ b/include/amber/amber.h
@@ -57,6 +57,8 @@ struct Options {
   EngineType engine;
   /// Holds engine specific configuration. Ownership stays with the caller.
   EngineConfig* config;
+  /// The SPIR-V environment to target.
+  uint32_t spv_env;
   /// Lists the buffers to extract at the end of the execution
   std::vector<BufferInfo> extractions;
 };

--- a/include/amber/amber.h
+++ b/include/amber/amber.h
@@ -58,7 +58,7 @@ struct Options {
   /// Holds engine specific configuration. Ownership stays with the caller.
   EngineConfig* config;
   /// The SPIR-V environment to target.
-  uint32_t spv_env;
+  std::string spv_env;
   /// Lists the buffers to extract at the end of the execution
   std::vector<BufferInfo> extractions;
 };

--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -24,7 +24,6 @@
 #include "amber/recipe.h"
 #include "samples/config_helper.h"
 #include "samples/ppm.h"
-#include "spirv-tools/libspirv.h"
 #include "src/build-versions.h"
 #include "src/make_unique.h"
 
@@ -42,7 +41,7 @@ struct Options {
   bool show_help = false;
   bool show_version_info = false;
   amber::EngineType engine = amber::kEngineTypeVulkan;
-  spv_target_env spv_env = SPV_ENV_UNIVERSAL_1_0;
+  std::string spv_env;
 };
 
 const char kUsage[] = R"(Usage: amber [options] SCRIPT [SCRIPTS...]
@@ -116,11 +115,7 @@ bool ParseArgs(const std::vector<std::string>& args, Options* opts) {
         std::cerr << "Missing value for -t argument." << std::endl;
         return false;
       }
-
-      if (!spvParseTargetEnv(args[i].c_str(), &(opts->spv_env))) {
-        std::cerr << "Unable to parse SPIR-V target environment." << std::endl;
-        return false;
-      }
+      opts->spv_env = args[i];
 
     } else if (arg == "-h" || arg == "--help") {
       opts->show_help = true;

--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -241,6 +241,7 @@ int main(int argc, const char** argv) {
 
   amber::Options amber_options;
   amber_options.engine = options.engine;
+  amber_options.spv_env = options.spv_env;
 
   std::set<std::string> required_features;
   std::set<std::string> required_extensions;

--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -24,6 +24,7 @@
 #include "amber/recipe.h"
 #include "samples/config_helper.h"
 #include "samples/ppm.h"
+#include "spirv-tools/libspirv.h"
 #include "src/build-versions.h"
 #include "src/make_unique.h"
 
@@ -41,6 +42,7 @@ struct Options {
   bool show_help = false;
   bool show_version_info = false;
   amber::EngineType engine = amber::kEngineTypeVulkan;
+  spv_target_env spv_env = SPV_ENV_UNIVERSAL_1_0;
 };
 
 const char kUsage[] = R"(Usage: amber [options] SCRIPT [SCRIPTS...]
@@ -49,6 +51,7 @@ const char kUsage[] = R"(Usage: amber [options] SCRIPT [SCRIPTS...]
   -p             -- Parse input files only; Don't execute.
   -s             -- Print summary of pass/failure.
   -d             -- Disable Vulkan/Dawn validation layer.
+  -t <spirv_env> -- The target SPIR-V environment. Defaults to SPV_ENV_UNIVERSAL_1_0.
   -i <filename>  -- Write rendering to <filename> as a PPM image.
   -b <filename>  -- Write contents of a UBO or SSBO to <filename>.
   -B <buffer>    -- Index of buffer to write. Defaults buffer 0.
@@ -105,6 +108,17 @@ bool ParseArgs(const std::vector<std::string>& args, Options* opts) {
         std::cerr
             << "Invalid value for -e argument. Must be one of: vulkan dawn"
             << std::endl;
+        return false;
+      }
+    } else if (arg == "-t") {
+      ++i;
+      if (i >= args.size()) {
+        std::cerr << "Missing value for -t argument." << std::endl;
+        return false;
+      }
+
+      if (!spvParseTargetEnv(args[i].c_str(), &(opts->spv_env))) {
+        std::cerr << "Unable to parse SPIR-V target environment." << std::endl;
         return false;
       }
 

--- a/src/amber.cc
+++ b/src/amber.cc
@@ -63,6 +63,8 @@ amber::Result Amber::ExecuteWithShaderData(const amber::Recipe* recipe,
   if (!script)
     return Result("Recipe must contain a parsed script");
 
+  script->SetSpvTargetEnv(opts->spv_env);
+
   auto engine = Engine::Create(opts->engine);
   if (!engine)
     return Result("Failed to create engine");

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -35,7 +35,7 @@ Result Executor::Execute(Engine* engine,
   // Process Shader nodes
   PipelineType pipeline_type = PipelineType::kGraphics;
   for (const auto& shader : script->GetShaders()) {
-    ShaderCompiler sc;
+    ShaderCompiler sc(script->GetSpvTargetEnv());
 
     Result r;
     std::vector<uint32_t> data;

--- a/src/script.h
+++ b/src/script.h
@@ -151,9 +151,9 @@ class Script : public RecipeImpl {
   }
 
   /// Sets the SPIR-V target environment.
-  void SetSpvTargetEnv(uint32_t env) { spv_env_ = env; }
+  void SetSpvTargetEnv(const std::string& env) { spv_env_ = env; }
   /// Retrieves the SPIR-V target environment.
-  uint32_t GetSpvTargetEnv() const { return spv_env_; }
+  const std::string& GetSpvTargetEnv() const { return spv_env_; }
 
  private:
   struct {
@@ -162,7 +162,7 @@ class Script : public RecipeImpl {
   } engine_info_;
 
   EngineData engine_data_;
-  uint32_t spv_env_ = 0;
+  std::string spv_env_;
   std::map<std::string, Shader*> name_to_shader_;
   std::map<std::string, Buffer*> name_to_buffer_;
   std::map<std::string, Pipeline*> name_to_pipeline_;

--- a/src/script.h
+++ b/src/script.h
@@ -150,6 +150,11 @@ class Script : public RecipeImpl {
     return commands_;
   }
 
+  /// Sets the SPIR-V target environment.
+  void SetSpvTargetEnv(uint32_t env) { spv_env_ = env; }
+  /// Retrieves the SPIR-V target environment.
+  uint32_t GetSpvTargetEnv() const { return spv_env_; }
+
  private:
   struct {
     std::vector<Feature> required_features;
@@ -157,6 +162,7 @@ class Script : public RecipeImpl {
   } engine_info_;
 
   EngineData engine_data_;
+  uint32_t spv_env_ = 0;
   std::map<std::string, Shader*> name_to_shader_;
   std::map<std::string, Buffer*> name_to_buffer_;
   std::map<std::string, Pipeline*> name_to_pipeline_;

--- a/src/shader_compiler.cc
+++ b/src/shader_compiler.cc
@@ -36,7 +36,9 @@
 
 namespace amber {
 
-ShaderCompiler::ShaderCompiler() = default;
+ShaderCompiler::ShaderCompiler() : spv_env_(0) {}
+
+ShaderCompiler::ShaderCompiler(uint32_t env) : spv_env_(env) {}
 
 ShaderCompiler::~ShaderCompiler() = default;
 
@@ -49,8 +51,7 @@ std::pair<Result, std::vector<uint32_t>> ShaderCompiler::Compile(
 
 #if AMBER_ENABLE_SPIRV_TOOLS
   std::string spv_errors;
-  // TODO(dsinclair): Vulkan env should be an option.
-  spvtools::SpirvTools tools(SPV_ENV_UNIVERSAL_1_0);
+  spvtools::SpirvTools tools(static_cast<spv_target_env>(spv_env_));
   tools.SetMessageConsumer([&spv_errors](spv_message_level_t level, const char*,
                                          const spv_position_t& position,
                                          const char* message) {

--- a/src/shader_compiler.cc
+++ b/src/shader_compiler.cc
@@ -36,9 +36,9 @@
 
 namespace amber {
 
-ShaderCompiler::ShaderCompiler() : spv_env_(0) {}
+ShaderCompiler::ShaderCompiler() = default;
 
-ShaderCompiler::ShaderCompiler(uint32_t env) : spv_env_(env) {}
+ShaderCompiler::ShaderCompiler(const std::string& env) : spv_env_(env) {}
 
 ShaderCompiler::~ShaderCompiler() = default;
 
@@ -51,7 +51,14 @@ std::pair<Result, std::vector<uint32_t>> ShaderCompiler::Compile(
 
 #if AMBER_ENABLE_SPIRV_TOOLS
   std::string spv_errors;
-  spvtools::SpirvTools tools(static_cast<spv_target_env>(spv_env_));
+
+  spv_target_env target_env = SPV_ENV_UNIVERSAL_1_0;
+  if (!spv_env_.empty()) {
+    if (!spvParseTargetEnv(spv_env_.c_str(), &target_env))
+      return {Result("Unable to parse SPIR-V target environment"), {}};
+  }
+
+  spvtools::SpirvTools tools(target_env);
   tools.SetMessageConsumer([&spv_errors](spv_message_level_t level, const char*,
                                          const spv_position_t& position,
                                          const char* message) {

--- a/src/shader_compiler.h
+++ b/src/shader_compiler.h
@@ -28,7 +28,7 @@ namespace amber {
 class ShaderCompiler {
  public:
   ShaderCompiler();
-  explicit ShaderCompiler(uint32_t env);
+  explicit ShaderCompiler(const std::string& env);
   ~ShaderCompiler();
 
   std::pair<Result, std::vector<uint32_t>> Compile(
@@ -39,7 +39,7 @@ class ShaderCompiler {
   Result ParseHex(const std::string& data, std::vector<uint32_t>* result) const;
   Result CompileGlsl(Shader* shader, std::vector<uint32_t>* result) const;
 
-  uint32_t spv_env_ = 0;
+  std::string spv_env_;
 };
 
 }  // namespace amber

--- a/src/shader_compiler.h
+++ b/src/shader_compiler.h
@@ -28,6 +28,7 @@ namespace amber {
 class ShaderCompiler {
  public:
   ShaderCompiler();
+  explicit ShaderCompiler(uint32_t env);
   ~ShaderCompiler();
 
   std::pair<Result, std::vector<uint32_t>> Compile(
@@ -37,6 +38,8 @@ class ShaderCompiler {
  private:
   Result ParseHex(const std::string& data, std::vector<uint32_t>* result) const;
   Result CompileGlsl(Shader* shader, std::vector<uint32_t>* result) const;
+
+  uint32_t spv_env_ = 0;
 };
 
 }  // namespace amber


### PR DESCRIPTION
This CL adds an option to the amber sample application to set the SPIR-V
target environment. The environment name matches the names accepted by
the other spirv-tools applications.

The envionment is set into the script and used by the shader compiler.