### PR TITLE
Differentiate between instance and device extensions.

### DIFF
--- a/include/amber/amber_vulkan.h
+++ b/include/amber/amber_vulkan.h
@@ -39,8 +39,11 @@ struct VulkanEngineConfig : public EngineConfig {
   /// Physical device features available for |physical_device|.
   VkPhysicalDeviceFeatures available_features;
 
+  /// Instance extensions available.
+  std::vector<std::string> available_instance_extensions;
+
   /// Physical device extensions available for |physical_device|.
-  std::vector<std::string> available_extensions;
+  std::vector<std::string> available_device_extensions;
 
   /// The given queue family index to use.
   uint32_t queue_family_index;

--- a/include/amber/recipe.h
+++ b/include/amber/recipe.h
@@ -34,8 +34,11 @@ class RecipeImpl {
   /// Returns required features in the given recipe.
   virtual std::vector<std::string> GetRequiredFeatures() const = 0;
 
-  /// Returns required extensions in the given recipe.
-  virtual std::vector<std::string> GetRequiredExtensions() const = 0;
+  /// Returns required device extensions in the given recipe.
+  virtual std::vector<std::string> GetRequiredDeviceExtensions() const = 0;
+
+  /// Returns required instance extensions in the given recipe.
+  virtual std::vector<std::string> GetRequiredInstanceExtensions() const = 0;
 
  protected:
   RecipeImpl();
@@ -57,8 +60,11 @@ class Recipe {
   /// Returns required features in the given recipe.
   std::vector<std::string> GetRequiredFeatures() const;
 
-  /// Returns required extensions in the given recipe.
-  std::vector<std::string> GetRequiredExtensions() const;
+  /// Returns required device extensions in the given recipe.
+  std::vector<std::string> GetRequiredDeviceExtensions() const;
+
+  /// Returns required instance extensions in the given recipe.
+  std::vector<std::string> GetRequiredInstanceExtensions() const;
 
  private:
   RecipeImpl* impl_;

--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -266,13 +266,21 @@ int main(int argc, const char** argv) {
   amber_options.spv_env = options.spv_env;
 
   std::set<std::string> required_features;
-  std::set<std::string> required_extensions;
+  std::set<std::string> required_device_extensions;
+  std::set<std::string> required_instance_extensions;
   for (const auto& recipe_data_elem : recipe_data) {
     const auto features = recipe_data_elem.recipe->GetRequiredFeatures();
     required_features.insert(features.begin(), features.end());
 
-    const auto extensions = recipe_data_elem.recipe->GetRequiredExtensions();
-    required_extensions.insert(extensions.begin(), extensions.end());
+    const auto device_extensions =
+        recipe_data_elem.recipe->GetRequiredDeviceExtensions();
+    required_device_extensions.insert(device_extensions.begin(),
+                                      device_extensions.end());
+
+    const auto inst_extensions =
+        recipe_data_elem.recipe->GetRequiredInstanceExtensions();
+    required_instance_extensions.insert(inst_extensions.begin(),
+                                        inst_extensions.end());
   }
 
   sample::ConfigHelper config_helper;
@@ -282,8 +290,10 @@ int main(int argc, const char** argv) {
       amber_options.engine, options.engine_major, options.engine_minor,
       std::vector<std::string>(required_features.begin(),
                                required_features.end()),
-      std::vector<std::string>(required_extensions.begin(),
-                               required_extensions.end()),
+      std::vector<std::string>(required_instance_extensions.begin(),
+                               required_instance_extensions.end()),
+      std::vector<std::string>(required_device_extensions.begin(),
+                               required_device_extensions.end()),
       options.disable_validation_layer, &config);
 
   if (!r.IsSuccess()) {

--- a/samples/config_helper.cc
+++ b/samples/config_helper.cc
@@ -41,7 +41,8 @@ amber::Result ConfigHelper::CreateConfig(
     uint32_t engine_major,
     uint32_t engine_minor,
     const std::vector<std::string>& required_features,
-    const std::vector<std::string>& required_extensions,
+    const std::vector<std::string>& required_instance_extensions,
+    const std::vector<std::string>& required_device_extensions,
     bool disable_validation_layer,
     std::unique_ptr<amber::EngineConfig>* config) {
   switch (engine) {
@@ -65,8 +66,9 @@ amber::Result ConfigHelper::CreateConfig(
     return amber::Result("Unable to create config helper");
 
   return impl_->CreateConfig(engine_major, engine_minor, required_features,
-                             required_extensions, disable_validation_layer,
-                             config);
+                             required_instance_extensions,
+                             required_device_extensions,
+                             disable_validation_layer, config);
 }
 
 amber::Result ConfigHelper::Shutdown() {

--- a/samples/config_helper.h
+++ b/samples/config_helper.h
@@ -36,7 +36,8 @@ class ConfigHelperImpl {
       uint32_t engine_major,
       uint32_t engine_minor,
       const std::vector<std::string>& required_features,
-      const std::vector<std::string>& required_extensions,
+      const std::vector<std::string>& required_instance_extensions,
+      const std::vector<std::string>& required_device_extensions,
       bool disable_validation_layer,
       std::unique_ptr<amber::EngineConfig>* config) = 0;
 
@@ -60,7 +61,8 @@ class ConfigHelper {
       uint32_t engine_major,
       uint32_t engine_minor,
       const std::vector<std::string>& required_features,
-      const std::vector<std::string>& required_extensions,
+      const std::vector<std::string>& required_instance_extensions,
+      const std::vector<std::string>& required_device_extensions,
       bool disable_validation_layer,
       std::unique_ptr<amber::EngineConfig>* config);
 

--- a/samples/config_helper_dawn.cc
+++ b/samples/config_helper_dawn.cc
@@ -35,6 +35,7 @@ amber::Result ConfigHelperDawn::CreateConfig(
     uint32_t,
     const std::vector<std::string>&,
     const std::vector<std::string>&,
+    const std::vector<std::string>&,
     bool,
     std::unique_ptr<amber::EngineConfig>* config) {
 #if AMBER_DAWN_METAL

--- a/samples/config_helper_dawn.h
+++ b/samples/config_helper_dawn.h
@@ -41,7 +41,8 @@ class ConfigHelperDawn : public ConfigHelperImpl {
       uint32_t engine_major,
       uint32_t engine_minor,
       const std::vector<std::string>& required_features,
-      const std::vector<std::string>& required_extensions,
+      const std::vector<std::string>& required_instance_extensions,
+      const std::vector<std::string>& required_device_extensions,
       bool disable_validation_layer,
       std::unique_ptr<amber::EngineConfig>* config) override;
 

--- a/samples/config_helper_vulkan.h
+++ b/samples/config_helper_vulkan.h
@@ -45,7 +45,8 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
       uint32_t engine_major,
       uint32_t engine_minor,
       const std::vector<std::string>& required_features,
-      const std::vector<std::string>& required_extensions,
+      const std::vector<std::string>& required_instance_extensions,
+      const std::vector<std::string>& required_device_extensions,
       bool disable_validation_layer,
       std::unique_ptr<amber::EngineConfig>* config) override;
 
@@ -54,9 +55,11 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
 
  private:
   // Create Vulkan instance.
-  amber::Result CreateVulkanInstance(uint32_t engine_major,
-                                     uint32_t engine_minor,
-                                     bool disable_validation_layer);
+  amber::Result CreateVulkanInstance(
+      uint32_t engine_major,
+      uint32_t engine_minor,
+      std::vector<std::string> required_instance_extensions,
+      bool disable_validation_layer);
 
   // Create |vulkan_callback_| that reports validation layer errors
   // via debugCallback() function in config_helper_vulkan.cc.
@@ -78,7 +81,8 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
   VkDebugReportCallbackEXT vulkan_callback_ = VK_NULL_HANDLE;
   VkPhysicalDevice vulkan_physical_device_ = VK_NULL_HANDLE;
   VkPhysicalDeviceFeatures available_features_ = {};
-  std::vector<std::string> available_extensions_;
+  std::vector<std::string> available_instance_extensions_;
+  std::vector<std::string> available_device_extensions_;
   uint32_t vulkan_queue_family_index_ = std::numeric_limits<uint32_t>::max();
   VkQueue vulkan_queue_ = VK_NULL_HANDLE;
   VkDevice vulkan_device_ = VK_NULL_HANDLE;

--- a/src/amber.cc
+++ b/src/amber.cc
@@ -73,7 +73,8 @@ amber::Result Amber::ExecuteWithShaderData(const amber::Recipe* recipe,
     return Result("Failed to create engine");
 
   Result r = engine->Initialize(opts->config, script->RequiredFeatures(),
-                                script->RequiredExtensions());
+                                script->GetRequiredInstanceExtensions(),
+                                script->GetRequiredDeviceExtensions());
   if (!r.IsSuccess())
     return r;
 

--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -183,6 +183,7 @@ EngineDawn::~EngineDawn() = default;
 
 Result EngineDawn::Initialize(EngineConfig* config,
                               const std::vector<Feature>&,
+                              const std::vector<std::string>&,
                               const std::vector<std::string>&) {
   if (device_)
     return Result("Dawn:Initialize device_ already exists");

--- a/src/dawn/engine_dawn.h
+++ b/src/dawn/engine_dawn.h
@@ -38,7 +38,8 @@ class EngineDawn : public Engine {
   // Initialize with given configuration data.
   Result Initialize(EngineConfig* config,
                     const std::vector<Feature>& features,
-                    const std::vector<std::string>& extensions) override;
+                    const std::vector<std::string>& instance_extensions,
+                    const std::vector<std::string>& device_extensions) override;
 
   Result Shutdown() override;
   // Record info for a pipeline.  The Dawn render pipeline will be created

--- a/src/engine.h
+++ b/src/engine.h
@@ -84,9 +84,11 @@ class Engine {
   /// are for validation purposes only. If possible the engine should verify
   /// that the constraints in |features| and |extensions| are valid and fail
   /// otherwise.
-  virtual Result Initialize(EngineConfig* config,
-                            const std::vector<Feature>& features,
-                            const std::vector<std::string>& extensions) = 0;
+  virtual Result Initialize(
+      EngineConfig* config,
+      const std::vector<Feature>& features,
+      const std::vector<std::string>& instance_extensions,
+      const std::vector<std::string>& device_extensions) = 0;
 
   /// Shutdown the engine and cleanup any resources.
   virtual Result Shutdown() = 0;

--- a/src/executor_test.cc
+++ b/src/executor_test.cc
@@ -35,16 +35,20 @@ class EngineStub : public Engine {
   // Engine
   Result Initialize(EngineConfig*,
                     const std::vector<Feature>& features,
-                    const std::vector<std::string>& extensions) override {
+                    const std::vector<std::string>& instance_exts,
+                    const std::vector<std::string>& device_exts) override {
     features_ = features;
-    extensions_ = extensions;
+    instance_extensions_ = instance_exts;
+    device_extensions_ = device_exts;
     return {};
   }
 
   Result Shutdown() override { return {}; }
 
   const std::vector<Feature>& GetFeatures() const { return features_; }
-  const std::vector<std::string>& GetExtensions() const { return extensions_; }
+  const std::vector<std::string>& GetDeviceExtensions() const {
+    return device_extensions_;
+  }
   uint32_t GetFenceTimeoutMs() { return GetEngineData().fence_timeout_ms; }
 
   Result CreatePipeline(Pipeline*) override { return {}; }
@@ -188,7 +192,8 @@ class EngineStub : public Engine {
   bool did_buffer_command_ = false;
 
   std::vector<Feature> features_;
-  std::vector<std::string> extensions_;
+  std::vector<std::string> instance_extensions_;
+  std::vector<std::string> device_extensions_;
 
   ClearColorCommand* last_clear_color_ = nullptr;
 };
@@ -201,9 +206,11 @@ class VkScriptExecutorTest : public testing::Test {
   std::unique_ptr<Engine> MakeEngine() { return MakeUnique<EngineStub>(); }
   std::unique_ptr<Engine> MakeAndInitializeEngine(
       const std::vector<Feature>& features,
-      const std::vector<std::string>& extensions) {
+      const std::vector<std::string>& instance_extensions,
+      const std::vector<std::string>& device_extensions) {
     auto engine = MakeUnique<EngineStub>();
-    engine->Initialize(nullptr, features, extensions);
+    engine->Initialize(nullptr, features, instance_extensions,
+                       device_extensions);
     return std::move(engine);
   }
   EngineStub* ToStub(Engine* engine) {
@@ -224,7 +231,8 @@ logicOp)";
 
   auto script = parser.GetScript();
   auto engine = MakeAndInitializeEngine(script->RequiredFeatures(),
-                                        script->RequiredExtensions());
+                                        script->GetRequiredInstanceExtensions(),
+                                        script->GetRequiredDeviceExtensions());
 
   Executor ex;
   Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
@@ -235,7 +243,7 @@ logicOp)";
   EXPECT_EQ(Feature::kRobustBufferAccess, features[0]);
   EXPECT_EQ(Feature::kLogicOp, features[1]);
 
-  const auto& extensions = ToStub(engine.get())->GetExtensions();
+  const auto& extensions = ToStub(engine.get())->GetDeviceExtensions();
   ASSERT_EQ(static_cast<size_t>(0U), extensions.size());
 
   EXPECT_EQ(100U, ToStub(engine.get())->GetFenceTimeoutMs());
@@ -252,7 +260,8 @@ VK_KHR_variable_pointers)";
 
   auto script = parser.GetScript();
   auto engine = MakeAndInitializeEngine(script->RequiredFeatures(),
-                                        script->RequiredExtensions());
+                                        script->GetRequiredInstanceExtensions(),
+                                        script->GetRequiredDeviceExtensions());
 
   Executor ex;
   Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
@@ -261,7 +270,7 @@ VK_KHR_variable_pointers)";
   const auto& features = ToStub(engine.get())->GetFeatures();
   ASSERT_EQ(static_cast<size_t>(0U), features.size());
 
-  const auto& extensions = ToStub(engine.get())->GetExtensions();
+  const auto& extensions = ToStub(engine.get())->GetDeviceExtensions();
   ASSERT_EQ(2U, extensions.size());
   EXPECT_EQ("VK_KHR_storage_buffer_storage_class", extensions[0]);
   EXPECT_EQ("VK_KHR_variable_pointers", extensions[1]);
@@ -280,7 +289,8 @@ depthstencil D24_UNORM_S8_UINT)";
 
   auto script = parser.GetScript();
   auto engine = MakeAndInitializeEngine(script->RequiredFeatures(),
-                                        script->RequiredExtensions());
+                                        script->GetRequiredInstanceExtensions(),
+                                        script->GetRequiredDeviceExtensions());
 
   Executor ex;
   Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
@@ -289,7 +299,7 @@ depthstencil D24_UNORM_S8_UINT)";
   const auto& features = ToStub(engine.get())->GetFeatures();
   ASSERT_EQ(static_cast<size_t>(0U), features.size());
 
-  const auto& extensions = ToStub(engine.get())->GetExtensions();
+  const auto& extensions = ToStub(engine.get())->GetDeviceExtensions();
   ASSERT_EQ(static_cast<size_t>(0U), extensions.size());
 
   EXPECT_EQ(100U, ToStub(engine.get())->GetFenceTimeoutMs());
@@ -305,7 +315,8 @@ fence_timeout 12345)";
 
   auto script = parser.GetScript();
   auto engine = MakeAndInitializeEngine(script->RequiredFeatures(),
-                                        script->RequiredExtensions());
+                                        script->GetRequiredInstanceExtensions(),
+                                        script->GetRequiredDeviceExtensions());
 
   Executor ex;
   Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
@@ -314,7 +325,7 @@ fence_timeout 12345)";
   const auto& features = ToStub(engine.get())->GetFeatures();
   ASSERT_EQ(static_cast<size_t>(0U), features.size());
 
-  const auto& extensions = ToStub(engine.get())->GetExtensions();
+  const auto& extensions = ToStub(engine.get())->GetDeviceExtensions();
   ASSERT_EQ(static_cast<size_t>(0U), extensions.size());
 
   EXPECT_EQ(12345U, ToStub(engine.get())->GetFenceTimeoutMs());
@@ -336,7 +347,8 @@ fence_timeout 12345)";
 
   auto script = parser.GetScript();
   auto engine = MakeAndInitializeEngine(script->RequiredFeatures(),
-                                        script->RequiredExtensions());
+                                        script->GetRequiredInstanceExtensions(),
+                                        script->GetRequiredDeviceExtensions());
 
   Executor ex;
   Result r = ex.Execute(engine.get(), script.get(), ShaderMap());
@@ -347,7 +359,7 @@ fence_timeout 12345)";
   EXPECT_EQ(Feature::kRobustBufferAccess, features[0]);
   EXPECT_EQ(Feature::kLogicOp, features[1]);
 
-  const auto& extensions = ToStub(engine.get())->GetExtensions();
+  const auto& extensions = ToStub(engine.get())->GetDeviceExtensions();
   ASSERT_EQ(2U, extensions.size());
   EXPECT_EQ("VK_KHR_storage_buffer_storage_class", extensions[0]);
   EXPECT_EQ("VK_KHR_variable_pointers", extensions[1]);

--- a/src/recipe.cc
+++ b/src/recipe.cc
@@ -35,8 +35,14 @@ std::vector<std::string> Recipe::GetRequiredFeatures() const {
   return impl_ ? impl_->GetRequiredFeatures() : std::vector<std::string>();
 }
 
-std::vector<std::string> Recipe::GetRequiredExtensions() const {
-  return impl_ ? impl_->GetRequiredExtensions() : std::vector<std::string>();
+std::vector<std::string> Recipe::GetRequiredDeviceExtensions() const {
+  return impl_ ? impl_->GetRequiredDeviceExtensions()
+               : std::vector<std::string>();
+}
+
+std::vector<std::string> Recipe::GetRequiredInstanceExtensions() const {
+  return impl_ ? impl_->GetRequiredInstanceExtensions()
+               : std::vector<std::string>();
 }
 
 }  // namespace amber

--- a/src/script.cc
+++ b/src/script.cc
@@ -165,8 +165,12 @@ std::vector<std::string> Script::GetRequiredFeatures() const {
   return required_features_in_string;
 }
 
-std::vector<std::string> Script::GetRequiredExtensions() const {
-  return engine_info_.required_extensions;
+void Script::AddRequiredExtension(const std::string& ext) {
+  // Make this smarter when we have more instance extensions to match.
+  if (ext == "VK_KHR_get_physical_device_properties2")
+    engine_info_.required_instance_extensions.push_back(ext);
+  else
+    engine_info_.required_device_extensions.push_back(ext);
 }
 
 }  // namespace amber

--- a/src/script.h
+++ b/src/script.h
@@ -45,8 +45,15 @@ class Script : public RecipeImpl {
   /// Returns required features in the given recipe.
   std::vector<std::string> GetRequiredFeatures() const override;
 
-  /// Returns required extensions in the given recipe.
-  std::vector<std::string> GetRequiredExtensions() const override;
+  /// Returns required device extensions in the given recipe.
+  std::vector<std::string> GetRequiredDeviceExtensions() const override {
+    return engine_info_.required_device_extensions;
+  }
+
+  /// Returns required instance extensions in the given recipe.
+  std::vector<std::string> GetRequiredInstanceExtensions() const override {
+    return engine_info_.required_instance_extensions;
+  }
 
   /// Adds |pipeline| to the list of known pipelines. The |pipeline| must have
   /// a unique name over all pipelines in the script.
@@ -126,14 +133,7 @@ class Script : public RecipeImpl {
   }
 
   /// Adds |ext| to the list of extensions that must be supported by the engine.
-  void AddRequiredExtension(const std::string& ext) {
-    engine_info_.required_extensions.push_back(ext);
-  }
-
-  /// Retrieves a list of extensions required for this script.
-  const std::vector<std::string>& RequiredExtensions() const {
-    return engine_info_.required_extensions;
-  }
+  void AddRequiredExtension(const std::string& ext);
 
   /// Retrieves the engine configuration data for this script.
   EngineData& GetEngineData() { return engine_data_; }
@@ -158,7 +158,8 @@ class Script : public RecipeImpl {
  private:
   struct {
     std::vector<Feature> required_features;
-    std::vector<std::string> required_extensions;
+    std::vector<std::string> required_device_extensions;
+    std::vector<std::string> required_instance_extensions;
   } engine_info_;
 
   EngineData engine_data_;

--- a/src/script_test.cc
+++ b/src/script_test.cc
@@ -288,4 +288,22 @@ TEST_F(ScriptTest, GetBuffers) {
   EXPECT_EQ(ptr2, buffers[1].get());
 }
 
+TEST_F(ScriptTest, IdentifiesDeviceExtensions) {
+  Script s;
+  s.AddRequiredExtension("VK_KHR_16bit_storage");
+  EXPECT_TRUE(s.GetRequiredInstanceExtensions().empty());
+  ASSERT_EQ(1U, s.GetRequiredDeviceExtensions().size());
+  EXPECT_EQ("VK_KHR_16bit_storage", s.GetRequiredDeviceExtensions()[0]);
+}
+
+TEST_F(ScriptTest,
+       IdentifesInstanceExt_VK_KHR_get_physical_device_properties2) {
+  Script s;
+  s.AddRequiredExtension("VK_KHR_get_physical_device_properties2");
+  EXPECT_TRUE(s.GetRequiredDeviceExtensions().empty());
+  ASSERT_EQ(1U, s.GetRequiredInstanceExtensions().size());
+  EXPECT_EQ("VK_KHR_get_physical_device_properties2",
+            s.GetRequiredInstanceExtensions()[0]);
+}
+
 }  // namespace amber

--- a/src/vkscript/parser_test.cc
+++ b/src/vkscript/parser_test.cc
@@ -113,17 +113,22 @@ TEST_F(VkScriptParserTest, RequireBlockNoArgumentFeatures) {
 TEST_F(VkScriptParserTest, RequireBlockExtensions) {
   std::string block = R"([require]
 VK_KHR_storage_buffer_storage_class
-VK_KHR_variable_pointers)";
+VK_KHR_variable_pointers
+VK_KHR_get_physical_device_properties2)";
 
   Parser parser;
   Result r = parser.Parse(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
   auto script = parser.GetScript();
-  auto& exts = script->RequiredExtensions();
-  ASSERT_EQ(2U, exts.size());
-  EXPECT_EQ("VK_KHR_storage_buffer_storage_class", exts[0]);
-  EXPECT_EQ("VK_KHR_variable_pointers", exts[1]);
+  auto device_exts = script->GetRequiredDeviceExtensions();
+  ASSERT_EQ(2U, device_exts.size());
+  EXPECT_EQ("VK_KHR_storage_buffer_storage_class", device_exts[0]);
+  EXPECT_EQ("VK_KHR_variable_pointers", device_exts[1]);
+
+  auto inst_exts = script->GetRequiredInstanceExtensions();
+  ASSERT_EQ(1U, inst_exts.size());
+  EXPECT_EQ("VK_KHR_get_physical_device_properties2", inst_exts[0]);
 }
 
 TEST_F(VkScriptParserTest, RequireBlockFramebuffer) {

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -40,7 +40,8 @@ class EngineVulkan : public Engine {
   // Engine
   Result Initialize(EngineConfig* config,
                     const std::vector<Feature>& features,
-                    const std::vector<std::string>& extensions) override;
+                    const std::vector<std::string>& instance_extensions,
+                    const std::vector<std::string>& device_extensions) override;
   Result Shutdown() override;
   Result CreatePipeline(amber::Pipeline* type) override;
 


### PR DESCRIPTION
This CL adds the necessary code to differentiate that
VK_KHR_get_physical_device_properties2 is an instance extension and not
a device extension.