### PR TITLE
[vulkan] Don't store pipeline_layout or pipeline.

### DIFF
--- a/src/vulkan/compute_pipeline.cc
+++ b/src/vulkan/compute_pipeline.cc
@@ -38,7 +38,9 @@ Result ComputePipeline::Initialize(VkCommandPool pool, VkQueue queue) {
   return Pipeline::Initialize(pool, queue);
 }
 
-Result ComputePipeline::CreateVkComputePipeline() {
+Result ComputePipeline::CreateVkComputePipeline(
+    const VkPipelineLayout& pipeline_layout,
+    VkPipeline* pipeline) {
   auto shader_stage_info = GetShaderStageInfo();
   if (shader_stage_info.size() != 1) {
     return Result(
@@ -51,18 +53,14 @@ Result ComputePipeline::CreateVkComputePipeline() {
 
   shader_stage_info[0].pName = GetEntryPointName(VK_SHADER_STAGE_COMPUTE_BIT);
 
-  Result r = CreateVkDescriptorRelatedObjectsAndPipelineLayoutIfNeeded();
-  if (!r.IsSuccess())
-    return r;
-
   VkComputePipelineCreateInfo pipeline_info = VkComputePipelineCreateInfo();
   pipeline_info.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
   pipeline_info.stage = shader_stage_info[0];
-  pipeline_info.layout = pipeline_layout_;
+  pipeline_info.layout = pipeline_layout;
 
   if (device_->GetPtrs()->vkCreateComputePipelines(
           device_->GetDevice(), VK_NULL_HANDLE, 1, &pipeline_info, nullptr,
-          &pipeline_) != VK_SUCCESS) {
+          pipeline) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateComputePipelines Fail");
   }
 
@@ -86,11 +84,15 @@ Result ComputePipeline::Compute(uint32_t x, uint32_t y, uint32_t z) {
   if (!r.IsSuccess())
     return r;
 
-  if (pipeline_ == VK_NULL_HANDLE) {
-    r = CreateVkComputePipeline();
-    if (!r.IsSuccess())
-      return r;
-  }
+  VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
+  r = CreateVkPipelineLayout(&pipeline_layout);
+  if (!r.IsSuccess())
+    return r;
+
+  VkPipeline pipeline = VK_NULL_HANDLE;
+  r = CreateVkComputePipeline(pipeline_layout, &pipeline);
+  if (!r.IsSuccess())
+    return r;
 
   // Note that a command updating a descriptor set and a command using
   // it must be submitted separately, because using a descriptor set
@@ -103,16 +105,26 @@ Result ComputePipeline::Compute(uint32_t x, uint32_t y, uint32_t z) {
   if (!r.IsSuccess())
     return r;
 
-  BindVkDescriptorSets();
-  BindVkPipeline();
+  BindVkDescriptorSets(pipeline_layout);
 
-  r = RecordPushConstant();
+  r = RecordPushConstant(pipeline_layout);
   if (!r.IsSuccess())
     return r;
 
+  device_->GetPtrs()->vkCmdBindPipeline(
+      command_->GetCommandBuffer(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
   device_->GetPtrs()->vkCmdDispatch(command_->GetCommandBuffer(), x, y, z);
 
-  return ReadbackDescriptorsToHostDataQueue();
+  r = ReadbackDescriptorsToHostDataQueue();
+  if (!r.IsSuccess())
+    return r;
+
+  device_->GetPtrs()->vkDestroyPipeline(device_->GetDevice(), pipeline,
+                                        nullptr);
+  device_->GetPtrs()->vkDestroyPipelineLayout(device_->GetDevice(),
+                                              pipeline_layout, nullptr);
+
+  return {};
 }
 
 }  // namespace vulkan

--- a/src/vulkan/compute_pipeline.h
+++ b/src/vulkan/compute_pipeline.h
@@ -39,7 +39,8 @@ class ComputePipeline : public Pipeline {
   Result Compute(uint32_t x, uint32_t y, uint32_t z);
 
  private:
-  Result CreateVkComputePipeline();
+  Result CreateVkComputePipeline(const VkPipelineLayout& pipeline_layout,
+                                 VkPipeline* pipeline);
 };
 
 }  // namespace vulkan

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -351,10 +351,6 @@ Result EngineVulkan::DoDrawRect(const DrawRectCommand* command) {
 
   auto* graphics = pipeline_->AsGraphics();
 
-  Result r = graphics->ResetPipeline();
-  if (!r.IsSuccess())
-    return r;
-
   // |format| is not Format for frame buffer but for vertex buffer.
   // Since draw rect command contains its vertex information and it
   // does not include a format of vertex buffer, we can choose any
@@ -401,11 +397,7 @@ Result EngineVulkan::DoDrawRect(const DrawRectCommand* command) {
   draw.SetVertexCount(4);
   draw.SetInstanceCount(1);
 
-  r = graphics->Draw(&draw, vertex_buffer.get());
-  if (!r.IsSuccess())
-    return r;
-
-  r = graphics->ResetPipeline();
+  Result r = graphics->Draw(&draw, vertex_buffer.get());
   if (!r.IsSuccess())
     return r;
 

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -490,19 +490,14 @@ GraphicsPipeline::GetPipelineColorBlendAttachmentState(
 Result GraphicsPipeline::CreateVkGraphicsPipeline(
     const PipelineData* pipeline_data,
     VkPrimitiveTopology topology,
-    const VertexBuffer* vertex_buffer) {
-  if (pipeline_ != VK_NULL_HANDLE)
-    return Result("Vulkan::Pipeline already created");
-
+    const VertexBuffer* vertex_buffer,
+    const VkPipelineLayout& pipeline_layout,
+    VkPipeline* pipeline) {
   if (!pipeline_data) {
     return Result(
         "Vulkan: GraphicsPipeline::CreateVkGraphicsPipeline PipelineData is "
         "null");
   }
-
-  Result r = CreateVkDescriptorRelatedObjectsAndPipelineLayoutIfNeeded();
-  if (!r.IsSuccess())
-    return r;
 
   VkPipelineVertexInputStateCreateInfo vertex_input_info =
       VkPipelineVertexInputStateCreateInfo();
@@ -636,13 +631,13 @@ Result GraphicsPipeline::CreateVkGraphicsPipeline(
     pipeline_info.pColorBlendState = &colorblend_info;
   }
 
-  pipeline_info.layout = pipeline_layout_;
+  pipeline_info.layout = pipeline_layout;
   pipeline_info.renderPass = render_pass_;
   pipeline_info.subpass = 0;
 
   if (device_->GetPtrs()->vkCreateGraphicsPipelines(
           device_->GetDevice(), VK_NULL_HANDLE, 1, &pipeline_info, nullptr,
-          &pipeline_) != VK_SUCCESS) {
+          pipeline) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateGraphicsPipelines Fail");
   }
 
@@ -838,33 +833,6 @@ Result GraphicsPipeline::ClearBuffer(const VkClearValue& clear_value,
   return frame_->CopyColorImageToHost(command_->GetCommandBuffer());
 }
 
-Result GraphicsPipeline::ResetPipeline() {
-  if (pipeline_ == VK_NULL_HANDLE)
-    return {};
-
-  Result r = command_->BeginIfNotInRecording();
-  if (!r.IsSuccess())
-    return r;
-
-  DeactivateRenderPassIfNeeded();
-
-  r = command_->End();
-  if (!r.IsSuccess())
-    return r;
-
-  r = command_->SubmitAndReset(GetFenceTimeout());
-  if (!r.IsSuccess())
-    return r;
-
-  if (pipeline_ != VK_NULL_HANDLE) {
-    device_->GetPtrs()->vkDestroyPipeline(device_->GetDevice(), pipeline_,
-                                          nullptr);
-    pipeline_ = VK_NULL_HANDLE;
-  }
-
-  return {};
-}
-
 Result GraphicsPipeline::Draw(const DrawArraysCommand* command,
                               VertexBuffer* vertex_buffer) {
   Result r = command_->BeginIfNotInRecording();
@@ -885,9 +853,13 @@ Result GraphicsPipeline::Draw(const DrawArraysCommand* command,
   if (!r.IsSuccess())
     return r;
 
+  VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
+  r = CreateVkPipelineLayout(&pipeline_layout);
+
+  VkPipeline pipeline = VK_NULL_HANDLE;
   r = CreateVkGraphicsPipeline(command->GetPipelineData(),
                                ToVkTopology(command->GetTopology()),
-                               vertex_buffer);
+                               vertex_buffer, pipeline_layout, &pipeline);
   if (!r.IsSuccess())
     return r;
 
@@ -910,12 +882,14 @@ Result GraphicsPipeline::Draw(const DrawArraysCommand* command,
   if (!r.IsSuccess())
     return r;
 
-  BindVkDescriptorSets();
-  BindVkPipeline();
+  BindVkDescriptorSets(pipeline_layout);
 
-  r = RecordPushConstant();
+  r = RecordPushConstant(pipeline_layout);
   if (!r.IsSuccess())
     return r;
+
+  device_->GetPtrs()->vkCmdBindPipeline(
+      command_->GetCommandBuffer(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
 
   if (vertex_buffer != nullptr)
     vertex_buffer->BindToCommandBuffer(command_->GetCommandBuffer());
@@ -958,7 +932,11 @@ Result GraphicsPipeline::Draw(const DrawArraysCommand* command,
   if (!r.IsSuccess())
     return r;
 
-  return ResetPipeline();
+  device_->GetPtrs()->vkDestroyPipeline(device_->GetDevice(), pipeline,
+                                        nullptr);
+  device_->GetPtrs()->vkDestroyPipelineLayout(device_->GetDevice(),
+                                              pipeline_layout, nullptr);
+  return {};
 }
 
 Result GraphicsPipeline::ProcessCommands() {

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -66,8 +66,6 @@ class GraphicsPipeline : public Pipeline {
 
   const FrameBuffer* GetFrame() const { return frame_.get(); }
 
-  Result ResetPipeline();
-
   uint32_t GetWidth() const { return frame_width_; }
   uint32_t GetHeight() const { return frame_height_; }
 
@@ -87,7 +85,9 @@ class GraphicsPipeline : public Pipeline {
 
   Result CreateVkGraphicsPipeline(const PipelineData* pipeline_data,
                                   VkPrimitiveTopology topology,
-                                  const VertexBuffer* vertex_buffer);
+                                  const VertexBuffer* vertex_buffer,
+                                  const VkPipelineLayout& pipeline_layout,
+                                  VkPipeline* pipeline);
 
   Result CreateRenderPass();
   Result ActivateRenderPassIfNeeded();

--- a/src/vulkan/pipeline.h
+++ b/src/vulkan/pipeline.h
@@ -88,21 +88,13 @@ class Pipeline {
   // VkFence objects.
   Result Initialize(VkCommandPool pool, VkQueue queue);
 
-  // Create Vulkan descriptor related objects i.e.,
-  // VkDescriptorSetLayout, VkDescriptorPool, VkDescriptorSet if
-  // |descriptor_related_objects_already_created_| is false. This
-  // method also creates VkPipelineLayout if |pipeline_layout_| is
-  // VK_NULL_HANDLE.
-  Result CreateVkDescriptorRelatedObjectsAndPipelineLayoutIfNeeded();
-
   Result UpdateDescriptorSetsIfNeeded();
 
   Result SendDescriptorDataToDeviceIfNeeded();
-  void BindVkPipeline();
-  void BindVkDescriptorSets();
+  void BindVkDescriptorSets(const VkPipelineLayout& pipeline_layout);
 
   // Record a Vulkan command for push contant.
-  Result RecordPushConstant();
+  Result RecordPushConstant(const VkPipelineLayout& pipeline_layout);
 
   const std::vector<VkPipelineShaderStageCreateInfo>& GetShaderStageInfo()
       const {
@@ -112,8 +104,7 @@ class Pipeline {
   const char* GetEntryPointName(VkShaderStageFlagBits stage) const;
   uint32_t GetFenceTimeout() const { return fence_timeout_ms_; }
 
-  VkPipeline pipeline_ = VK_NULL_HANDLE;
-  VkPipelineLayout pipeline_layout_ = VK_NULL_HANDLE;
+  Result CreateVkPipelineLayout(VkPipelineLayout* pipeline_layout);
 
   Device* device_ = nullptr;
   VkPhysicalDeviceMemoryProperties memory_properties_;
@@ -128,9 +119,10 @@ class Pipeline {
     std::vector<std::unique_ptr<Descriptor>> descriptors_;
   };
 
-  void DestroyVkDescriptorAndPipelineRelatedObjects();
-  void ResetVkPipelineRelatedObjects();
-  Result CreatePipelineLayout();
+  // Create Vulkan descriptor related objects i.e.,
+  // VkDescriptorSetLayout, VkDescriptorPool, VkDescriptorSet if
+  // |descriptor_related_objects_already_created_| is false.
+  Result CreateVkDescriptorRelatedObjectsIfNeeded();
 
   Result CreateDescriptorSetLayouts();
   Result CreateDescriptorPools();


### PR DESCRIPTION
Currently the pipeline_layout and pipeline _may_ get destroyed between
compute/draw calls. As such, there is a bunch of code to check and
re-create if needed.

This Cl changes the code to no longer store pipeline_ or
pipeline_layout_ in the vulkan/pipepline object. Instead, both the
layout and pipeline are created each draw/compute call.