### PR TITLE
WIP: Add --log-graphics-call-time flag

### DIFF
--- a/include/amber/amber.h
+++ b/include/amber/amber.h
@@ -61,6 +61,10 @@ class Delegate {
   virtual void Log(const std::string& message) = 0;
   /// Tells whether to log the graphics API calls
   virtual bool LogGraphicsCalls() const = 0;
+  /// Tells whether to log the duration of graphics API calls
+  virtual bool LogGraphicsCallsTime() const = 0;
+  /// Returns the current timestamp in nanoseconds
+  virtual uint64_t GetTimestampNs() const = 0;
 };
 
 struct Options {

--- a/samples/Android.mk
+++ b/samples/Android.mk
@@ -23,7 +23,8 @@ LOCAL_SRC_FILES:= \
     config_helper_vulkan.cc \
     log.cc \
     ppm.cc \
-    png.cc
+    png.cc \
+    timestamp.cc
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/.. $(LOCAL_PATH)/../include
 LOCAL_LDLIBS:=-landroid -lvulkan -llog
 LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti -Werror -Wno-unknown-pragmas -DAMBER_ENGINE_VULKAN=1

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -20,6 +20,7 @@ set(AMBER_SOURCES
     log.cc
     ppm.cc
     png.cc
+    timestamp.cc
     ${CMAKE_BINARY_DIR}/src/build-versions.h.fake
 )
 

--- a/samples/timestamp.cc
+++ b/samples/timestamp.cc
@@ -1,0 +1,69 @@
+// Copyright 2019 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "samples/timestamp.h"
+
+#include <cassert>
+
+#if defined(_WIN32) || defined(_WIN64)
+#define SAMPLE_PLATFORM_WINDOWS 1
+#define SAMPLE_PLATFORM_POSIX 0
+#elif defined(__linux__) || defined(__APPLE__)
+#define SAMPLE_PLATFORM_POSIX 1
+#define SAMPLE_PLATFORM_WINDOWS 0
+#endif
+
+#if SAMPLE_PLATFORM_WINDOWS
+#include <windows.h>
+#elif SAMPLE_PLATFORM_POSIX
+#include <time.h>
+#else
+#error "Unknown platform"
+#endif
+
+namespace timestamp {
+
+uint64_t SampleGetTimestampNs() {
+  uint64_t timestamp = 0;
+
+#if SAMPLE_PLATFORM_WINDOWS
+
+  LARGE_INTEGER tick_per_seconds;
+  if (!QueryPerformanceFrequency(&tick_per_seconds)) {
+    return 0;
+  }
+  LARGE_INTEGER ticks;
+  if (!QueryPerformanceCounter(&ticks)) {
+    return 0;
+  }
+  double tick_duration_ns = static_cast<double>(1.0e9) /
+                            static_cast<double>(tick_per_seconds.QuadPart);
+  timestamp = uint64_t(static_cast<double>(ticks.QuadPart) * tick_duration_ns);
+
+#elif SAMPLE_PLATFORM_POSIX
+
+  struct timespec time;
+  if (clock_gettime(CLOCK_MONOTONIC, &time)) {
+    return 0;
+  }
+  timestamp = static_cast<uint64_t>((time.tv_sec * 1000000000) + time.tv_nsec);
+
+#else
+#error "Implement timestamp::SampleGetTimestampNs"
+#endif
+
+  return timestamp;
+}
+
+}  // namespace timestamp

--- a/samples/timestamp.h
+++ b/samples/timestamp.h
@@ -1,0 +1,27 @@
+// Copyright 2019 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SAMPLES_TIMESTAMP_H_
+#define SAMPLES_TIMESTAMP_H_
+
+#include "amber/amber.h"
+
+namespace timestamp {
+
+/// Return a timestamp in nanoseconds.
+uint64_t SampleGetTimestampNs();
+
+}  // namespace timestamp
+
+#endif  // SAMPLES_TIMESTAMP_H_

--- a/src/vulkan/device.cc
+++ b/src/vulkan/device.cc
@@ -15,9 +15,11 @@
 #include "src/vulkan/device.h"
 
 #include <cstring>
+#include <iomanip>  // Vulkan wrappers: std::setw(), std::left/right
 #include <iostream>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Fix #342 

Provide a timestamp in nanoseconds in front of each graphics API call log.

This is a work-in-progress draft to discuss the following:
- Should GetTimestamp() be implemented in samples/ (like it is in this draft), or is it OK to put the implementation under src/ ?
- Currently we prefix each API call with a timestamp, was the idea to actually return the API call *duration*?
- Are you OK with the refactoring of vulkan wrapper generation using a python template string? (I can extract this as a preliminary, isolated PR if you prefer?)