### PR TITLE
 Add buffer to probe command.

### DIFF
--- a/src/amber.cc
+++ b/src/amber.cc
@@ -133,14 +133,18 @@ amber::Result Amber::ExecuteWithShaderData(const amber::Recipe* recipe,
   // to almost always fail.
   for (BufferInfo& buffer_info : opts->extractions) {
     if (buffer_info.buffer_name == "framebuffer") {
+      auto* buffer = script->GetBuffer(buffer_info.buffer_name);
+      if (!buffer)
+        break;
+
       ResourceInfo info;
-      r = engine->GetFrameBufferInfo(pipeline, 0, &info);
+      r = engine->GetFrameBufferInfo(pipeline, buffer, &info);
       if (!r.IsSuccess())
         break;
 
       buffer_info.width = info.image_info.width;
       buffer_info.height = info.image_info.height;
-      r = engine->GetFrameBuffer(pipeline, 0, &(buffer_info.values));
+      r = engine->GetFrameBuffer(pipeline, buffer, &(buffer_info.values));
       if (!r.IsSuccess())
         break;
 

--- a/src/command.cc
+++ b/src/command.cc
@@ -90,8 +90,8 @@ Probe::Probe(Type type, Pipeline* pipeline) : Command(type, pipeline) {}
 
 Probe::~Probe() = default;
 
-ProbeCommand::ProbeCommand(Pipeline* pipeline)
-    : Probe(Type::kProbe, pipeline) {}
+ProbeCommand::ProbeCommand(Pipeline* pipeline, Buffer* buffer)
+    : Probe(Type::kProbe, pipeline), buffer_(buffer) {}
 
 ProbeCommand::~ProbeCommand() = default;
 

--- a/src/command.h
+++ b/src/command.h
@@ -22,6 +22,7 @@
 
 #include "amber/shader_info.h"
 #include "amber/value.h"
+#include "src/buffer.h"
 #include "src/command_data.h"
 #include "src/datum_type.h"
 #include "src/pipeline_data.h"
@@ -217,8 +218,10 @@ class Probe : public Command {
 
 class ProbeCommand : public Probe {
  public:
-  explicit ProbeCommand(Pipeline* pipeline);
+  explicit ProbeCommand(Pipeline* pipeline, Buffer* buffer);
   ~ProbeCommand() override;
+
+  Buffer* GetBuffer() const { return buffer_; }
 
   void SetWholeWindow() { is_whole_window_ = true; }
   bool IsWholeWindow() const { return is_whole_window_; }
@@ -261,6 +264,8 @@ class ProbeCommand : public Probe {
     kRGB = 0,
     kRGBA,
   };
+
+  Buffer* buffer_;
 
   bool is_whole_window_ = false;
   bool is_probe_rect_ = false;

--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -449,7 +449,7 @@ Result EngineDawn::CreateFramebufferIfNeeded() {
   return {};
 }
 
-Result EngineDawn::GetFrameBufferInfo(Pipeline*, size_t, ResourceInfo* info) {
+Result EngineDawn::GetFrameBufferInfo(Pipeline*, Buffer*, ResourceInfo* info) {
   assert(info);
 
   if (render_pipeline_info_.fb_data == nullptr)
@@ -467,7 +467,7 @@ Result EngineDawn::GetFrameBufferInfo(Pipeline*, size_t, ResourceInfo* info) {
   return {};
 }
 
-Result EngineDawn::GetFrameBuffer(Pipeline*, size_t, std::vector<Value>*) {
+Result EngineDawn::GetFrameBuffer(Pipeline*, Buffer*, std::vector<Value>*) {
   return Result("Dawn::GetFrameBuffer not implemented");
 }
 

--- a/src/dawn/engine_dawn.h
+++ b/src/dawn/engine_dawn.h
@@ -61,11 +61,9 @@ class EngineDawn : public Engine {
       const PatchParameterVerticesCommand* cmd) override;
   Result DoBuffer(const BufferCommand* cmd) override;
   Result DoProcessCommands(Pipeline*) override;
-  Result GetFrameBufferInfo(Pipeline*,
-                            size_t attachment_idx,
-                            ResourceInfo* info) override;
+  Result GetFrameBufferInfo(Pipeline*, Buffer*, ResourceInfo* info) override;
   Result GetFrameBuffer(Pipeline*,
-                        size_t attachment_idx,
+                        Buffer*,
                         std::vector<Value>* values) override;
   Result GetDescriptorInfo(Pipeline*,
                            const uint32_t descriptor_set,

--- a/src/engine.h
+++ b/src/engine.h
@@ -139,13 +139,13 @@ class Engine {
   /// DoProcessCommands() and since then no graphics pipeline drawing
   /// commands have occurred e.g., DoClear, DoDrawArrays, DoDrawRect.
   virtual Result GetFrameBufferInfo(Pipeline* pipeline,
-                                    size_t attachment_idx,
+                                    Buffer* buffer,
                                     ResourceInfo* info) = 0;
 
   /// Copy the content of the framebuffer into |values|, each value is a pixel
   /// in R8G8B8A8 format.
   virtual Result GetFrameBuffer(Pipeline* pipeline,
-                                size_t attachment_idx,
+                                Buffer* buffer,
                                 std::vector<Value>* values) = 0;
 
   /// Copy the contents of the resource bound to the given descriptor

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -80,7 +80,8 @@ Result Executor::Execute(Engine* engine,
       // This must come after processing commands because we require
       // the framebuffer data to be mapped into host memory and have
       // a valid host-side pointer.
-      r = engine->GetFrameBufferInfo(cmd->GetPipeline(), 0, &info);
+      r = engine->GetFrameBufferInfo(cmd->GetPipeline(),
+                                     cmd->AsProbe()->GetBuffer(), &info);
       if (!r.IsSuccess())
         return r;
       assert(info.cpu_memory != nullptr);

--- a/src/executor_test.cc
+++ b/src/executor_test.cc
@@ -161,10 +161,10 @@ class EngineStub : public Engine {
   }
 
   Result DoProcessCommands(Pipeline*) override { return {}; }
-  Result GetFrameBufferInfo(Pipeline*, size_t, ResourceInfo*) override {
+  Result GetFrameBufferInfo(Pipeline*, Buffer*, ResourceInfo*) override {
     return {};
   }
-  Result GetFrameBuffer(Pipeline*, size_t, std::vector<Value>*) override {
+  Result GetFrameBuffer(Pipeline*, Buffer*, std::vector<Value>*) override {
     return {};
   }
   Result GetDescriptorInfo(Pipeline*,

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -215,7 +215,8 @@ Result Pipeline::AddColorAttachment(Buffer* buf, uint32_t location) {
   return {};
 }
 
-Result Pipeline::GetLocationForColorAttachment(Buffer* buf, uint32_t* loc) {
+Result Pipeline::GetLocationForColorAttachment(Buffer* buf,
+                                               uint32_t* loc) const {
   for (const auto& info : color_attachments_) {
     if (info.buffer == buf) {
       *loc = info.location;

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -215,6 +215,16 @@ Result Pipeline::AddColorAttachment(Buffer* buf, uint32_t location) {
   return {};
 }
 
+Result Pipeline::GetLocationForColorAttachment(Buffer* buf, uint32_t* loc) {
+  for (const auto& info : color_attachments_) {
+    if (info.buffer == buf) {
+      *loc = info.location;
+      return {};
+    }
+  }
+  return Result("Unable to find requested buffer");
+}
+
 Result Pipeline::SetDepthBuffer(Buffer* buf) {
   if (depth_buffer_.buffer != nullptr)
     return Result("can only bind one depth buffer in a PIPELINE");

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -115,7 +115,7 @@ class Pipeline {
     return color_attachments_;
   }
   Result AddColorAttachment(Buffer* buf, uint32_t location);
-  Result GetLocationForColorAttachment(Buffer* buf, uint32_t* loc);
+  Result GetLocationForColorAttachment(Buffer* buf, uint32_t* loc) const;
 
   Result SetDepthBuffer(Buffer* buf);
   const BufferInfo& GetDepthBuffer() const { return depth_buffer_; }

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -115,6 +115,7 @@ class Pipeline {
     return color_attachments_;
   }
   Result AddColorAttachment(Buffer* buf, uint32_t location);
+  Result GetLocationForColorAttachment(Buffer* buf, uint32_t* loc);
 
   Result SetDepthBuffer(Buffer* buf);
   const BufferInfo& GetDepthBuffer() const { return depth_buffer_; }

--- a/src/verifier_test.cc
+++ b/src/verifier_test.cc
@@ -59,7 +59,10 @@ class VerifierTest : public testing::Test {
 
 TEST_F(VerifierTest, ProbeFrameBufferWholeWindow) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetWholeWindow();
   probe.SetProbeRect();
   probe.SetIsRGBA();
@@ -94,7 +97,10 @@ TEST_F(VerifierTest, ProbeFrameBufferWholeWindow) {
 
 TEST_F(VerifierTest, ProbeFrameBufferRelative) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetProbeRect();
   probe.SetRelative();
   probe.SetIsRGBA();
@@ -125,7 +131,10 @@ TEST_F(VerifierTest, ProbeFrameBufferRelative) {
 
 TEST_F(VerifierTest, ProbeFrameBufferRelativeSmallExpectFail) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetProbeRect();
   probe.SetRelative();
   probe.SetIsRGBA();
@@ -152,7 +161,10 @@ TEST_F(VerifierTest, ProbeFrameBufferRelativeSmallExpectFail) {
 
 TEST_F(VerifierTest, ProbeFrameBuffer) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetProbeRect();
   probe.SetIsRGBA();
   probe.SetX(1.0f);
@@ -182,7 +194,10 @@ TEST_F(VerifierTest, ProbeFrameBuffer) {
 
 TEST_F(VerifierTest, ProbeFrameBufferUInt8) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetIsRGBA();
   probe.SetX(0.0f);
   probe.SetY(0.0f);
@@ -210,7 +225,10 @@ TEST_F(VerifierTest, ProbeFrameBufferUInt8) {
 
 TEST_F(VerifierTest, ProbeFrameBufferUInt16) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetIsRGBA();
   probe.SetX(0.0f);
   probe.SetY(0.0f);
@@ -238,7 +256,10 @@ TEST_F(VerifierTest, ProbeFrameBufferUInt16) {
 
 TEST_F(VerifierTest, ProbeFrameBufferUInt32) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetIsRGBA();
   probe.SetX(0.0f);
   probe.SetY(0.0f);
@@ -266,7 +287,10 @@ TEST_F(VerifierTest, ProbeFrameBufferUInt32) {
 
 TEST_F(VerifierTest, ProbeFrameBufferUInt64) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetIsRGBA();
   probe.SetX(0.0f);
   probe.SetY(0.0f);
@@ -294,7 +318,10 @@ TEST_F(VerifierTest, ProbeFrameBufferUInt64) {
 
 TEST_F(VerifierTest, ProbeFrameBufferSInt8) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetIsRGBA();
   probe.SetX(0.0f);
   probe.SetY(0.0f);
@@ -322,7 +349,10 @@ TEST_F(VerifierTest, ProbeFrameBufferSInt8) {
 
 TEST_F(VerifierTest, ProbeFrameBufferSInt16) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetIsRGBA();
   probe.SetX(0.0f);
   probe.SetY(0.0f);
@@ -350,7 +380,10 @@ TEST_F(VerifierTest, ProbeFrameBufferSInt16) {
 
 TEST_F(VerifierTest, ProbeFrameBufferSInt32) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetIsRGBA();
   probe.SetX(0.0f);
   probe.SetY(0.0f);
@@ -378,7 +411,10 @@ TEST_F(VerifierTest, ProbeFrameBufferSInt32) {
 
 TEST_F(VerifierTest, ProbeFrameBufferSInt64) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetIsRGBA();
   probe.SetX(0.0f);
   probe.SetY(0.0f);
@@ -406,7 +442,10 @@ TEST_F(VerifierTest, ProbeFrameBufferSInt64) {
 
 TEST_F(VerifierTest, ProbeFrameBufferFloat32) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetIsRGBA();
   probe.SetX(0.0f);
   probe.SetY(0.0f);
@@ -434,7 +473,10 @@ TEST_F(VerifierTest, ProbeFrameBufferFloat32) {
 
 TEST_F(VerifierTest, ProbeFrameBufferFloat64) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetIsRGBA();
   probe.SetX(0.0f);
   probe.SetY(0.0f);
@@ -462,7 +504,10 @@ TEST_F(VerifierTest, ProbeFrameBufferFloat64) {
 
 TEST_F(VerifierTest, HexFloatToFloatR16G11B10) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetX(0.0f);
   probe.SetY(0.0f);
 
@@ -501,7 +546,10 @@ TEST_F(VerifierTest, HexFloatToFloatR16G11B10) {
 
 TEST_F(VerifierTest, HexFloatToFloatR11G16B10) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetX(0.0f);
   probe.SetY(0.0f);
 
@@ -540,7 +588,10 @@ TEST_F(VerifierTest, HexFloatToFloatR11G16B10) {
 
 TEST_F(VerifierTest, HexFloatToFloatR10G11B16) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetX(0.0f);
   probe.SetY(0.0f);
 
@@ -586,7 +637,10 @@ TEST_F(VerifierTest, ProbeFrameBufferNotRect) {
   frame_buffer[2][1][3] = 204;
 
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetIsRGBA();
   probe.SetX(1.0f);
   probe.SetY(2.0f);
@@ -603,7 +657,10 @@ TEST_F(VerifierTest, ProbeFrameBufferNotRect) {
 
 TEST_F(VerifierTest, ProbeFrameBufferRGB) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetWholeWindow();
   probe.SetProbeRect();
   probe.SetB(0.5f);
@@ -636,7 +693,10 @@ TEST_F(VerifierTest, ProbeFrameBufferRGB) {
 
 TEST_F(VerifierTest, ProbeFrameBufferBadRowStride) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetWholeWindow();
   probe.SetProbeRect();
 
@@ -654,6 +714,9 @@ TEST_F(VerifierTest, ProbeFrameBufferBadRowStride) {
 
 TEST_F(VerifierTest, ProbeSSBOUint8Single) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -677,6 +740,9 @@ TEST_F(VerifierTest, ProbeSSBOUint8Single) {
 
 TEST_F(VerifierTest, ProbeSSBOUint8Multiple) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -701,6 +767,9 @@ TEST_F(VerifierTest, ProbeSSBOUint8Multiple) {
 
 TEST_F(VerifierTest, ProbeSSBOUint8Many) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -730,6 +799,9 @@ TEST_F(VerifierTest, ProbeSSBOUint8Many) {
 
 TEST_F(VerifierTest, ProbeSSBOUint32Single) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -753,6 +825,9 @@ TEST_F(VerifierTest, ProbeSSBOUint32Single) {
 
 TEST_F(VerifierTest, ProbeSSBOUint32Multiple) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -778,6 +853,9 @@ TEST_F(VerifierTest, ProbeSSBOUint32Multiple) {
 
 TEST_F(VerifierTest, ProbeSSBOUint32Many) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -807,6 +885,9 @@ TEST_F(VerifierTest, ProbeSSBOUint32Many) {
 
 TEST_F(VerifierTest, ProbeSSBOFloatSingle) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -830,6 +911,9 @@ TEST_F(VerifierTest, ProbeSSBOFloatSingle) {
 
 TEST_F(VerifierTest, ProbeSSBOFloatMultiple) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -855,6 +939,9 @@ TEST_F(VerifierTest, ProbeSSBOFloatMultiple) {
 
 TEST_F(VerifierTest, ProbeSSBOFloatMany) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -884,6 +971,9 @@ TEST_F(VerifierTest, ProbeSSBOFloatMany) {
 
 TEST_F(VerifierTest, ProbeSSBODoubleSingle) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -907,6 +997,9 @@ TEST_F(VerifierTest, ProbeSSBODoubleSingle) {
 
 TEST_F(VerifierTest, ProbeSSBODoubleMultiple) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -932,6 +1025,9 @@ TEST_F(VerifierTest, ProbeSSBODoubleMultiple) {
 
 TEST_F(VerifierTest, ProbeSSBODoubleMany) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -961,6 +1057,9 @@ TEST_F(VerifierTest, ProbeSSBODoubleMany) {
 
 TEST_F(VerifierTest, ProbeSSBOEqualFail) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -988,6 +1087,9 @@ TEST_F(VerifierTest, ProbeSSBOEqualFail) {
 
 TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithAbsoluteTolerance) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -1022,6 +1124,9 @@ TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithAbsoluteTolerance) {
 
 TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithAbsoluteToleranceFail) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -1053,6 +1158,9 @@ TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithAbsoluteToleranceFail) {
 
 TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithRelativeTolerance) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -1087,6 +1195,9 @@ TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithRelativeTolerance) {
 
 TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithRelativeToleranceFail) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -1118,6 +1229,9 @@ TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithRelativeToleranceFail) {
 
 TEST_F(VerifierTest, ProbeSSBONotEqual) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -1143,6 +1257,9 @@ TEST_F(VerifierTest, ProbeSSBONotEqual) {
 
 TEST_F(VerifierTest, ProbeSSBONotEqualFail) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -1170,6 +1287,9 @@ TEST_F(VerifierTest, ProbeSSBONotEqualFail) {
 
 TEST_F(VerifierTest, ProbeSSBOLess) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -1195,6 +1315,9 @@ TEST_F(VerifierTest, ProbeSSBOLess) {
 
 TEST_F(VerifierTest, ProbeSSBOLessFail) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -1222,6 +1345,9 @@ TEST_F(VerifierTest, ProbeSSBOLessFail) {
 
 TEST_F(VerifierTest, ProbeSSBOLessOrEqual) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -1247,6 +1373,9 @@ TEST_F(VerifierTest, ProbeSSBOLessOrEqual) {
 
 TEST_F(VerifierTest, ProbeSSBOLessOrEqualFail) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -1274,6 +1403,9 @@ TEST_F(VerifierTest, ProbeSSBOLessOrEqualFail) {
 
 TEST_F(VerifierTest, ProbeSSBOGreater) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -1299,6 +1431,9 @@ TEST_F(VerifierTest, ProbeSSBOGreater) {
 
 TEST_F(VerifierTest, ProbeSSBOGreaterFail) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -1326,6 +1461,9 @@ TEST_F(VerifierTest, ProbeSSBOGreaterFail) {
 
 TEST_F(VerifierTest, ProbeSSBOGreaterOrEqual) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -1351,6 +1489,9 @@ TEST_F(VerifierTest, ProbeSSBOGreaterOrEqual) {
 
 TEST_F(VerifierTest, ProbeSSBOGreaterOrEqualFail) {
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   ProbeSSBOCommand probe_ssbo(&pipeline);
 
   DatumType datum_type;
@@ -1378,7 +1519,10 @@ TEST_F(VerifierTest, ProbeSSBOGreaterOrEqualFail) {
 
 TEST_F(VerifierTest, CheckRGBAOrderForFailure) {
   Pipeline pipeline(PipelineType::kGraphics);
-  ProbeCommand probe(&pipeline);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
+  ProbeCommand probe(&pipeline, color_buf.get());
   probe.SetIsRGBA();
   probe.SetX(0.0f);
   probe.SetY(0.0f);

--- a/src/vkscript/command_parser.cc
+++ b/src/vkscript/command_parser.cc
@@ -834,7 +834,16 @@ Result CommandParser::ProcessProbe(bool relative) {
   if (token->AsString() == "ssbo")
     return ProcessProbeSSBO();
 
-  auto cmd = MakeUnique<ProbeCommand>(pipeline_);
+  if (pipeline_->GetColorAttachments().empty())
+    return Result("Pipeline missing color buffers. Something went wrong.");
+
+  // VkScript has a single generated colour buffer which should always be
+  // available.
+  auto* buffer = pipeline_->GetColorAttachments()[0].buffer;
+  if (!buffer)
+    return Result("Pipeline missing color buffers, something went wrong.");
+
+  auto cmd = MakeUnique<ProbeCommand>(pipeline_, buffer);
   cmd->SetLine(tokenizer_->GetCurrentLine());
 
   cmd->SetTolerances(current_tolerances_);

--- a/src/vkscript/command_parser_test.cc
+++ b/src/vkscript/command_parser_test.cc
@@ -789,6 +789,9 @@ TEST_P(CommandParserProbeTest, ProbeRgb) {
                      "probe rgb 25 30 0.2 0.4 0.6";
 
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   CommandParser cp(&pipeline, 1, data);
   Result r = cp.Parse();
   ASSERT_TRUE(r.IsSuccess()) << data << std::endl << r.Error();
@@ -820,6 +823,9 @@ TEST_P(CommandParserProbeTest, ProbeRgba) {
                      "probe rgba 25 30 1 255 9 4";
 
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   CommandParser cp(&pipeline, 1, data);
   Result r = cp.Parse();
   ASSERT_TRUE(r.IsSuccess()) << data << std::endl << r.Error();
@@ -852,6 +858,9 @@ TEST_P(CommandParserProbeTest, ProbeRect) {
                      "probe rect rgba 25 30 200 400 1 255 9 4";
 
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   CommandParser cp(&pipeline, 1, data);
   Result r = cp.Parse();
   ASSERT_TRUE(r.IsSuccess()) << data << std::endl << r.Error();
@@ -884,6 +893,9 @@ TEST_P(CommandParserProbeTest, ProbeNotRect) {
                      "probe rgba 25 30 1 255 9 4";
 
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   CommandParser cp(&pipeline, 1, data);
   Result r = cp.Parse();
   ASSERT_TRUE(r.IsSuccess()) << data << std::endl << r.Error();
@@ -918,6 +930,9 @@ TEST_F(CommandParserTest, ProbeAllRGB) {
   std::string data = "probe all rgb 0.2 0.3 0.4";
 
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   CommandParser cp(&pipeline, 1, data);
   Result r = cp.Parse();
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
@@ -941,6 +956,9 @@ TEST_F(CommandParserTest, ProbeAllRGBA) {
   std::string data = "probe all rgba 0.2 0.3 0.4 0.5";
 
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   CommandParser cp(&pipeline, 1, data);
   Result r = cp.Parse();
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
@@ -965,6 +983,9 @@ TEST_F(CommandParserTest, ProbeCommandRectBrackets) {
   std::string data = "relative probe rect rgb (0.5, 0.6, 0.3, 0.4) 1 2 3";
 
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   CommandParser cp(&pipeline, 1, data);
   Result r = cp.Parse();
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
@@ -993,6 +1014,9 @@ TEST_F(CommandParserTest, ProbeCommandNotRectBrackets) {
   std::string data = "relative probe rgb (0.5, 0.6) 1 2 3";
 
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   CommandParser cp(&pipeline, 1, data);
   Result r = cp.Parse();
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
@@ -1021,6 +1045,9 @@ TEST_F(CommandParserTest, ProbeCommandColorBrackets) {
   std::string data = "relative probe rect rgb 0.5 0.6 0.3 0.4 (1, 2, 3)";
 
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   CommandParser cp(&pipeline, 1, data);
   Result r = cp.Parse();
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
@@ -1049,6 +1076,9 @@ TEST_F(CommandParserTest, ProbeCommandColorOptionalCommas) {
   std::string data = "relative probe rect rgb 0.5, 0.6, 0.3 0.4 1 2 3";
 
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   CommandParser cp(&pipeline, 1, data);
   Result r = cp.Parse();
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
@@ -1179,6 +1209,9 @@ TEST_F(CommandParserTest, ProbeErrors) {
 
   for (const auto& probe : probes) {
     Pipeline pipeline(PipelineType::kGraphics);
+    auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+    pipeline.AddColorAttachment(color_buf.get(), 0);
+
     CommandParser cp(&pipeline, 1, probe.str);
     Result r = cp.Parse();
     EXPECT_FALSE(r.IsSuccess()) << probe.str;
@@ -1200,6 +1233,9 @@ TEST_F(CommandParserTest, ProbeWithInvalidRGBA) {
   std::string data = "probe 1";
 
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   CommandParser cp(&pipeline, 1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
@@ -1210,6 +1246,9 @@ TEST_F(CommandParserTest, ProbeWithRectAndInvalidRGB) {
   std::string data = "probe rect 1";
 
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   CommandParser cp(&pipeline, 1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
@@ -1220,6 +1259,9 @@ TEST_F(CommandParserTest, ProbeWithRectMissingFormat) {
   std::string data = "probe rect unknown";
 
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   CommandParser cp(&pipeline, 1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
@@ -1230,6 +1272,9 @@ TEST_F(CommandParserTest, ProbeAllMissingFormat) {
   std::string data = "probe all unknown";
 
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   CommandParser cp(&pipeline, 1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
@@ -1240,6 +1285,9 @@ TEST_F(CommandParserTest, ProbeAlWithInvalidRGB) {
   std::string data = "probe all unknown";
 
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   CommandParser cp(&pipeline, 1, data);
   Result r = cp.Parse();
   ASSERT_FALSE(r.IsSuccess());
@@ -3593,6 +3641,9 @@ tolerance 2% 3% 4% 5%
 probe all rgba 0.2 0.3 0.4 0.5)";
 
   Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+  pipeline.AddColorAttachment(color_buf.get(), 0);
+
   CommandParser cp(&pipeline, 1, data);
   Result r = cp.Parse();
   ASSERT_TRUE(r.IsSuccess()) << r.Error();

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -411,7 +411,7 @@ Result EngineVulkan::DoProcessCommands(amber::Pipeline* pipeline) {
 }
 
 Result EngineVulkan::GetFrameBufferInfo(amber::Pipeline* pipeline,
-                                        size_t attachment_idx,
+                                        amber::Buffer* buffer,
                                         ResourceInfo* resource_info) {
   if (!resource_info)
     return Result("Vulkan::GetFrameBufferInfo missing resource info");
@@ -421,6 +421,11 @@ Result EngineVulkan::GetFrameBufferInfo(amber::Pipeline* pipeline,
     return Result("Vulkan::GetFrameBufferInfo missing pipeline");
   if (!info.vk_pipeline->IsGraphics())
     return Result("Vulkan::GetFrameBufferInfo for Non-Graphics Pipeline");
+
+  uint32_t attachment_idx = 0;
+  Result r = pipeline->GetLocationForColorAttachment(buffer, &attachment_idx);
+  if (!r.IsSuccess())
+    return r;
 
   const auto graphics = info.vk_pipeline->AsGraphics();
   const auto frame = graphics->GetFrame();
@@ -444,16 +449,21 @@ Result EngineVulkan::GetFrameBufferInfo(amber::Pipeline* pipeline,
 }
 
 Result EngineVulkan::GetFrameBuffer(amber::Pipeline* pipeline,
-                                    size_t attachment_idx,
+                                    amber::Buffer* buffer,
                                     std::vector<Value>* values) {
   values->resize(0);
 
   ResourceInfo resource_info;
-  GetFrameBufferInfo(pipeline, attachment_idx, &resource_info);
+  GetFrameBufferInfo(pipeline, buffer, &resource_info);
   if (resource_info.type != ResourceInfoType::kImage) {
     return Result(
         "Vulkan:GetFrameBuffer() is invalid for non-image framebuffer");
   }
+
+  uint32_t attachment_idx = 0;
+  Result r = pipeline->GetLocationForColorAttachment(buffer, &attachment_idx);
+  if (!r.IsSuccess())
+    return r;
 
   auto& info = pipeline_map_[pipeline];
   const auto frame = info.vk_pipeline->AsGraphics()->GetFrame();

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -60,10 +60,10 @@ class EngineVulkan : public Engine {
   Result DoBuffer(const BufferCommand* cmd) override;
   Result DoProcessCommands(amber::Pipeline* pipeline) override;
   Result GetFrameBufferInfo(amber::Pipeline* pipeline,
-                            size_t attachment_idx,
+                            amber::Buffer* buffer,
                             ResourceInfo* info) override;
   Result GetFrameBuffer(amber::Pipeline* pipeline,
-                        size_t attachment_idx,
+                        amber::Buffer* buffer,
                         std::vector<Value>* values) override;
   Result GetDescriptorInfo(amber::Pipeline* pipeline,
                            const uint32_t descriptor_set,


### PR DESCRIPTION
This CL extends the ProbeCommand to contain the buffer to probe against.
With VkScript there is a generated image buffer which is used. For
AmberScript the buffer is provided in the EXPECT command.