### PR TITLE
Add -ps option to allow compiling shaders.

### DIFF
--- a/include/amber/amber.h
+++ b/include/amber/amber.h
@@ -61,6 +61,8 @@ struct Options {
   std::string spv_env;
   /// Lists the buffers to extract at the end of the execution
   std::vector<BufferInfo> extractions;
+  /// Terminate after compiling shaders; Don't execute script.
+  bool shader_compile_only;
 };
 
 /// Main interface to the Amber environment.

--- a/include/amber/amber.h
+++ b/include/amber/amber.h
@@ -61,8 +61,8 @@ struct Options {
   std::string spv_env;
   /// Lists the buffers to extract at the end of the execution
   std::vector<BufferInfo> extractions;
-  /// Terminate after compiling shaders; Don't execute script.
-  bool shader_compile_only;
+  /// Terminate after creating the pipelines.
+  bool pipeline_create_only;
 };
 
 /// Main interface to the Amber environment.

--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -39,6 +39,7 @@ struct Options {
   uint32_t engine_major = 1;
   uint32_t engine_minor = 0;
   bool parse_only = false;
+  bool shader_compile_only = false;
   bool disable_validation_layer = false;
   bool show_summary = false;
   bool show_help = false;
@@ -51,6 +52,7 @@ const char kUsage[] = R"(Usage: amber [options] SCRIPT [SCRIPTS...]
 
  options:
   -p                        -- Parse input files only; Don't execute.
+  -ps                       -- Parse input files, compile shaders; Don't execute.
   -s                        -- Print summary of pass/failure.
   -d                        -- Disable validation layers.
   -t <spirv_env>            -- The target SPIR-V environment. Defaults to SPV_ENV_UNIVERSAL_1_0.
@@ -145,6 +147,8 @@ bool ParseArgs(const std::vector<std::string>& args, Options* opts) {
       opts->show_version_info = true;
     } else if (arg == "-p") {
       opts->parse_only = true;
+    } else if (arg == "-ps") {
+      opts->shader_compile_only = true;
     } else if (arg == "-d") {
       opts->disable_validation_layer = true;
     } else if (arg == "-s") {
@@ -264,6 +268,7 @@ int main(int argc, const char** argv) {
   amber::Options amber_options;
   amber_options.engine = options.engine;
   amber_options.spv_env = options.spv_env;
+  amber_options.shader_compile_only = options.shader_compile_only;
 
   std::set<std::string> required_features;
   std::set<std::string> required_extensions;

--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -39,7 +39,7 @@ struct Options {
   uint32_t engine_major = 1;
   uint32_t engine_minor = 0;
   bool parse_only = false;
-  bool shader_compile_only = false;
+  bool pipeline_create_only = false;
   bool disable_validation_layer = false;
   bool show_summary = false;
   bool show_help = false;
@@ -52,7 +52,7 @@ const char kUsage[] = R"(Usage: amber [options] SCRIPT [SCRIPTS...]
 
  options:
   -p                        -- Parse input files only; Don't execute.
-  -ps                       -- Parse input files, compile shaders; Don't execute.
+  -ps                       -- Parse input files, create pipelines; Don't execute.
   -s                        -- Print summary of pass/failure.
   -d                        -- Disable validation layers.
   -t <spirv_env>            -- The target SPIR-V environment. Defaults to SPV_ENV_UNIVERSAL_1_0.
@@ -148,7 +148,7 @@ bool ParseArgs(const std::vector<std::string>& args, Options* opts) {
     } else if (arg == "-p") {
       opts->parse_only = true;
     } else if (arg == "-ps") {
-      opts->shader_compile_only = true;
+      opts->pipeline_create_only = true;
     } else if (arg == "-d") {
       opts->disable_validation_layer = true;
     } else if (arg == "-s") {
@@ -268,7 +268,7 @@ int main(int argc, const char** argv) {
   amber::Options amber_options;
   amber_options.engine = options.engine;
   amber_options.spv_env = options.spv_env;
-  amber_options.shader_compile_only = options.shader_compile_only;
+  amber_options.pipeline_create_only = options.pipeline_create_only;
 
   std::set<std::string> required_features;
   std::set<std::string> required_extensions;

--- a/src/amber.cc
+++ b/src/amber.cc
@@ -68,6 +68,10 @@ amber::Result Amber::ExecuteWithShaderData(const amber::Recipe* recipe,
 
   script->SetSpvTargetEnv(opts->spv_env);
 
+  Executor executor;
+  if (opts->shader_compile_only)
+    return executor.CompileShaders(script, shader_data);
+
   auto engine = Engine::Create(opts->engine);
   if (!engine)
     return Result("Failed to create engine");
@@ -77,7 +81,6 @@ amber::Result Amber::ExecuteWithShaderData(const amber::Recipe* recipe,
   if (!r.IsSuccess())
     return r;
 
-  Executor executor;
   r = executor.Execute(engine.get(), script, shader_data);
   if (!r.IsSuccess()) {
     // Clean up Vulkan/Dawn objects

--- a/src/amber.cc
+++ b/src/amber.cc
@@ -68,10 +68,6 @@ amber::Result Amber::ExecuteWithShaderData(const amber::Recipe* recipe,
 
   script->SetSpvTargetEnv(opts->spv_env);
 
-  Executor executor;
-  if (opts->shader_compile_only)
-    return executor.CompileShaders(script, shader_data);
-
   auto engine = Engine::Create(opts->engine);
   if (!engine)
     return Result("Failed to create engine");
@@ -81,7 +77,11 @@ amber::Result Amber::ExecuteWithShaderData(const amber::Recipe* recipe,
   if (!r.IsSuccess())
     return r;
 
-  r = executor.Execute(engine.get(), script, shader_data);
+  Executor executor;
+  r = executor.Execute(engine.get(), script, shader_data,
+                       opts->pipeline_create_only
+                           ? ExecutionType::kPipelineCreateOnly
+                           : ExecutionType::kExecute);
   if (!r.IsSuccess()) {
     // Clean up Vulkan/Dawn objects
     engine->Shutdown();

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -48,7 +48,8 @@ Result Executor::CompileShaders(const amber::Script* script,
 
 Result Executor::Execute(Engine* engine,
                          const amber::Script* script,
-                         const ShaderMap& shader_map) {
+                         const ShaderMap& shader_map,
+                         ExecutionType executionType) {
   engine->SetEngineData(script->GetEngineData());
 
   if (script->GetPipelines().empty())
@@ -66,6 +67,8 @@ Result Executor::Execute(Engine* engine,
   r = engine->CreatePipeline(pipeline);
   if (!r.IsSuccess())
     return r;
+  if (executionType == ExecutionType::kPipelineCreateOnly)
+    return {};
 
   // Process Commands
   for (const auto& cmd : script->GetCommands()) {

--- a/src/executor.h
+++ b/src/executor.h
@@ -22,6 +22,8 @@
 
 namespace amber {
 
+enum class ExecutionType { kExecute = 0, kPipelineCreateOnly };
+
 /// The executor is responsible for running the given script against an engine.
 class Executor {
  public:
@@ -29,17 +31,17 @@ class Executor {
   Executor();
   ~Executor();
 
-  /// Execute just the shader compile for each shader. This will be run
-  /// automatically by Execute() but is provided here if the entire engine is
-  /// not required.
-  Result CompileShaders(const Script* script, const ShaderMap& shader_map);
-
   /// Executes |script| against |engine|. For each shader described in |script|
   /// if the shader name exists in |map| the value for that map'd key will be
   /// used as the shader binary.
-  Result Execute(Engine* engine, const Script* script, const ShaderMap& map);
+  Result Execute(Engine* engine,
+                 const Script* script,
+                 const ShaderMap& map,
+                 ExecutionType executionType);
 
  private:
+  Result CompileShaders(const Script* script, const ShaderMap& shader_map);
+
   Verifier verifier_;
 };
 

--- a/src/executor.h
+++ b/src/executor.h
@@ -29,6 +29,11 @@ class Executor {
   Executor();
   ~Executor();
 
+  /// Execute just the shader compile for each shader. This will be run
+  /// automatically by Execute() but is provided here if the entire engine is
+  /// not required.
+  Result CompileShaders(const Script* script, const ShaderMap& shader_map);
+
   /// Executes |script| against |engine|. For each shader described in |script|
   /// if the shader name exists in |map| the value for that map'd key will be
   /// used as the shader binary.

--- a/src/executor_test.cc
+++ b/src/executor_test.cc
@@ -227,7 +227,8 @@ logicOp)";
                                         script->RequiredExtensions());
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
 
   const auto& features = ToStub(engine.get())->GetFeatures();
@@ -255,7 +256,8 @@ VK_KHR_variable_pointers)";
                                         script->RequiredExtensions());
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
 
   const auto& features = ToStub(engine.get())->GetFeatures();
@@ -283,7 +285,8 @@ depthstencil D24_UNORM_S8_UINT)";
                                         script->RequiredExtensions());
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
 
   const auto& features = ToStub(engine.get())->GetFeatures();
@@ -308,7 +311,8 @@ fence_timeout 12345)";
                                         script->RequiredExtensions());
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
 
   const auto& features = ToStub(engine.get())->GetFeatures();
@@ -339,7 +343,8 @@ fence_timeout 12345)";
                                         script->RequiredExtensions());
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
 
   const auto& features = ToStub(engine.get())->GetFeatures();
@@ -367,7 +372,8 @@ clear)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   EXPECT_TRUE(ToStub(engine.get())->DidClearCommand());
 }
@@ -385,7 +391,8 @@ clear)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("clear command failed", r.Error());
 }
@@ -402,7 +409,8 @@ clear color 244 123 123 13)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidClearColorCommand());
 
@@ -429,7 +437,8 @@ clear color 123 123 123 123)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("clear color command failed", r.Error());
 }
@@ -446,7 +455,8 @@ clear depth 24)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidClearDepthCommand());
 }
@@ -464,7 +474,8 @@ clear depth 24)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("clear depth command failed", r.Error());
 }
@@ -481,7 +492,8 @@ clear stencil 24)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidClearStencilCommand());
 }
@@ -499,7 +511,8 @@ clear stencil 24)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("clear stencil command failed", r.Error());
 }
@@ -516,7 +529,8 @@ draw rect 2 4 10 20)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidDrawRectCommand());
 }
@@ -534,7 +548,8 @@ draw rect 2 4 10 20)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("draw rect command failed", r.Error());
 }
@@ -551,7 +566,8 @@ draw arrays TRIANGLE_LIST 0 0)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidDrawArraysCommand());
 }
@@ -569,7 +585,8 @@ draw arrays TRIANGLE_LIST 0 0)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("draw arrays command failed", r.Error());
 }
@@ -586,7 +603,8 @@ compute 2 3 4)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidComputeCommand());
 }
@@ -604,7 +622,8 @@ compute 2 3 4)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("compute command failed", r.Error());
 }
@@ -621,7 +640,8 @@ vertex entrypoint main)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidEntryPointCommand());
 }
@@ -639,7 +659,8 @@ vertex entrypoint main)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("entrypoint command failed", r.Error());
 }
@@ -656,7 +677,8 @@ patch parameter vertices 10)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidPatchParameterVerticesCommand());
 }
@@ -674,7 +696,8 @@ patch parameter vertices 10)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("patch command failed", r.Error());
 }
@@ -691,7 +714,8 @@ probe rect rgba 2 3 40 40 0.2 0.4 0.4 0.3)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   // ASSERT_TRUE(ToStub(engine.get())->DidProbeCommand());
 }
@@ -709,7 +733,8 @@ probe rect rgba 2 3 40 40 0.2 0.4 0.4 0.3)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("probe command failed", r.Error());
 }
@@ -726,7 +751,8 @@ ssbo 0 24)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidBufferCommand());
 }
@@ -744,7 +770,8 @@ ssbo 0 24)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("buffer command failed", r.Error());
 }
@@ -761,7 +788,8 @@ probe ssbo vec3 0 2 <= 2 3 4)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   // ASSERT_TRUE(ToStub(engine.get())->DidProbeSSBOCommand());
 }
@@ -779,7 +807,8 @@ probe ssbo vec3 0 2 <= 2 3 4)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
+  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+                        ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("probe ssbo command failed", r.Error());
 }


### PR DESCRIPTION
This CL adds a -ps option to the sample app to allow parsing the script
and executing the shader compiler. The script is not run against the
engine (and the engine is not created).