### PR TITLE
[vulkan] Set correct colour attachment locations.

### DIFF
--- a/src/vulkan/frame_buffer.cc
+++ b/src/vulkan/frame_buffer.cc
@@ -51,7 +51,7 @@ Result FrameBuffer::Initialize(
       if (info->location >= color_attachments_.size())
         return Result("color attachment locations must be sequential from 0");
       if (seen_idx[info->location] != -1) {
-        return Result("can not use duplicate attachment location: " +
+        return Result("duplicate attachment location: " +
                       std::to_string(info->location));
       }
       seen_idx[info->location] = static_cast<int32_t>(info->location);

--- a/src/vulkan/frame_buffer.cc
+++ b/src/vulkan/frame_buffer.cc
@@ -54,7 +54,7 @@ Result FrameBuffer::Initialize(
         return Result("can not use duplicate attachment location: " +
                       std::to_string(info->location));
       }
-      seen_idx[info->location] = info->location;
+      seen_idx[info->location] = static_cast<int32_t>(info->location);
     }
 
     attachments.resize(color_attachments_.size());

--- a/src/vulkan/frame_buffer.cc
+++ b/src/vulkan/frame_buffer.cc
@@ -52,7 +52,7 @@ Result FrameBuffer::Initialize(
         return Result("color attachment locations must be sequential from 0");
       if (seen_idx[info->location] != -1) {
         return Result("can not use duplicate attachment location: " +
-                      info->location);
+                      std::to_string(info->location));
       }
       seen_idx[info->location] = info->location;
     }

--- a/src/vulkan/frame_buffer.cc
+++ b/src/vulkan/frame_buffer.cc
@@ -58,14 +58,15 @@ Result FrameBuffer::Initialize(
     for (auto* info : color_attachments_) {
       color_images_.push_back(MakeUnique<Image>(
           device_,
-          ToVkFormat(info->buffer->AsFormatBuffer()->GetFormat().GetFormatType()),
+          ToVkFormat(
+              info->buffer->AsFormatBuffer()->GetFormat().GetFormatType()),
           VK_IMAGE_ASPECT_COLOR_BIT, width_, height_, depth_, properties));
 
-      Result r = color_images_.back()->Initialize(
-          VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+      Result r =
+          color_images_.back()->Initialize(VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                                           VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
       if (!r.IsSuccess())
         return r;
-
 
       attachments[info->location] = color_images_.back()->GetVkImageView();
     }


### PR DESCRIPTION
This CL fixes the colour attachment code to set the colour attachment
into the requested location, not the order they were attached. This
allows setting the locations out of order.

Note, the locations must be a complete set of numbers starting from 0.