### PR TITLE
Sample app shutdown always

### DIFF
--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -330,9 +330,9 @@ int main(int argc, const char** argv) {
     std::cout << "\nSummary: "
               << (options.input_filenames.size() - failures.size()) << " pass, "
               << failures.size() << " fail" << std::endl;
-
-    config_helper.Shutdown();
   }
+
+  config_helper.Shutdown();
 
   return !failures.empty();
 }


### PR DESCRIPTION
Currently the shutdown logic is only being run if the -s option is
passed. This is a mistake and it should be run all the time.