### PR TITLE
Convert PushConstant to use a vector.

### DIFF
--- a/src/vulkan/push_constant.cc
+++ b/src/vulkan/push_constant.cc
@@ -27,9 +27,9 @@ PushConstant::PushConstant(Device* device, uint32_t max_push_constant_size)
     : Resource(device,
                max_push_constant_size,
                VkPhysicalDeviceMemoryProperties()),
-      max_push_constant_size_(max_push_constant_size),
-      memory_(std::unique_ptr<uint8_t>(new uint8_t[max_push_constant_size])) {
-  SetMemoryPtr(static_cast<void*>(memory_.get()));
+      max_push_constant_size_(max_push_constant_size) {
+  memory_.resize(max_push_constant_size_);
+  SetMemoryPtr(static_cast<void*>(memory_.data()));
 }
 
 PushConstant::~PushConstant() = default;
@@ -98,7 +98,7 @@ Result PushConstant::RecordPushConstantVkCommand(
   device_->GetPtrs()->vkCmdPushConstants(
       command_buffer, pipeline_layout, VK_SHADER_STAGE_ALL,
       push_const_range.offset, push_const_range.size,
-      memory_.get() + push_const_range.offset);
+      memory_.data() + push_const_range.offset);
   return {};
 }
 

--- a/src/vulkan/push_constant.h
+++ b/src/vulkan/push_constant.h
@@ -75,7 +75,7 @@ class PushConstant : public Resource {
   // if address ranges overlap, then the later values take effect.
   std::vector<BufferInput> push_constant_data_;
 
-  std::unique_ptr<uint8_t> memory_;
+  std::vector<uint8_t> memory_;
 };
 
 }  // namespace vulkan


### PR DESCRIPTION
Instead of allocating an array of uint8_t's and storing into a
unique_ptr, this CL changes the PushConstant code to have a
std::vector<uint8_t> instead.

Issue #277.