### PR TITLE
Fixup sample app buffer parsing

### DIFF
--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -50,18 +50,18 @@ struct Options {
 const char kUsage[] = R"(Usage: amber [options] SCRIPT [SCRIPTS...]
 
  options:
-  -p                  -- Parse input files only; Don't execute.
-  -s                  -- Print summary of pass/failure.
-  -d                  -- Disable validation layers.
-  -t <spirv_env> -- The target SPIR-V environment. Defaults to SPV_ENV_UNIVERSAL_1_0.
-  -i <filename>       -- Write rendering to <filename> as a PPM image.
-  -b <filename>       -- Write contents of a UBO or SSBO to <filename>.
-  -B [<desc set>:]<binding>     -- Descriptor set and binding of buffer to write.
-                                   Default is [0:]0.
-  -e <engine>         -- Specify graphics engine: vulkan, dawn. Default is vulkan.
-  -v <engine version> -- Engine version (eg, 1.1 for Vulkan). Default 1.0.
-  -V, --version       -- Output version information for Amber and libraries.
-  -h                  -- This help text.
+  -p                        -- Parse input files only; Don't execute.
+  -s                        -- Print summary of pass/failure.
+  -d                        -- Disable validation layers.
+  -t <spirv_env>            -- The target SPIR-V environment. Defaults to SPV_ENV_UNIVERSAL_1_0.
+  -i <filename>             -- Write rendering to <filename> as a PPM image.
+  -b <filename>             -- Write contents of a UBO or SSBO to <filename>.
+  -B [<desc set>:]<binding> -- Descriptor set and binding of buffer to write.
+                               Default is [0:]0.
+  -e <engine>               -- Specify graphics engine: vulkan, dawn. Default is vulkan.
+  -v <engine version>       -- Engine version (eg, 1.1 for Vulkan). Default 1.0.
+  -V, --version             -- Output version information for Amber and libraries.
+  -h                        -- This help text.
 )";
 
 bool ParseArgs(const std::vector<std::string>& args, Options* opts) {
@@ -293,7 +293,13 @@ int main(int argc, const char** argv) {
 
   amber_options.config = config.get();
 
-  if (!options.buffer_filename.empty() && !options.buffer_to_dump.empty()) {
+  if (!options.buffer_filename.empty()) {
+    // Have a filename to dump, but no explicit buffer, set the default of 0:0.
+    if (options.buffer_to_dump.empty()) {
+      options.buffer_to_dump.emplace_back();
+      options.buffer_to_dump.back().buffer_name = "0:0";
+    }
+
     amber_options.extractions.insert(amber_options.extractions.end(),
                                      options.buffer_to_dump.begin(),
                                      options.buffer_to_dump.end());

--- a/src/descriptor_set_and_binding_parser.cc
+++ b/src/descriptor_set_and_binding_parser.cc
@@ -15,6 +15,8 @@
 #include "src/descriptor_set_and_binding_parser.h"
 
 #include <iostream>
+#include <limits>
+
 #include "src/tokenizer.h"
 
 namespace amber {
@@ -47,19 +49,25 @@ Result DescriptorSetAndBindingParser::Parse(const std::string& buffer_id) {
     descriptor_set_ = 0;
   }
 
-  std::cout << token->AsString() << std::endl;
-  if (!token->IsString() || token->AsString() != ",") {
+  if (!token->IsString())
     return Result("Invalid buffer id: " + buffer_id);
-  }
 
-  token = t.NextToken();
-  if (!token->IsInteger() || token->AsInt32() < 0) {
+  auto& str = token->AsString();
+  if (str.size() < 2 || str[0] != ':')
+    return Result("Invalid buffer id: " + buffer_id);
+
+  auto substr = str.substr(1, str.size());
+  uint64_t binding_val = strtoul(substr.c_str(), nullptr, 10);
+  if (binding_val > std::numeric_limits<uint32_t>::max())
+    return Result("binding value too large in probe ssbo command: " +
+                  token->ToOriginalString());
+  if (static_cast<int32_t>(binding_val) < 0) {
     return Result(
         "Binding for a buffer must be non-negative integer, but you gave: " +
         token->ToOriginalString());
   }
 
-  binding_ = token->AsUint32();
+  binding_ = static_cast<uint32_t>(binding_val);
   return {};
 }
 

--- a/src/descriptor_set_and_binding_parser.cc
+++ b/src/descriptor_set_and_binding_parser.cc
@@ -57,6 +57,16 @@ Result DescriptorSetAndBindingParser::Parse(const std::string& buffer_id) {
     return Result("Invalid buffer id: " + buffer_id);
 
   auto substr = str.substr(1, str.size());
+  // Validate all characters are integers.
+  for (size_t i = 0; i < substr.size(); ++i) {
+    if (substr[i] < '0' || substr[i] > '9') {
+      return Result(
+          "Binding for a buffer must be non-negative integer, "
+          "but you gave: " +
+          substr);
+    }
+  }
+
   uint64_t binding_val = strtoul(substr.c_str(), nullptr, 10);
   if (binding_val > std::numeric_limits<uint32_t>::max())
     return Result("binding value too large in probe ssbo command: " +

--- a/src/descriptor_set_and_binding_parser_test.cc
+++ b/src/descriptor_set_and_binding_parser_test.cc
@@ -22,7 +22,7 @@ using DescriptorSetAndBindingParserTest = testing::Test;
 
 TEST_F(DescriptorSetAndBindingParserTest, CommaAndBinding) {
   DescriptorSetAndBindingParser parser;
-  Result r = parser.Parse(",1234");
+  Result r = parser.Parse(":1234");
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
   EXPECT_EQ(0, parser.GetDescriptorSet());
@@ -40,7 +40,7 @@ TEST_F(DescriptorSetAndBindingParserTest, Binding) {
 
 TEST_F(DescriptorSetAndBindingParserTest, DescSetAndBinding) {
   DescriptorSetAndBindingParser parser;
-  Result r = parser.Parse("1234,5678");
+  Result r = parser.Parse("1234:5678");
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
   EXPECT_EQ(1234, parser.GetDescriptorSet());
@@ -67,7 +67,7 @@ TEST_F(DescriptorSetAndBindingParserTest, InvalidCharacterBetweenTwoNumbers) {
 
 TEST_F(DescriptorSetAndBindingParserTest, InvalidCharacterAfterComma) {
   DescriptorSetAndBindingParser parser;
-  Result r = parser.Parse("1234,a5678");
+  Result r = parser.Parse("1234:a5678");
   EXPECT_EQ(
       "Binding for a buffer must be non-negative integer, but you gave: a5678",
       r.Error());
@@ -75,7 +75,7 @@ TEST_F(DescriptorSetAndBindingParserTest, InvalidCharacterAfterComma) {
 
 TEST_F(DescriptorSetAndBindingParserTest, NegativeDescSet) {
   DescriptorSetAndBindingParser parser;
-  Result r = parser.Parse("-1234,5678");
+  Result r = parser.Parse("-1234:5678");
   EXPECT_EQ(
       "Descriptor set and binding for a buffer must be non-negative integer, "
       "but you gave: -1234",
@@ -84,7 +84,7 @@ TEST_F(DescriptorSetAndBindingParserTest, NegativeDescSet) {
 
 TEST_F(DescriptorSetAndBindingParserTest, NegativeBindingAfterComma) {
   DescriptorSetAndBindingParser parser;
-  Result r = parser.Parse(",-1234");
+  Result r = parser.Parse(":-1234");
   EXPECT_EQ(
       "Binding for a buffer must be non-negative integer, but you gave: -1234",
       r.Error());
@@ -101,7 +101,7 @@ TEST_F(DescriptorSetAndBindingParserTest, NegativeBinding) {
 
 TEST_F(DescriptorSetAndBindingParserTest, DescSetAndNegativeBinding) {
   DescriptorSetAndBindingParser parser;
-  Result r = parser.Parse("1234,-5678");
+  Result r = parser.Parse("1234:-5678");
   EXPECT_EQ(
       "Binding for a buffer must be non-negative integer, but you gave: -5678",
       r.Error());

--- a/src/tokenizer.cc
+++ b/src/tokenizer.cc
@@ -157,7 +157,8 @@ std::unique_ptr<Token> Tokenizer::NextToken() {
   if (tok_str.size() > 1 && tok_str[0] == '-')
     tok->SetNegative();
 
-  tok->SetOriginalString(tok_str);
+  tok->SetOriginalString(
+      tok_str.substr(0, static_cast<size_t>(final_pos - tok_str.c_str())));
 
   // If the number isn't the whole token then move back so we can then parse
   // the string portion.

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -20,6 +20,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
       -Wno-disabled-macro-expansion
       -Wno-exit-time-constructors
       -Wno-exit-time-destructors
+      -Wno-extra-semi-stmt
       -Wno-global-constructors
       -Wno-missing-field-initializers
       -Wno-format-nonliteral
@@ -44,6 +45,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
       -Wno-error
       -Wno-exit-time-destructors
       -Wno-extra-semi
+      -Wno-extra-semi-stmt
       -Wno-float-equal
       -Wno-format-nonliteral
       -Wno-format-pedantic
@@ -85,6 +87,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
       -Wno-documentation-pedantic
       -Wno-double-promotion
       -Wno-extra-semi
+      -Wno-extra-semi-stmt
       -Wno-float-equal
       -Wno-format-nonliteral
       -Wno-implicit-fallthrough
@@ -132,9 +135,11 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 
   set(GLSLANG_BUILD_FIXES
       -Wno-error
+      -Wno-implicit-fallthrough
       -Wno-overflow
       -Wno-missing-field-initializers
       -Wno-pedantic
+      -Wno-strict-aliasing
       -Wno-unused-parameter
       -Wno-unused-variable)
 


### PR DESCRIPTION
This CL fixes the -B flag to default to 0:0 if not provided. It also
fixes the code to use : as the separator instead of ,