### PR TITLE
Add Delegate class to enable hooking log function around graphics API calls

### DIFF
--- a/include/amber/amber.h
+++ b/include/amber/amber.h
@@ -52,6 +52,17 @@ struct BufferInfo {
   std::vector<Value> values;
 };
 
+/// Delegate class for various hook functions
+class Delegate {
+ public:
+  virtual ~Delegate();
+
+  /// Log the given message
+  virtual void Log(const std::string& message) = 0;
+  /// Tells whether to log the graphics API calls
+  virtual bool LogGraphicsCalls() const = 0;
+};
+
 struct Options {
   /// Sets the engine to be created. Default Vulkan.
   EngineType engine;
@@ -63,6 +74,8 @@ struct Options {
   std::vector<BufferInfo> extractions;
   /// Terminate after creating the pipelines.
   bool pipeline_create_only;
+  /// Delegate implementation
+  Delegate* delegate;
 };
 
 /// Main interface to the Amber environment.

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(amber ${AMBER_SOURCES})
 target_include_directories(amber PRIVATE "${CMAKE_BINARY_DIR}")
 set_target_properties(amber PROPERTIES OUTPUT_NAME "amber")
 target_link_libraries(amber libamber ${AMBER_EXTRA_LIBS})
+amber_default_compile_options(amber)
 
 add_custom_command(
     OUTPUT ${CMAKE_BINARY_DIR}/src/build-versions.h.fake

--- a/src/amber.cc
+++ b/src/amber.cc
@@ -29,6 +29,8 @@
 
 namespace amber {
 
+Delegate::~Delegate() = default;
+
 Amber::Amber() = default;
 
 Amber::~Amber() = default;
@@ -77,7 +79,8 @@ Result CreateEngineAndCheckRequirements(const Recipe* recipe,
 
   // Engine initialization checks requirements.  Current backends don't do
   // much else.  Refactor this if they end up doing to much here.
-  Result r = engine->Initialize(opts->config, script->GetRequiredFeatures(),
+  Result r = engine->Initialize(opts->config, opts->delegate,
+                                script->GetRequiredFeatures(),
                                 script->GetRequiredInstanceExtensions(),
                                 script->GetRequiredDeviceExtensions());
   if (!r.IsSuccess())

--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -182,6 +182,7 @@ EngineDawn::EngineDawn() : Engine() {}
 EngineDawn::~EngineDawn() = default;
 
 Result EngineDawn::Initialize(EngineConfig* config,
+                              Delegate*,
                               const std::vector<std::string>&,
                               const std::vector<std::string>&,
                               const std::vector<std::string>&) {

--- a/src/dawn/engine_dawn.h
+++ b/src/dawn/engine_dawn.h
@@ -37,6 +37,7 @@ class EngineDawn : public Engine {
   // Engine
   // Initialize with given configuration data.
   Result Initialize(EngineConfig* config,
+                    Delegate*,
                     const std::vector<std::string>& features,
                     const std::vector<std::string>& instance_extensions,
                     const std::vector<std::string>& device_extensions) override;

--- a/src/engine.h
+++ b/src/engine.h
@@ -85,6 +85,7 @@ class Engine {
   /// otherwise.
   virtual Result Initialize(
       EngineConfig* config,
+      Delegate* delegate,
       const std::vector<std::string>& features,
       const std::vector<std::string>& instance_extensions,
       const std::vector<std::string>& device_extensions) = 0;

--- a/src/executor_test.cc
+++ b/src/executor_test.cc
@@ -34,6 +34,7 @@ class EngineStub : public Engine {
 
   // Engine
   Result Initialize(EngineConfig*,
+                    Delegate*,
                     const std::vector<std::string>& features,
                     const std::vector<std::string>& instance_exts,
                     const std::vector<std::string>& device_exts) override {
@@ -214,7 +215,7 @@ class VkScriptExecutorTest : public testing::Test {
       const std::vector<std::string>& instance_extensions,
       const std::vector<std::string>& device_extensions) {
     auto engine = MakeUnique<EngineStub>();
-    engine->Initialize(nullptr, features, instance_extensions,
+    engine->Initialize(nullptr, nullptr, features, instance_extensions,
                        device_extensions);
     return std::move(engine);
   }

--- a/src/vulkan/device.cc
+++ b/src/vulkan/device.cc
@@ -15,6 +15,7 @@
 #include "src/vulkan/device.h"
 
 #include <cstring>
+#include <iostream>
 #include <memory>
 #include <set>
 #include <string>
@@ -354,20 +355,28 @@ Device::Device(VkInstance instance,
 
 Device::~Device() = default;
 
-Result Device::LoadVulkanPointers(
-    PFN_vkGetInstanceProcAddr getInstanceProcAddr) {
+Result Device::LoadVulkanPointers(PFN_vkGetInstanceProcAddr getInstanceProcAddr,
+                                  Delegate* delegate) {
+  // Note: logging Vulkan calls is done via the delegate rather than a Vulkan
+  // layer because we want such logging even when Amber is built as a native
+  // executable on Android, where Vulkan layers are usable only with APKs.
+  if (delegate && delegate->LogGraphicsCalls())
+    delegate->Log("Loading Vulkan Pointers");
+
 #include "src/vk-wrappers.inc"
+
   return {};
 }
 
 Result Device::Initialize(
     PFN_vkGetInstanceProcAddr getInstanceProcAddr,
+    Delegate* delegate,
     const std::vector<std::string>& required_features,
     const std::vector<std::string>& required_extensions,
     const VkPhysicalDeviceFeatures& available_features,
     const VkPhysicalDeviceFeatures2KHR& available_features2,
     const std::vector<std::string>& available_extensions) {
-  Result r = LoadVulkanPointers(getInstanceProcAddr);
+  Result r = LoadVulkanPointers(getInstanceProcAddr, delegate);
   if (!r.IsSuccess())
     return r;
 

--- a/src/vulkan/device.h
+++ b/src/vulkan/device.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "amber/amber.h"
 #include "amber/result.h"
 #include "amber/vulkan_header.h"
 
@@ -40,6 +41,7 @@ class Device {
   ~Device();
 
   Result Initialize(PFN_vkGetInstanceProcAddr getInstanceProcAddr,
+                    Delegate* delegate,
                     const std::vector<std::string>& required_features,
                     const std::vector<std::string>& required_extensions,
                     const VkPhysicalDeviceFeatures& available_features,
@@ -62,7 +64,7 @@ class Device {
   const VulkanPtrs* GetPtrs() const { return &ptrs_; }
 
  private:
-  Result LoadVulkanPointers(PFN_vkGetInstanceProcAddr);
+  Result LoadVulkanPointers(PFN_vkGetInstanceProcAddr, Delegate* delegate);
 
   VkInstance instance_ = VK_NULL_HANDLE;
   VkPhysicalDevice physical_device_ = VK_NULL_HANDLE;

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -78,6 +78,7 @@ EngineVulkan::~EngineVulkan() = default;
 
 Result EngineVulkan::Initialize(
     EngineConfig* config,
+    Delegate* delegate,
     const std::vector<std::string>& features,
     const std::vector<std::string>& instance_extensions,
     const std::vector<std::string>& device_extensions) {
@@ -105,7 +106,7 @@ Result EngineVulkan::Initialize(
                                vk_config->queue);
 
   Result r = device_->Initialize(
-      vk_config->vkGetInstanceProcAddr, features, device_extensions,
+      vk_config->vkGetInstanceProcAddr, delegate, features, device_extensions,
       vk_config->available_features, vk_config->available_features2,
       vk_config->available_device_extensions);
   if (!r.IsSuccess())

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -40,6 +40,7 @@ class EngineVulkan : public Engine {
 
   // Engine
   Result Initialize(EngineConfig* config,
+                    Delegate* delegate,
                     const std::vector<std::string>& features,
                     const std::vector<std::string>& instance_extensions,
                     const std::vector<std::string>& device_extensions) override;


### PR DESCRIPTION
This adds a Delegate which enables to define hook functions that will
be called around each graphics API calls.

In practice, a pointer to the delegate object is passed at engine
creation and the Vulkan engine eventually pass it to
LoadVulkanPointers() which calls the functions produced by
update_vk_wrappers.py. This enable to choose at function load time
whether to load a straighforward wrapper to the API command, or to
load a lambda that surround the API command with calls to the delegate
methods.

The delegate currently offers only a log() method, called before the
actual API command, but other delegate methods may be added later on.

The --verbose flag enables the delegate to produce a log of API calls.