### PR TITLE
Fix debug build

### DIFF
--- a/src/vulkan/image.cc
+++ b/src/vulkan/image.cc
@@ -14,6 +14,7 @@
 
 #include "src/vulkan/image.h"
 
+#include <cassert>
 #include <limits>
 
 #include "src/vulkan/command_buffer.h"

--- a/src/vulkan/image.cc
+++ b/src/vulkan/image.cc
@@ -14,7 +14,6 @@
 
 #include "src/vulkan/image.h"
 
-#include <cassert>
 #include <limits>
 
 #include "src/vulkan/command_buffer.h"
@@ -245,7 +244,11 @@ Result Image::AllocateAndBindMemoryToVkImage(VkImage image,
                                              VkMemoryPropertyFlags flags,
                                              bool force_flags,
                                              uint32_t* memory_type_index) {
-  assert(memory_type_index);
+  if (memory_type_index == nullptr) {
+    return Result(
+        "Vulkan: Image::AllocateAndBindMemoryToVkImage memory_type_index is "
+        "nullptr");
+  }
 
   *memory_type_index = 0;
 

--- a/src/vulkan/resource.cc
+++ b/src/vulkan/resource.cc
@@ -14,7 +14,6 @@
 
 #include "src/vulkan/resource.h"
 
-#include <cassert>
 #include <cstring>
 #include <limits>
 
@@ -225,7 +224,11 @@ Result Resource::AllocateAndBindMemoryToVkBuffer(VkBuffer buffer,
                                                  VkMemoryPropertyFlags flags,
                                                  bool force_flags,
                                                  uint32_t* memory_type_index) {
-  assert(memory_type_index);
+  if (memory_type_index == nullptr) {
+    return Result(
+        "Vulkan: Resource::AllocateAndBindMemoryToVkBuffer memory_type_index "
+        "is nullptr");
+  }
 
   *memory_type_index = 0;
 

--- a/src/vulkan/resource.cc
+++ b/src/vulkan/resource.cc
@@ -14,6 +14,7 @@
 
 #include "src/vulkan/resource.h"
 
+#include <cassert>
 #include <cstring>
 #include <limits>
 


### PR DESCRIPTION
Fixes debug builds, which currently fails with errors like:

```
../../src/vulkan/resource.cc:227:3: error: ‘assert’ was not declared in this scope
   assert(memory_type_index);
   ^~~~~~
```