### PR TITLE
Fixup version dump script.

### DIFF
--- a/tools/update_build_version.py
+++ b/tools/update_build_version.py
@@ -65,7 +65,7 @@ def main():
   projects = ['spirv-tools', 'spirv-headers', 'glslang', 'shaderc']
   new_content = get_version_string('amber', sys.argv[2]) + "\n"
   new_content = new_content + ''.join([
-    '{}\n'.format(get_version_string(p, srcdir + p))
+    '{}\n'.format(get_version_string(p, os.path.join(srcdir, p)))
     for p in projects
   ])
 


### PR DESCRIPTION
This CL fixes the version dump script to correct the paths which were
missing a separator character.