### PR TITLE
Log Vulkan API calls with the new VKLOG() macro

### DIFF
--- a/src/vulkan/CMakeLists.txt
+++ b/src/vulkan/CMakeLists.txt
@@ -32,6 +32,14 @@ set(VULKAN_ENGINE_SOURCES
     vertex_buffer.cc
 )
 
+if (${AMBER_LOG_VULKAN})
+  set(VULKAN_ENGINE_SOURCES
+    ${VULKAN_ENGINE_SOURCES}
+    vklog.cc
+    )
+  add_definitions(-DAMBER_LOG_VULKAN)
+endif()
+
 add_library(libamberenginevulkan ${VULKAN_ENGINE_SOURCES})
 amber_default_compile_options(libamberenginevulkan)
 set_target_properties(libamberenginevulkan PROPERTIES

--- a/src/vulkan/buffer.cc
+++ b/src/vulkan/buffer.cc
@@ -16,6 +16,7 @@
 
 #include "src/vulkan/command_buffer.h"
 #include "src/vulkan/device.h"
+#include "src/vulkan/vklog.h"
 
 namespace amber {
 namespace vulkan {
@@ -74,9 +75,9 @@ Result Buffer::CreateVkBufferView(VkFormat format) {
   buffer_view_info.format = format;
   buffer_view_info.offset = 0;
   buffer_view_info.range = VK_WHOLE_SIZE;
-  if (device_->GetPtrs()->vkCreateBufferView(device_->GetDevice(),
-                                             &buffer_view_info, nullptr,
-                                             &view_) != VK_SUCCESS) {
+  if (VKLOG(device_->GetPtrs()->vkCreateBufferView(
+          device_->GetDevice(), &buffer_view_info, nullptr, &view_)) !=
+      VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateBufferView Fail");
   }
 
@@ -103,24 +104,26 @@ void Buffer::CopyFromBuffer(CommandBuffer* command, const Buffer& src) {
   region.dstOffset = 0;
   region.size = src.GetSizeInBytes();
 
-  device_->GetPtrs()->vkCmdCopyBuffer(command->GetCommandBuffer(), src.buffer_,
-                                      buffer_, 1, &region);
+  VKLOG(device_->GetPtrs()->vkCmdCopyBuffer(command->GetCommandBuffer(),
+                                            src.buffer_, buffer_, 1, &region));
   MemoryBarrier(command);
 }
 
 void Buffer::Shutdown() {
   if (view_ != VK_NULL_HANDLE) {
-    device_->GetPtrs()->vkDestroyBufferView(device_->GetDevice(), view_,
-                                            nullptr);
+    VKLOG(device_->GetPtrs()->vkDestroyBufferView(device_->GetDevice(), view_,
+                                                  nullptr));
   }
 
   if (memory_ != VK_NULL_HANDLE) {
     UnMapMemory(memory_);
-    device_->GetPtrs()->vkFreeMemory(device_->GetDevice(), memory_, nullptr);
+    VKLOG(device_->GetPtrs()->vkFreeMemory(device_->GetDevice(), memory_,
+                                           nullptr));
   }
 
   if (buffer_ != VK_NULL_HANDLE)
-    device_->GetPtrs()->vkDestroyBuffer(device_->GetDevice(), buffer_, nullptr);
+    VKLOG(device_->GetPtrs()->vkDestroyBuffer(device_->GetDevice(), buffer_,
+                                              nullptr));
 
   Resource::Shutdown();
 }

--- a/src/vulkan/command_pool.cc
+++ b/src/vulkan/command_pool.cc
@@ -15,6 +15,7 @@
 #include "src/vulkan/command_pool.h"
 
 #include "src/vulkan/device.h"
+#include "src/vulkan/vklog.h"
 
 namespace amber {
 namespace vulkan {
@@ -29,8 +30,8 @@ Result CommandPool::Initialize(uint32_t queue_family_index) {
   pool_info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
   pool_info.queueFamilyIndex = queue_family_index;
 
-  if (device_->GetPtrs()->vkCreateCommandPool(device_->GetDevice(), &pool_info,
-                                              nullptr, &pool_) != VK_SUCCESS) {
+  if (VKLOG(device_->GetPtrs()->vkCreateCommandPool(
+          device_->GetDevice(), &pool_info, nullptr, &pool_)) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateCommandPool Fail");
   }
 
@@ -41,8 +42,8 @@ void CommandPool::Shutdown() {
   if (pool_ == VK_NULL_HANDLE)
     return;
 
-  device_->GetPtrs()->vkDestroyCommandPool(device_->GetDevice(), pool_,
-                                           nullptr);
+  VKLOG(device_->GetPtrs()->vkDestroyCommandPool(device_->GetDevice(), pool_,
+                                                 nullptr));
 }
 
 }  // namespace vulkan

--- a/src/vulkan/compute_pipeline.cc
+++ b/src/vulkan/compute_pipeline.cc
@@ -16,6 +16,7 @@
 
 #include "src/vulkan/command_pool.h"
 #include "src/vulkan/device.h"
+#include "src/vulkan/vklog.h"
 
 namespace amber {
 namespace vulkan {
@@ -59,9 +60,9 @@ Result ComputePipeline::CreateVkComputePipeline(
   pipeline_info.stage = shader_stage_info[0];
   pipeline_info.layout = pipeline_layout;
 
-  if (device_->GetPtrs()->vkCreateComputePipelines(
+  if (VKLOG(device_->GetPtrs()->vkCreateComputePipelines(
           device_->GetDevice(), VK_NULL_HANDLE, 1, &pipeline_info, nullptr,
-          pipeline) != VK_SUCCESS) {
+          pipeline)) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateComputePipelines Fail");
   }
 
@@ -112,18 +113,19 @@ Result ComputePipeline::Compute(uint32_t x, uint32_t y, uint32_t z) {
   if (!r.IsSuccess())
     return r;
 
-  device_->GetPtrs()->vkCmdBindPipeline(
-      command_->GetCommandBuffer(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
-  device_->GetPtrs()->vkCmdDispatch(command_->GetCommandBuffer(), x, y, z);
+  VKLOG(device_->GetPtrs()->vkCmdBindPipeline(
+      command_->GetCommandBuffer(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline));
+  VKLOG(
+      device_->GetPtrs()->vkCmdDispatch(command_->GetCommandBuffer(), x, y, z));
 
   r = ReadbackDescriptorsToHostDataQueue();
   if (!r.IsSuccess())
     return r;
 
-  device_->GetPtrs()->vkDestroyPipeline(device_->GetDevice(), pipeline,
-                                        nullptr);
-  device_->GetPtrs()->vkDestroyPipelineLayout(device_->GetDevice(),
-                                              pipeline_layout, nullptr);
+  VKLOG(device_->GetPtrs()->vkDestroyPipeline(device_->GetDevice(), pipeline,
+                                              nullptr));
+  VKLOG(device_->GetPtrs()->vkDestroyPipelineLayout(device_->GetDevice(),
+                                                    pipeline_layout, nullptr));
 
   return {};
 }

--- a/src/vulkan/descriptor.cc
+++ b/src/vulkan/descriptor.cc
@@ -17,6 +17,7 @@
 #include <cassert>
 
 #include "src/vulkan/device.h"
+#include "src/vulkan/vklog.h"
 
 namespace amber {
 namespace vulkan {
@@ -143,8 +144,8 @@ Result Descriptor::UpdateDescriptorSetForBufferView(
 }
 
 void Descriptor::UpdateVkDescriptorSet(const VkWriteDescriptorSet& write) {
-  device_->GetPtrs()->vkUpdateDescriptorSets(device_->GetDevice(), 1, &write, 0,
-                                             nullptr);
+  VKLOG(device_->GetPtrs()->vkUpdateDescriptorSets(device_->GetDevice(), 1,
+                                                   &write, 0, nullptr));
   is_descriptor_set_update_needed_ = false;
 }
 

--- a/src/vulkan/device.cc
+++ b/src/vulkan/device.cc
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "src/make_unique.h"
+#include "src/vulkan/vklog.h"
 
 namespace amber {
 namespace vulkan {
@@ -445,11 +446,11 @@ Result Device::Initialize(
         "required extensions");
   }
 
-  ptrs_.vkGetPhysicalDeviceProperties(physical_device_,
-                                      &physical_device_properties_);
+  VKLOG(ptrs_.vkGetPhysicalDeviceProperties(physical_device_,
+                                            &physical_device_properties_));
 
-  ptrs_.vkGetPhysicalDeviceMemoryProperties(physical_device_,
-                                            &physical_memory_properties_);
+  VKLOG(ptrs_.vkGetPhysicalDeviceMemoryProperties(
+      physical_device_, &physical_memory_properties_));
 
   return {};
 }

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -24,6 +24,7 @@
 #include "src/vulkan/descriptor.h"
 #include "src/vulkan/format_data.h"
 #include "src/vulkan/graphics_pipeline.h"
+#include "src/vulkan/vklog.h"
 
 namespace amber {
 namespace vulkan {
@@ -143,7 +144,8 @@ Result EngineVulkan::Shutdown() {
   for (auto it = modules_.begin(); it != modules_.end(); ++it) {
     auto vk_device = device_->GetDevice();
     if (vk_device != VK_NULL_HANDLE && it->second != VK_NULL_HANDLE)
-      device_->GetPtrs()->vkDestroyShaderModule(vk_device, it->second, nullptr);
+      VKLOG(device_->GetPtrs()->vkDestroyShaderModule(vk_device, it->second,
+                                                      nullptr));
   }
 
   if (pipeline_)
@@ -247,8 +249,8 @@ Result EngineVulkan::SetShader(ShaderType type,
     return Result("Vulkan::Setting Duplicated Shader Types Fail");
 
   VkShaderModule shader;
-  if (device_->GetPtrs()->vkCreateShaderModule(
-          device_->GetDevice(), &info, nullptr, &shader) != VK_SUCCESS) {
+  if (VKLOG(device_->GetPtrs()->vkCreateShaderModule(
+          device_->GetDevice(), &info, nullptr, &shader)) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateShaderModule Fail");
   }
 
@@ -527,8 +529,8 @@ bool EngineVulkan::IsFormatSupportedByPhysicalDevice(
     VkPhysicalDevice physical_device,
     VkFormat format) {
   VkFormatProperties properties = VkFormatProperties();
-  device_->GetPtrs()->vkGetPhysicalDeviceFormatProperties(physical_device,
-                                                          format, &properties);
+  VKLOG(device_->GetPtrs()->vkGetPhysicalDeviceFormatProperties(
+      physical_device, format, &properties));
 
   VkFormatFeatureFlagBits flag = VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT;
   bool is_buffer_type_image = false;
@@ -561,8 +563,8 @@ bool EngineVulkan::IsFormatSupportedByPhysicalDevice(
 bool EngineVulkan::IsDescriptorSetInBounds(VkPhysicalDevice physical_device,
                                            uint32_t descriptor_set) {
   VkPhysicalDeviceProperties properties = VkPhysicalDeviceProperties();
-  device_->GetPtrs()->vkGetPhysicalDeviceProperties(physical_device,
-                                                    &properties);
+  VKLOG(device_->GetPtrs()->vkGetPhysicalDeviceProperties(physical_device,
+                                                          &properties));
   return properties.limits.maxBoundDescriptorSets > descriptor_set;
 }
 

--- a/src/vulkan/frame_buffer.cc
+++ b/src/vulkan/frame_buffer.cc
@@ -22,6 +22,7 @@
 #include "src/vulkan/command_buffer.h"
 #include "src/vulkan/device.h"
 #include "src/vulkan/format_data.h"
+#include "src/vulkan/vklog.h"
 
 namespace amber {
 namespace vulkan {
@@ -74,9 +75,9 @@ Result FrameBuffer::Initialize(
   frame_buffer_info.height = height_;
   frame_buffer_info.layers = 1;
 
-  if (device_->GetPtrs()->vkCreateFramebuffer(device_->GetDevice(),
-                                              &frame_buffer_info, nullptr,
-                                              &frame_) != VK_SUCCESS) {
+  if (VKLOG(device_->GetPtrs()->vkCreateFramebuffer(
+          device_->GetDevice(), &frame_buffer_info, nullptr, &frame_)) !=
+      VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateFramebuffer Fail");
   }
 
@@ -144,8 +145,8 @@ Result FrameBuffer::ChangeFrameImageLayout(CommandBuffer* command,
 
 void FrameBuffer::Shutdown() {
   if (frame_ != VK_NULL_HANDLE) {
-    device_->GetPtrs()->vkDestroyFramebuffer(device_->GetDevice(), frame_,
-                                             nullptr);
+    VKLOG(device_->GetPtrs()->vkDestroyFramebuffer(device_->GetDevice(), frame_,
+                                                   nullptr));
   }
 
   if (color_image_)

--- a/src/vulkan/image.cc
+++ b/src/vulkan/image.cc
@@ -19,6 +19,7 @@
 #include "src/vulkan/command_buffer.h"
 #include "src/vulkan/device.h"
 #include "src/vulkan/format_data.h"
+#include "src/vulkan/vklog.h"
 
 namespace amber {
 namespace vulkan {
@@ -67,8 +68,9 @@ Result Image::Initialize(VkImageUsageFlags usage) {
 
   image_info_.usage = usage;
 
-  if (device_->GetPtrs()->vkCreateImage(device_->GetDevice(), &image_info_,
-                                        nullptr, &image_) != VK_SUCCESS) {
+  if (VKLOG(device_->GetPtrs()->vkCreateImage(
+          device_->GetDevice(), &image_info_, nullptr, &image_)) !=
+      VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateImage Fail");
   }
 
@@ -111,9 +113,9 @@ Result Image::CreateVkImageView() {
       1,       /* layerCount */
   };
 
-  if (device_->GetPtrs()->vkCreateImageView(device_->GetDevice(),
-                                            &image_view_info, nullptr,
-                                            &view_) != VK_SUCCESS) {
+  if (VKLOG(device_->GetPtrs()->vkCreateImageView(
+          device_->GetDevice(), &image_view_info, nullptr, &view_)) !=
+      VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateImageView Fail");
   }
 
@@ -122,15 +124,17 @@ Result Image::CreateVkImageView() {
 
 void Image::Shutdown() {
   if (view_ != VK_NULL_HANDLE) {
-    device_->GetPtrs()->vkDestroyImageView(device_->GetDevice(), view_,
-                                           nullptr);
+    VKLOG(device_->GetPtrs()->vkDestroyImageView(device_->GetDevice(), view_,
+                                                 nullptr));
   }
 
   if (image_ != VK_NULL_HANDLE)
-    device_->GetPtrs()->vkDestroyImage(device_->GetDevice(), image_, nullptr);
+    VKLOG(device_->GetPtrs()->vkDestroyImage(device_->GetDevice(), image_,
+                                             nullptr));
 
   if (memory_ != VK_NULL_HANDLE)
-    device_->GetPtrs()->vkFreeMemory(device_->GetDevice(), memory_, nullptr);
+    VKLOG(device_->GetPtrs()->vkFreeMemory(device_->GetDevice(), memory_,
+                                           nullptr));
 
   Resource::Shutdown();
 }
@@ -152,9 +156,9 @@ Result Image::CopyToHost(CommandBuffer* command) {
   copy_region.imageExtent = {image_info_.extent.width,
                              image_info_.extent.height, 1};
 
-  device_->GetPtrs()->vkCmdCopyImageToBuffer(
+  VKLOG(device_->GetPtrs()->vkCmdCopyImageToBuffer(
       command->GetCommandBuffer(), image_, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-      GetHostAccessibleBuffer(), 1, &copy_region);
+      GetHostAccessibleBuffer(), 1, &copy_region));
 
   MemoryBarrier(command);
   return {};
@@ -235,8 +239,8 @@ void Image::ChangeLayout(CommandBuffer* command,
       break;
   }
 
-  device_->GetPtrs()->vkCmdPipelineBarrier(
-      command->GetCommandBuffer(), from, to, 0, 0, NULL, 0, NULL, 1, &barrier);
+  VKLOG(device_->GetPtrs()->vkCmdPipelineBarrier(
+      command->GetCommandBuffer(), from, to, 0, 0, NULL, 0, NULL, 1, &barrier));
 }
 
 Result Image::AllocateAndBindMemoryToVkImage(VkImage image,
@@ -268,8 +272,8 @@ Result Image::AllocateAndBindMemoryToVkImage(VkImage image,
   if (!r.IsSuccess())
     return r;
 
-  if (device_->GetPtrs()->vkBindImageMemory(device_->GetDevice(), image,
-                                            *memory, 0) != VK_SUCCESS) {
+  if (VKLOG(device_->GetPtrs()->vkBindImageMemory(device_->GetDevice(), image,
+                                                  *memory, 0)) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkBindImageMemory Fail");
   }
 
@@ -279,8 +283,8 @@ Result Image::AllocateAndBindMemoryToVkImage(VkImage image,
 const VkMemoryRequirements Image::GetVkImageMemoryRequirements(
     VkImage image) const {
   VkMemoryRequirements requirement;
-  device_->GetPtrs()->vkGetImageMemoryRequirements(device_->GetDevice(), image,
-                                                   &requirement);
+  VKLOG(device_->GetPtrs()->vkGetImageMemoryRequirements(device_->GetDevice(),
+                                                         image, &requirement));
   return requirement;
 }
 

--- a/src/vulkan/index_buffer.cc
+++ b/src/vulkan/index_buffer.cc
@@ -21,6 +21,7 @@
 #include "src/vulkan/command_buffer.h"
 #include "src/vulkan/device.h"
 #include "src/vulkan/format_data.h"
+#include "src/vulkan/vklog.h"
 
 namespace amber {
 namespace vulkan {
@@ -64,9 +65,9 @@ Result IndexBuffer::BindToCommandBuffer(CommandBuffer* command) {
   if (!buffer_)
     return Result("IndexBuffer::BindToCommandBuffer |buffer_| is nullptr");
 
-  device_->GetPtrs()->vkCmdBindIndexBuffer(command->GetCommandBuffer(),
-                                           buffer_->GetVkBuffer(), 0,
-                                           VK_INDEX_TYPE_UINT32);
+  VKLOG(device_->GetPtrs()->vkCmdBindIndexBuffer(command->GetCommandBuffer(),
+                                                 buffer_->GetVkBuffer(), 0,
+                                                 VK_INDEX_TYPE_UINT32));
   return {};
 }
 

--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -26,6 +26,7 @@
 #include "src/vulkan/compute_pipeline.h"
 #include "src/vulkan/device.h"
 #include "src/vulkan/graphics_pipeline.h"
+#include "src/vulkan/vklog.h"
 
 namespace amber {
 namespace vulkan {
@@ -78,16 +79,16 @@ void Pipeline::Shutdown() {
 
   for (auto& info : descriptor_set_info_) {
     if (info.layout != VK_NULL_HANDLE) {
-      device_->GetPtrs()->vkDestroyDescriptorSetLayout(device_->GetDevice(),
-                                                       info.layout, nullptr);
+      VKLOG(device_->GetPtrs()->vkDestroyDescriptorSetLayout(
+          device_->GetDevice(), info.layout, nullptr));
     }
 
     if (info.empty)
       continue;
 
     if (info.pool != VK_NULL_HANDLE) {
-      device_->GetPtrs()->vkDestroyDescriptorPool(device_->GetDevice(),
-                                                  info.pool, nullptr);
+      VKLOG(device_->GetPtrs()->vkDestroyDescriptorPool(device_->GetDevice(),
+                                                        info.pool, nullptr));
     }
 
     for (auto& desc : info.descriptors_) {
@@ -116,8 +117,8 @@ Result Pipeline::CreateDescriptorSetLayouts() {
     desc_info.bindingCount = static_cast<uint32_t>(bindings.size());
     desc_info.pBindings = bindings.data();
 
-    if (device_->GetPtrs()->vkCreateDescriptorSetLayout(
-            device_->GetDevice(), &desc_info, nullptr, &info.layout) !=
+    if (VKLOG(device_->GetPtrs()->vkCreateDescriptorSetLayout(
+            device_->GetDevice(), &desc_info, nullptr, &info.layout)) !=
         VK_SUCCESS) {
       return Result("Vulkan::Calling vkCreateDescriptorSetLayout Fail");
     }
@@ -154,9 +155,9 @@ Result Pipeline::CreateDescriptorPools() {
     pool_info.poolSizeCount = static_cast<uint32_t>(pool_sizes.size());
     pool_info.pPoolSizes = pool_sizes.data();
 
-    if (device_->GetPtrs()->vkCreateDescriptorPool(device_->GetDevice(),
-                                                   &pool_info, nullptr,
-                                                   &info.pool) != VK_SUCCESS) {
+    if (VKLOG(device_->GetPtrs()->vkCreateDescriptorPool(
+            device_->GetDevice(), &pool_info, nullptr, &info.pool)) !=
+        VK_SUCCESS) {
       return Result("Vulkan::Calling vkCreateDescriptorPool Fail");
     }
   }
@@ -176,8 +177,8 @@ Result Pipeline::CreateDescriptorSets() {
     desc_set_info.pSetLayouts = &descriptor_set_info_[i].layout;
 
     VkDescriptorSet desc_set = VK_NULL_HANDLE;
-    if (device_->GetPtrs()->vkAllocateDescriptorSets(
-            device_->GetDevice(), &desc_set_info, &desc_set) != VK_SUCCESS) {
+    if (VKLOG(device_->GetPtrs()->vkAllocateDescriptorSets(
+            device_->GetDevice(), &desc_set_info, &desc_set)) != VK_SUCCESS) {
       return Result("Vulkan::Calling vkAllocateDescriptorSets Fail");
     }
     descriptor_set_info_[i].vk_desc_set = desc_set;
@@ -208,9 +209,9 @@ Result Pipeline::CreateVkPipelineLayout(VkPipelineLayout* pipeline_layout) {
     pipeline_layout_info.pPushConstantRanges = &push_const_range;
   }
 
-  if (device_->GetPtrs()->vkCreatePipelineLayout(
+  if (VKLOG(device_->GetPtrs()->vkCreatePipelineLayout(
           device_->GetDevice(), &pipeline_layout_info, nullptr,
-          pipeline_layout) != VK_SUCCESS) {
+          pipeline_layout)) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreatePipelineLayout Fail");
   }
 
@@ -388,12 +389,12 @@ void Pipeline::BindVkDescriptorSets(const VkPipelineLayout& pipeline_layout) {
     if (descriptor_set_info_[i].empty)
       continue;
 
-    device_->GetPtrs()->vkCmdBindDescriptorSets(
+    VKLOG(device_->GetPtrs()->vkCmdBindDescriptorSets(
         command_->GetCommandBuffer(),
         IsGraphics() ? VK_PIPELINE_BIND_POINT_GRAPHICS
                      : VK_PIPELINE_BIND_POINT_COMPUTE,
         pipeline_layout, static_cast<uint32_t>(i), 1,
-        &descriptor_set_info_[i].vk_desc_set, 0, nullptr);
+        &descriptor_set_info_[i].vk_desc_set, 0, nullptr));
   }
 }
 

--- a/src/vulkan/push_constant.cc
+++ b/src/vulkan/push_constant.cc
@@ -20,6 +20,7 @@
 
 #include "src/vulkan/command_buffer.h"
 #include "src/vulkan/device.h"
+#include "src/vulkan/vklog.h"
 
 namespace amber {
 namespace vulkan {
@@ -96,10 +97,10 @@ Result PushConstant::RecordPushConstantVkCommand(
   // be multiple of 4.
   assert(push_const_range.offset % 4U == 0 && push_const_range.size % 4U == 0);
 
-  device_->GetPtrs()->vkCmdPushConstants(
+  VKLOG(device_->GetPtrs()->vkCmdPushConstants(
       command->GetCommandBuffer(), pipeline_layout, VK_SHADER_STAGE_ALL,
       push_const_range.offset, push_const_range.size,
-      memory_.data() + push_const_range.offset);
+      memory_.data() + push_const_range.offset));
   return {};
 }
 

--- a/src/vulkan/vertex_buffer.cc
+++ b/src/vulkan/vertex_buffer.cc
@@ -21,6 +21,7 @@
 #include "src/vulkan/command_buffer.h"
 #include "src/vulkan/device.h"
 #include "src/vulkan/format_data.h"
+#include "src/vulkan/vklog.h"
 
 namespace amber {
 namespace vulkan {
@@ -263,8 +264,8 @@ void VertexBuffer::BindToCommandBuffer(CommandBuffer* command) {
   const VkDeviceSize offset = 0;
   const VkBuffer buffer = buffer_->GetVkBuffer();
   // TODO(jaebaek): Support multiple binding
-  device_->GetPtrs()->vkCmdBindVertexBuffers(command->GetCommandBuffer(), 0, 1,
-                                             &buffer, &offset);
+  VKLOG(device_->GetPtrs()->vkCmdBindVertexBuffers(command->GetCommandBuffer(),
+                                                   0, 1, &buffer, &offset));
 }
 
 Result VertexBuffer::SendVertexData(

--- a/src/vulkan/vklog.cc
+++ b/src/vulkan/vklog.cc
@@ -14,10 +14,10 @@
 
 #include "src/vulkan/vklog.h"
 
-#include <iostream>
-
 // Use C string library for preprocessor strings like __FILE__
 #include <string.h>
+
+#include <iostream>
 
 namespace amber {
 namespace vulkan {

--- a/src/vulkan/vklog.cc
+++ b/src/vulkan/vklog.cc
@@ -1,0 +1,60 @@
+// Copyright 2019 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/vulkan/vklog.h"
+
+#include <iostream>
+
+// Use C string library for preprocessor strings like __FILE__
+#include <string.h>
+
+namespace amber {
+namespace vulkan {
+
+namespace {
+#ifdef _WIN32
+const char kSeparator = '\\';
+#else  // _WIN32
+const char kSeparator = '/';
+#endif
+}  // namespace
+
+void vklog(const char* filepath, int line, const char* expr) {
+  // Strip file path to only the file basename
+  const char* basename = strrchr(filepath, kSeparator);
+  if (basename == nullptr) {
+    basename = filepath;
+  } else {
+    if (strlen(basename + 1) <= 0) {
+      // Nothing beyond the separator, weird. Use the plain filepath.
+      basename = filepath;
+    } else {
+      // Move beyond the separator character
+      basename++;
+    }
+  }
+
+  // Clean up the api call: remove anything prefixing 'vk'
+  const char* call = strstr(expr, "vk");
+  if (call == nullptr) {
+    // All calls should contain "vk", this is suspicious. Use the plain expr.
+    call = expr;
+  }
+
+  // Log the call in compiler output style: file:line call
+  std::cout << basename << ":" << line << " " << call << std::endl;
+}
+
+}  // namespace vulkan
+}  // namespace amber

--- a/src/vulkan/vklog.h
+++ b/src/vulkan/vklog.h
@@ -1,0 +1,36 @@
+// Copyright 2019 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SRC_VULKAN_VKLOG_H_
+#define SRC_VULKAN_VKLOG_H_
+
+#ifdef AMBER_LOG_VULKAN
+
+#define VKLOG(expr) (amber::vulkan::vklog(__FILE__, __LINE__, #expr), (expr))
+
+namespace amber {
+namespace vulkan {
+
+void vklog(const char* filepath, int line, const char* expr);
+
+}  // namespace vulkan
+}  // namespace amber
+
+#else  // AMBER_LOG_VULKAN
+
+#define VKLOG(expr) (expr)
+
+#endif  // AMBER_LOG_VULKAN
+
+#endif  // SRC_VULKAN_VKLOG_H_


### PR DESCRIPTION
Fix #324  

The VKLOG() macro pseudo-code is:
`#define VKLOG(expr) ( printf(#expr) , (expr) )`

It uses the C comma operator to make sure the VKLOG(vkCall(...)) expression returns the value of the vkCall() inside it, if any (some vkCalls return void). In addition, it prints the stripped file name and line number. This macro is meaningful only if AMBER_LOG_VULKAN is defined at cmake time, otherwise it just evaluates its argument.

An example of log:

```
device.cc:450 vkGetPhysicalDeviceProperties(physical_device_, &physical_device_properties_)
device.cc:453 vkGetPhysicalDeviceMemoryProperties(physical_device_, &physical_memory_properties_)
command_pool.cc:34 vkCreateCommandPool(device_->GetDevice(), &pool_info, nullptr, &pool_)
engine_vulkan.cc:532 vkGetPhysicalDeviceFormatProperties(physical_device, format, &properties)
engine_vulkan.cc:252 vkCreateShaderModule( device_->GetDevice(), &info, nullptr, &shader)
engine_vulkan.cc:252 vkCreateShaderModule( device_->GetDevice(), &info, nullptr, &shader)
command_buffer.cc:37 vkAllocateCommandBuffers( device_->GetDevice(), &command_info, &command_)
command_buffer.cc:44 vkCreateFence(device_->GetDevice(), &fence_info, nullptr, &fence_)
graphics_pipeline.cc:419 vkCreateRenderPass(device_->GetDevice(), &render_pass_info, nullptr, &render_pass_)
image.cc:72 vkCreateImage(device_->GetDevice(), &image_info_, nullptr, &image_)
image.cc:284 vkGetImageMemoryRequirements(device_->GetDevice(), image, &requirement)
[etc]
```

The logging is currently in place for all API calls under src/vulkan/, not for API calls in /samples, we would need to make vklog.h/cc accessible in samples for this.

What do you think of the approach?

Is it relevant to log the Vulkan calls of the samples?
