### PR TITLE
Fixup image buffer dump

### DIFF
--- a/samples/ppm.cc
+++ b/samples/ppm.cc
@@ -52,10 +52,10 @@ std::pair<amber::Result, std::string> ConvertToPPM(
   // Write PPM data
   for (amber::Value value : values) {
     const uint32_t pixel = value.AsUint32();
-    // We assume R8G8B8A8_UINT here:
-    image.push_back(byte0(pixel));  // R
+    // We assume B8G8R8A8_UNORM here:
+    image.push_back(byte2(pixel));  // R
     image.push_back(byte1(pixel));  // G
-    image.push_back(byte2(pixel));  // B
+    image.push_back(byte0(pixel));  // B
     // PPM does not support alpha channel
   }
 

--- a/samples/ppm.cc
+++ b/samples/ppm.cc
@@ -53,9 +53,9 @@ std::pair<amber::Result, std::string> ConvertToPPM(
   for (amber::Value value : values) {
     const uint32_t pixel = value.AsUint32();
     // We assume B8G8R8A8_UNORM here:
-    image.push_back(byte2(pixel));  // B
+    image.push_back(byte2(pixel));  // R
     image.push_back(byte1(pixel));  // G
-    image.push_back(byte0(pixel));  // R
+    image.push_back(byte0(pixel));  // B
     // PPM does not support alpha channel
   }
 

--- a/samples/ppm.cc
+++ b/samples/ppm.cc
@@ -53,9 +53,9 @@ std::pair<amber::Result, std::string> ConvertToPPM(
   for (amber::Value value : values) {
     const uint32_t pixel = value.AsUint32();
     // We assume B8G8R8A8_UNORM here:
-    image.push_back(byte2(pixel));  // R
+    image.push_back(byte2(pixel));  // B
     image.push_back(byte1(pixel));  // G
-    image.push_back(byte0(pixel));  // B
+    image.push_back(byte0(pixel));  // R
     // PPM does not support alpha channel
   }
 

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -30,6 +30,7 @@ namespace {
 
 const uint32_t kFramebufferWidth = 250;
 const uint32_t kFramebufferHeight = 250;
+const FormatType kDefaultFramebufferFormat = FormatType::kB8G8R8A8_UNORM;
 
 VkShaderStageFlagBits ToVkShaderStage(ShaderType type) {
   switch (type) {
@@ -93,9 +94,9 @@ Result EngineVulkan::Initialize(EngineConfig* config,
       return r;
   }
 
-  // Set VK_FORMAT_B8G8R8A8_UNORM for color frame buffer in default.
+  // Set VK_FORMAT_B8G8R8A8_UNORM for color frame buffer by default.
   color_frame_format_ = MakeUnique<Format>();
-  color_frame_format_->SetFormatType(FormatType::kB8G8R8A8_UNORM);
+  color_frame_format_->SetFormatType(kDefaultFramebufferFormat);
   color_frame_format_->AddComponent(FormatComponentType::kB, FormatMode::kUNorm,
                                     8);
   color_frame_format_->AddComponent(FormatComponentType::kG, FormatMode::kUNorm,
@@ -464,7 +465,7 @@ Result EngineVulkan::GetFrameBuffer(std::vector<Value>* values) {
   }
 
   // TODO(jaebaek): Support other formats
-  if (color_frame_format_->GetFormatType() != FormatType::kR8G8B8A8_UINT)
+  if (color_frame_format_->GetFormatType() != kDefaultFramebufferFormat)
     return Result("Vulkan::GetFrameBuffer Unsupported buffer format");
 
   Value pixel;


### PR DESCRIPTION
This CL updates the image dumping code to the new default framebuffer format of B8G8R8A8_UNORM.
  