### PR TITLE
Add image dump in PNG

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -25,7 +25,7 @@ deps = {
       vars['glslang_revision'],
 
   'third_party/lodepng': vars['lvandeve_git'] + '/lodepng.git@' +
-      vars['glslang_revision'],
+      vars['lodepng_revision'],
 
   'third_party/shaderc': vars['google_git'] + '/shaderc.git@' +
       vars['shaderc_revision'],

--- a/DEPS
+++ b/DEPS
@@ -3,10 +3,12 @@ use_relative_paths = True
 vars = {
   'google_git':  'https://github.com/google',
   'khronos_git': 'https://github.com/KhronosGroup',
+  'lvandeve_git':  'https://github.com/lvandeve',
 
   'cpplint_revision': '9f41862c0efa7681e2147910d39629c73a2b2702',
   'glslang_revision': 'f44b17ee135d5e153ce000e88b806b5377812b11',
   'googletest_revision': 'd5932506d6eed73ac80b9bcc47ed723c8c74eb1e',
+  'lodepng_revision': 'ba9fc1f084f03b5fbf8c9a5df9448173f27544b1',
   'shaderc_revision': '53c776f776821bc037b31b8b3b79db2fa54b4ce7',
   'spirv_headers_revision': '8bea0a266ac9b718aa0818d9e3a47c0b77c2cb23',
   'spirv_tools_revision': '39bfb6b978e937487a9cedfd964d61a3ac4384b8',
@@ -20,6 +22,9 @@ deps = {
       vars['googletest_revision'],
 
   'third_party/glslang': vars['khronos_git'] + '/glslang.git@' +
+      vars['glslang_revision'],
+
+  'third_party/lodepng': vars['lvandeve_git'] + '/lodepng.git@' +
       vars['glslang_revision'],
 
   'third_party/shaderc': vars['google_git'] + '/shaderc.git@' +

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -14,11 +14,16 @@
 
 include_directories("${PROJECT_SOURCE_DIR}/include")
 
+set(LODEPNG ${PROJECT_SOURCE_DIR}/third_party/lodepng)
+include_directories("${PROJECT_SOURCE_DIR}/third_party")
+
 set(AMBER_SOURCES
     amber.cc
     config_helper.cc
     log.cc
     ppm.cc
+    png.cc
+    ${LODEPNG}/lodepng.cpp
     ${CMAKE_BINARY_DIR}/src/build-versions.h.fake
 )
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -14,20 +14,16 @@
 
 include_directories("${PROJECT_SOURCE_DIR}/include")
 
-set(LODEPNG ${PROJECT_SOURCE_DIR}/third_party/lodepng)
-include_directories("${PROJECT_SOURCE_DIR}/third_party")
-
 set(AMBER_SOURCES
     amber.cc
     config_helper.cc
     log.cc
     ppm.cc
     png.cc
-    ${LODEPNG}/lodepng.cpp
     ${CMAKE_BINARY_DIR}/src/build-versions.h.fake
 )
 
-set(AMBER_EXTRA_LIBS "")
+set(AMBER_EXTRA_LIBS "lodepng")
 
 if (${Vulkan_FOUND})
   set(AMBER_SOURCES ${AMBER_SOURCES} config_helper_vulkan.cc)

--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -24,6 +24,7 @@
 #include "amber/amber.h"
 #include "amber/recipe.h"
 #include "samples/config_helper.h"
+#include "samples/png.h"
 #include "samples/ppm.h"
 #include "src/build-versions.h"
 #include "src/make_unique.h"
@@ -54,7 +55,7 @@ const char kUsage[] = R"(Usage: amber [options] SCRIPT [SCRIPTS...]
   -s                  -- Print summary of pass/failure.
   -d                  -- Disable validation layers.
   -t <spirv_env> -- The target SPIR-V environment. Defaults to SPV_ENV_UNIVERSAL_1_0.
-  -i <filename>       -- Write rendering to <filename> as a PPM image.
+  -i <filename>       -- Write rendering to <filename> as a PNG image if it ends with '.png', or as a PPM image otherwise.
   -b <filename>       -- Write contents of a UBO or SSBO to <filename>.
   -B [<desc set>:]<binding>     -- Descriptor set and binding of buffer to write.
                                    Default is [0:]0.
@@ -319,10 +320,18 @@ int main(int argc, const char** argv) {
 
     if (!options.image_filename.empty()) {
       std::string image;
+      bool usePNG = options.image_filename.compare(
+          options.image_filename.length() - 5, options.image_filename.length(),
+          ".png");
       for (amber::BufferInfo buffer_info : amber_options.extractions) {
         if (buffer_info.buffer_name == "framebuffer") {
-          std::tie(result, image) = ppm::ConvertToPPM(
-              buffer_info.width, buffer_info.height, buffer_info.values);
+          if (usePNG) {
+            std::tie(result, image) = png::ConvertToPNG(
+                buffer_info.width, buffer_info.height, buffer_info.values);
+          } else {
+            std::tie(result, image) = ppm::ConvertToPPM(
+                buffer_info.width, buffer_info.height, buffer_info.values);
+          }
           break;
         }
       }

--- a/samples/png.cc
+++ b/samples/png.cc
@@ -18,7 +18,7 @@
 
 #include "amber/result.h"
 #include "amber/value.h"
-#include "lodepng/lodepng.h"
+#include "third_party/lodepng/lodepng.h"
 
 namespace png {
 

--- a/samples/png.cc
+++ b/samples/png.cc
@@ -1,0 +1,77 @@
+// Copyright 2019 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "samples/png.h"
+
+#include <cassert>
+
+#include "amber/result.h"
+#include "amber/value.h"
+#include "lodepng/lodepng.h"
+
+namespace png {
+
+namespace {
+
+unsigned char byte0(uint32_t word) {
+  return static_cast<unsigned char>(word);
+}
+
+unsigned char byte1(uint32_t word) {
+  return static_cast<unsigned char>(word >> 8);
+}
+
+unsigned char byte2(uint32_t word) {
+  return static_cast<unsigned char>(word >> 16);
+}
+
+unsigned char byte3(uint32_t word) {
+  return static_cast<unsigned char>(word >> 24);
+}
+
+}  // namespace
+
+std::pair<amber::Result, std::string> ConvertToPNG(
+    uint32_t width,
+    uint32_t height,
+    const std::vector<amber::Value>& values) {
+  assert(values.size() == width * height);
+
+  std::vector<unsigned char> data;
+
+  // Prepare data as lodepng expects it
+  for (amber::Value value : values) {
+    const uint32_t pixel = value.AsUint32();
+    data.push_back(byte2(pixel));  // R
+    data.push_back(byte1(pixel));  // G
+    data.push_back(byte0(pixel));  // B
+    data.push_back(byte3(pixel));  // A
+  }
+
+  std::vector<unsigned char> png;
+  unsigned error = lodepng::encode(png, data, width, height);
+  if (error) {
+    return std::make_pair(amber::Result("lodepng::encode() returned non-zero"),
+                          nullptr);
+  }
+
+  std::string image;
+  for (unsigned char c : png) {
+    image.push_back(c);
+  }
+
+  return std::make_pair(amber::Result(), image);
+}
+
+}  // namespace png

--- a/samples/png.h
+++ b/samples/png.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SAMPLES_PPM_H_
-#define SAMPLES_PPM_H_
+#ifndef SAMPLES_PNG_H_
+#define SAMPLES_PNG_H_
 
 #include <string>
 #include <utility>
@@ -21,16 +21,16 @@
 
 #include "amber/amber.h"
 
-namespace ppm {
+namespace png {
 
 /// Converts the image of dimensions |width| and |height| and with pixels stored
-/// in row-major order in |values| with format B8G8R8A8 into PPM format,
-/// returning the PPM binary as a string.
-std::pair<amber::Result, std::string> ConvertToPPM(
+/// in row-major order in |values| with format B8G8R8A8 into PNG format,
+/// returning the PNG binary as a string.
+std::pair<amber::Result, std::string> ConvertToPNG(
     uint32_t width,
     uint32_t height,
     const std::vector<amber::Value>& values);
 
-}  // namespace ppm
+}  // namespace png
 
-#endif  // SAMPLES_PPM_H_
+#endif  // SAMPLES_PNG_H_

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -77,6 +77,11 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
       -Wno-weak-vtables
       -Wno-zero-as-null-pointer-constant)
 
+  set(LODEPNG_BUILD_FIXES
+      -Wno-missing-prototypes
+      -Wno-old-style-cast
+  )
+
   set(SPIRV_TOOLS_BUILD_FIXES
       -Wno-conditional-uninitialized
       -Wno-covered-switch-default
@@ -138,6 +143,8 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
       -Wno-unused-parameter
       -Wno-unused-variable)
 
+  set(LODEPNG_BUILD_FIXES "")
+
   set(SPIRV_TOOLS_BUILD_FIXES "")
 
   set(SHADERC_BUILD_FIXES
@@ -183,8 +190,13 @@ if (MSVC)
 	/wd5045
   )
 
+  set(LODEPNG_BUILD_FIXES
+	/W3
+	/wd4267
+  )
+
   set(SPIRV_TOOLS_BUILD_FIXES
-    /W3
+	/W3
 	/wd4365
 	/wd4389
 	/wd4571
@@ -203,7 +215,7 @@ if (MSVC)
 	/wd5045
   )
 
-set(SHADERC_BUILD_FIXES
+  set(SHADERC_BUILD_FIXES
 	/W3
 	/wd4365
 	/wd4571
@@ -264,4 +276,9 @@ if (${AMBER_ENABLE_SHADERC})
   set(CMAKE_CXX_FLAGS ${CXX_BACK})
 endif()
 
+# Lodepng
+set(CXX_BACK ${CMAKE_CXX_FLAGS})
+SET(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "${LODEPNG_BUILD_FIXES}")
+STRING(REGEX REPLACE ";" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 add_library(lodepng STATIC ${CMAKE_CURRENT_SOURCE_DIR}/lodepng/lodepng.cpp)
+set(CMAKE_CXX_FLAGS ${CXX_BACK})

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -263,3 +263,5 @@ if (${AMBER_ENABLE_SHADERC})
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/shaderc)
   set(CMAKE_CXX_FLAGS ${CXX_BACK})
 endif()
+
+add_library(lodepng STATIC ${CMAKE_CURRENT_SOURCE_DIR}/lodepng/lodepng.cpp)


### PR DESCRIPTION
This change adds support to dump image to PNG format, it relies on the third party 'lodepng' library (zlib license).

Maybe PPM support can be dropped subsequently, but it would break backward compatibility with vkrunner.

Note that in the cmake we add `third_party/` as an include directory in order to please the linter about the `import` line of lodepng, which the linter insists to have the directory in it.