### PR TITLE
Correctly store BufferType in buffer.

### DIFF
--- a/src/amberscript/parser_test.cc
+++ b/src/amberscript/parser_test.cc
@@ -2620,7 +2620,7 @@ END
   const auto* pipeline = pipelines[0].get();
   const auto& bufs = pipeline->GetBuffers();
   ASSERT_EQ(1U, bufs.size());
-  EXPECT_EQ(BufferType::kUniform, bufs[0].type);
+  EXPECT_EQ(BufferType::kUniform, bufs[0].buffer->GetBufferType());
   EXPECT_EQ(1U, bufs[0].descriptor_set);
   EXPECT_EQ(2U, bufs[0].binding);
   EXPECT_EQ(static_cast<uint32_t>(0), bufs[0].location);
@@ -2654,7 +2654,7 @@ END)";
   const auto* pipeline = pipelines[0].get();
   const auto& bufs = pipeline->GetBuffers();
   ASSERT_EQ(1U, bufs.size());
-  EXPECT_EQ(BufferType::kUniform, bufs[0].type);
+  EXPECT_EQ(BufferType::kUniform, bufs[0].buffer->GetBufferType());
   EXPECT_EQ(1U, bufs[0].descriptor_set);
   EXPECT_EQ(2U, bufs[0].binding);
   EXPECT_EQ(5U, bufs[0].location);
@@ -2924,7 +2924,7 @@ PIPELINE graphics my_pipeline
   const auto* pipeline = pipelines[0].get();
   const auto& bufs = pipeline->GetBuffers();
   ASSERT_EQ(1U, bufs.size());
-  EXPECT_EQ(test_data.type, bufs[0].type);
+  EXPECT_EQ(test_data.type, bufs[0].buffer->GetBufferType());
 }
 INSTANTIATE_TEST_CASE_P(
     AmberScriptParserBufferTypeTest,

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -51,6 +51,7 @@ class Buffer {
 
   /// Returns the BufferType of this buffer.
   BufferType GetBufferType() const { return buffer_type_; }
+  void SetBufferType(BufferType type) { buffer_type_ = type; }
 
   /// Set the location binding value for the buffer.
   void SetLocation(uint8_t loc) { location_ = loc; }
@@ -83,7 +84,7 @@ class Buffer {
   explicit Buffer(BufferType type);
 
  private:
-  BufferType buffer_type_;
+  BufferType buffer_type_ = BufferType::kUnknown;
   std::vector<Value> data_;
   std::string name_;
   size_t size_ = 0;

--- a/src/buffer_data.h
+++ b/src/buffer_data.h
@@ -18,7 +18,9 @@
 namespace amber {
 
 /// Types of buffers which can be created.
-enum class BufferType : uint8_t {
+enum class BufferType : int8_t {
+  /// Unknown buffer type
+  kUnknown = -1,
   /// A color buffer.
   kColor = 0,
   /// A depth/stencil buffer.

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -218,8 +218,9 @@ Result Pipeline::AddColorAttachment(Buffer* buf, uint32_t location) {
 Result Pipeline::SetDepthBuffer(Buffer* buf) {
   if (depth_buffer_.buffer != nullptr)
     return Result("can only bind one depth buffer in a PIPELINE");
+  if (buf->GetBufferType() != BufferType::kDepth)
+    return Result("expected a depth buffer");
 
-  depth_buffer_.type = BufferType::kDepth;
   depth_buffer_.buffer = buf;
   depth_buffer_.width = fb_width_;
   depth_buffer_.height = fb_height_;
@@ -244,10 +245,11 @@ Result Pipeline::AddVertexBuffer(Buffer* buf, uint32_t location) {
     if (vtex.buffer == buf)
       return Result("vertex buffer may only be bound to a PIPELINE once");
   }
+  if (buf->GetBufferType() != BufferType::kVertex)
+    return Result("expected a vertex buffer");
 
   vertex_buffers_.push_back(BufferInfo{buf});
   vertex_buffers_.back().location = location;
-  vertex_buffers_.back().type = BufferType::kVertex;
   return {};
 }
 

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -67,7 +67,6 @@ class Pipeline {
     explicit BufferInfo(Buffer* buf) : buffer(buf) {}
 
     Buffer* buffer = nullptr;
-    BufferType type = BufferType::kColor;
     uint32_t descriptor_set = 0;
     uint32_t binding = 0;
     uint32_t location = 0;
@@ -128,7 +127,6 @@ class Pipeline {
   Buffer* GetIndexBuffer() const { return index_buffer_; }
 
   void AddBuffer(Buffer* buf,
-                 BufferType type,
                  uint32_t descriptor_set,
                  uint32_t binding,
                  uint32_t location) {
@@ -138,7 +136,6 @@ class Pipeline {
     info.descriptor_set = descriptor_set;
     info.binding = binding;
     info.location = location;
-    info.type = type;
   }
   const std::vector<BufferInfo>& GetBuffers() const { return buffers_; }
 

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -168,7 +168,7 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
 
   for (const auto& colour_info : pipeline->GetColorAttachments()) {
     auto& fmt = colour_info.buffer->AsFormatBuffer()->GetFormat();
-    if (!VerifyFormatAvailable(fmt, colour_info.type))
+    if (!VerifyFormatAvailable(fmt, colour_info.buffer->GetBufferType()))
       return Result("Vulkan color attachment format is not supported");
   }
 
@@ -176,7 +176,7 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
   if (pipeline->GetDepthBuffer().buffer) {
     const auto& depth_info = pipeline->GetDepthBuffer();
     auto& depth_fmt = depth_info.buffer->AsFormatBuffer()->GetFormat();
-    if (!VerifyFormatAvailable(depth_fmt, depth_info.type))
+    if (!VerifyFormatAvailable(depth_fmt, depth_info.buffer->GetBufferType()))
       return Result("Vulkan depth attachment format is not supported");
 
     depth_buffer_format = depth_fmt.GetFormatType();
@@ -213,7 +213,7 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
     auto& fmt = vtex_info.buffer->IsFormatBuffer()
                     ? vtex_info.buffer->AsFormatBuffer()->GetFormat()
                     : Format();
-    if (!VerifyFormatAvailable(fmt, vtex_info.type))
+    if (!VerifyFormatAvailable(fmt, vtex_info.buffer->GetBufferType()))
       return Result("Vulkan vertex buffer format is not supported");
 
     if (!info.vertex_buffer)


### PR DESCRIPTION
Previously the buffer type existed in both the Buffer and
Pipeline::BufferInfo. These buffer types could diverge, which could
cause issues with thinking the buffer is of an incorrect type.

This CL removes the buffer type from BufferInfo and always uses the
buffer to retrieve the type.