### PR TITLE
Fix unused parameter warning

### DIFF
--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -456,8 +456,7 @@ Result EngineDawn::GetFrameBufferInfo(ResourceInfo* info) {
   return {};
 }
 
-Result EngineDawn::GetFrameBuffer(std::vector<Value>* values) {
-  assert(values);
+Result EngineDawn::GetFrameBuffer(std::vector<Value>*) {
   return Result("Dawn::GetFrameBuffer not implemented");
 }
 


### PR DESCRIPTION
Warning occurs on a release build because the assert disappears.