### PR TITLE
Add vulkan information into -V output.

### DIFF
--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -231,11 +231,6 @@ int main(int argc, const char** argv) {
     return 0;
   }
 
-  if (options.input_filenames.empty()) {
-    std::cerr << "Input file must be provided." << std::endl;
-    return 2;
-  }
-
   amber::Result result;
   std::vector<std::string> failures;
   struct RecipeData {
@@ -303,7 +298,7 @@ int main(int argc, const char** argv) {
                                required_instance_extensions.end()),
       std::vector<std::string>(required_device_extensions.begin(),
                                required_device_extensions.end()),
-      options.disable_validation_layer, &config);
+      options.disable_validation_layer, options.show_version_info, &config);
 
   if (!r.IsSuccess()) {
     std::cout << r.Error() << std::endl;

--- a/samples/config_helper.cc
+++ b/samples/config_helper.cc
@@ -44,6 +44,7 @@ amber::Result ConfigHelper::CreateConfig(
     const std::vector<std::string>& required_instance_extensions,
     const std::vector<std::string>& required_device_extensions,
     bool disable_validation_layer,
+    bool show_version_info,
     std::unique_ptr<amber::EngineConfig>* config) {
   switch (engine) {
     case amber::kEngineTypeVulkan:
@@ -65,10 +66,10 @@ amber::Result ConfigHelper::CreateConfig(
   if (!impl_)
     return amber::Result("Unable to create config helper");
 
-  return impl_->CreateConfig(engine_major, engine_minor, required_features,
-                             required_instance_extensions,
-                             required_device_extensions,
-                             disable_validation_layer, config);
+  return impl_->CreateConfig(
+      engine_major, engine_minor, required_features,
+      required_instance_extensions, required_device_extensions,
+      disable_validation_layer, show_version_info, config);
 }
 
 amber::Result ConfigHelper::Shutdown() {

--- a/samples/config_helper.h
+++ b/samples/config_helper.h
@@ -39,6 +39,7 @@ class ConfigHelperImpl {
       const std::vector<std::string>& required_instance_extensions,
       const std::vector<std::string>& required_device_extensions,
       bool disable_validation_layer,
+      bool show_version_info,
       std::unique_ptr<amber::EngineConfig>* config) = 0;
 
   // Destroy instance and device.
@@ -64,6 +65,7 @@ class ConfigHelper {
       const std::vector<std::string>& required_instance_extensions,
       const std::vector<std::string>& required_device_extensions,
       bool disable_validation_layer,
+      bool show_version_info,
       std::unique_ptr<amber::EngineConfig>* config);
 
   // Destroy instance and device.

--- a/samples/config_helper_dawn.cc
+++ b/samples/config_helper_dawn.cc
@@ -37,6 +37,7 @@ amber::Result ConfigHelperDawn::CreateConfig(
     const std::vector<std::string>&,
     const std::vector<std::string>&,
     bool,
+    bool,
     std::unique_ptr<amber::EngineConfig>* config) {
 #if AMBER_DAWN_METAL
   auto r = dawn::CreateMetalDevice(&dawn_instance_, &dawn_device_);

--- a/samples/config_helper_dawn.h
+++ b/samples/config_helper_dawn.h
@@ -44,6 +44,7 @@ class ConfigHelperDawn : public ConfigHelperImpl {
       const std::vector<std::string>& required_instance_extensions,
       const std::vector<std::string>& required_device_extensions,
       bool disable_validation_layer,
+      bool show_version_info,
       std::unique_ptr<amber::EngineConfig>* config) override;
 
   // Destroy Dawn instance and device.

--- a/samples/config_helper_vulkan.h
+++ b/samples/config_helper_vulkan.h
@@ -48,6 +48,7 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
       const std::vector<std::string>& required_instance_extensions,
       const std::vector<std::string>& required_device_extensions,
       bool disable_validation_layer,
+      bool show_version_info,
       std::unique_ptr<amber::EngineConfig>* config) override;
 
   // Destroy Vulkan instance and device.
@@ -88,6 +89,9 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
 
   // Creates the physical device given the device |info|.
   amber::Result DoCreateDevice(VkDeviceCreateInfo* info);
+
+  // Writes information related to the vulkan instance to stdout.
+  void DumpPhysicalDeviceInfo();
 
   VkInstance vulkan_instance_ = VK_NULL_HANDLE;
   VkDebugReportCallbackEXT vulkan_callback_ = VK_NULL_HANDLE;


### PR DESCRIPTION
This CL adds information from the vulkan physical device into the -V
output when requested.

Fixes #323