### PR TITLE
Output requested images/buffers on probe failure.

### DIFF
--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -336,7 +336,8 @@ int main(int argc, const char** argv) {
     if (!result.IsSuccess()) {
       std::cerr << file << ": " << result.Error() << std::endl;
       failures.push_back(file);
-      continue;
+      // Note, we continue after failure to allow dumping the buffers which may
+      // give clues as to the failure.
     }
 
     if (!options.image_filename.empty()) {
@@ -357,19 +358,20 @@ int main(int argc, const char** argv) {
           break;
         }
       }
-      if (!result.IsSuccess()) {
+      if (result.IsSuccess()) {
+        std::ofstream image_file;
+        image_file.open(options.image_filename,
+                        std::ios::out | std::ios::binary);
+        if (!image_file.is_open()) {
+          std::cerr << "Cannot open file for image dump: ";
+          std::cerr << options.image_filename << std::endl;
+          continue;
+        }
+        image_file << image;
+        image_file.close();
+      } else {
         std::cerr << result.Error() << std::endl;
-        continue;
       }
-      std::ofstream image_file;
-      image_file.open(options.image_filename, std::ios::out | std::ios::binary);
-      if (!image_file.is_open()) {
-        std::cerr << "Cannot open file for image dump: ";
-        std::cerr << options.image_filename << std::endl;
-        continue;
-      }
-      image_file << image;
-      image_file.close();
     }
 
     if (!options.buffer_filename.empty()) {

--- a/src/amber.cc
+++ b/src/amber.cc
@@ -86,40 +86,37 @@ amber::Result Amber::ExecuteWithShaderData(const amber::Recipe* recipe,
   // Hold the executor result until the extractions are complete. This will let
   // us dump any buffers requested even on failure.
 
+  // The dump process holds onto the results and terminates the loop if any dump
+  // fails. This will allow us to validate |extractor_result| first as if the
+  // extractor fails before running the pipeline that will trigger the dumps
+  // to almost always fail.
   for (BufferInfo& buffer_info : opts->extractions) {
     if (buffer_info.buffer_name == "framebuffer") {
       ResourceInfo info;
       r = engine->GetFrameBufferInfo(&info);
-      if (!r.IsSuccess()) {
-        engine->Shutdown();
-        return r;
-      }
+      if (!r.IsSuccess())
+        break;
+
       buffer_info.width = info.image_info.width;
       buffer_info.height = info.image_info.height;
       r = engine->GetFrameBuffer(&(buffer_info.values));
-      if (!r.IsSuccess()) {
-        engine->Shutdown();
-        return r;
-      }
+      if (!r.IsSuccess())
+        break;
 
       continue;
     }
 
     DescriptorSetAndBindingParser desc_set_and_binding_parser;
     r = desc_set_and_binding_parser.Parse(buffer_info.buffer_name);
-    if (!r.IsSuccess()) {
-      engine->Shutdown();
-      return r;
-    }
+    if (!r.IsSuccess())
+      break;
 
     ResourceInfo info = ResourceInfo();
     r = engine->GetDescriptorInfo(
         desc_set_and_binding_parser.GetDescriptorSet(),
         desc_set_and_binding_parser.GetBinding(), &info);
-    if (!r.IsSuccess()) {
-      engine->Shutdown();
-      return r;
-    }
+    if (!r.IsSuccess())
+      break;
 
     const uint8_t* ptr = static_cast<const uint8_t*>(info.cpu_memory);
     auto& values = buffer_info.values;
@@ -133,6 +130,10 @@ amber::Result Amber::ExecuteWithShaderData(const amber::Recipe* recipe,
   if (!executor_result.IsSuccess()) {
     engine->Shutdown();
     return executor_result;
+  }
+  if (!r.IsSuccess()) {
+    engine->Shutdown();
+    return r;
   }
   return engine->Shutdown();
 }

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -80,7 +80,7 @@ Result Executor::Execute(Engine* engine,
         return r;
 
       // This must come after processing commands because we require
-      // the frambuffer buffer to be mapped into host memory and have
+      // the framebuffer data to be mapped into host memory and have
       // a valid host-side pointer.
       r = engine->GetFrameBufferInfo(&info);
       if (!r.IsSuccess())

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -454,8 +454,9 @@ Result EngineVulkan::DoProcessCommands() {
 
 Result EngineVulkan::GetFrameBufferInfo(ResourceInfo* info) {
   if (!info)
-    return Result("Vulkan::GetFrameBufferInfo Missing info");
-
+    return Result("Vulkan::GetFrameBufferInfo missing info");
+  if (!pipeline_)
+    return Result("Vulkan::GetFrameBufferIfno missing pipeline");
   if (!pipeline_->IsGraphics())
     return Result("Vulkan::GetFrameBufferInfo for Non-Graphics Pipeline");
 


### PR DESCRIPTION
This Cl updates the sample app to allow dumping of image and buffer data
even if the probes fail to execute.

Fixes #314.