### PR TITLE
Rename vulkan/image to vulkan/transfer_image

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -58,12 +58,12 @@ LOCAL_SRC_FILES:= \
     src/vulkan/format_data.cc \
     src/vulkan/frame_buffer.cc \
     src/vulkan/graphics_pipeline.cc \
-    src/vulkan/image.cc \
     src/vulkan/index_buffer.cc \
     src/vulkan/pipeline.cc \
     src/vulkan/push_constant.cc \
     src/vulkan/resource.cc \
     src/vulkan/transfer_buffer.cc \
+    src/vulkan/transfer_image.cc \
     src/vulkan/vertex_buffer.cc
 LOCAL_STATIC_LIBRARIES:=glslang SPIRV-Tools shaderc
 LOCAL_C_INCLUDES:=$(LOCAL_PATH)/include

--- a/src/vulkan/CMakeLists.txt
+++ b/src/vulkan/CMakeLists.txt
@@ -24,11 +24,11 @@ set(VULKAN_ENGINE_SOURCES
     frame_buffer.cc
     graphics_pipeline.cc
     index_buffer.cc
-    image.cc
     pipeline.cc
     push_constant.cc
     resource.cc
     transfer_buffer.cc
+    transfer_image.cc
     vertex_buffer.cc
     ${CMAKE_BINARY_DIR}/src/vk-wrappers.inc.fake
 )

--- a/src/vulkan/frame_buffer.cc
+++ b/src/vulkan/frame_buffer.cc
@@ -59,7 +59,7 @@ Result FrameBuffer::Initialize(
 
     attachments.resize(color_attachments_.size());
     for (auto* info : color_attachments_) {
-      color_images_.push_back(MakeUnique<Image>(
+      color_images_.push_back(MakeUnique<TransferImage>(
           device_,
           ToVkFormat(
               info->buffer->AsFormatBuffer()->GetFormat().GetFormatType()),
@@ -77,7 +77,7 @@ Result FrameBuffer::Initialize(
   }
 
   if (depth_format != VK_FORMAT_UNDEFINED) {
-    depth_image_ = MakeUnique<Image>(
+    depth_image_ = MakeUnique<TransferImage>(
         device_, depth_format,
         static_cast<VkImageAspectFlags>(
             VkFormatHasStencilComponent(depth_format)

--- a/src/vulkan/frame_buffer.h
+++ b/src/vulkan/frame_buffer.h
@@ -19,7 +19,7 @@
 #include <vector>
 
 #include "src/pipeline.h"
-#include "src/vulkan/image.h"
+#include "src/vulkan/transfer_image.h"
 
 namespace amber {
 namespace vulkan {
@@ -66,8 +66,8 @@ class FrameBuffer {
   Device* device_ = nullptr;
   std::vector<const amber::Pipeline::BufferInfo*> color_attachments_;
   VkFramebuffer frame_ = VK_NULL_HANDLE;
-  std::vector<std::unique_ptr<Image>> color_images_;
-  std::unique_ptr<Image> depth_image_;
+  std::vector<std::unique_ptr<TransferImage>> color_images_;
+  std::unique_ptr<TransferImage> depth_image_;
   uint32_t width_ = 0;
   uint32_t height_ = 0;
   uint32_t depth_ = 1;

--- a/src/vulkan/transfer_image.h
+++ b/src/vulkan/transfer_image.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SRC_VULKAN_IMAGE_H_
-#define SRC_VULKAN_IMAGE_H_
+#ifndef SRC_VULKAN_TRANSFER_IMAGE_H_
+#define SRC_VULKAN_TRANSFER_IMAGE_H_
 
 #include "amber/result.h"
 #include "amber/vulkan_header.h"
@@ -25,16 +25,16 @@ namespace vulkan {
 class CommandBuffer;
 class Device;
 
-class Image : public Resource {
+class TransferImage : public Resource {
  public:
-  Image(Device* device,
-        VkFormat format,
-        VkImageAspectFlags aspect,
-        uint32_t x,
-        uint32_t y,
-        uint32_t z,
-        const VkPhysicalDeviceMemoryProperties& properties);
-  ~Image() override;
+  TransferImage(Device* device,
+                VkFormat format,
+                VkImageAspectFlags aspect,
+                uint32_t x,
+                uint32_t y,
+                uint32_t z,
+                const VkPhysicalDeviceMemoryProperties& properties);
+  ~TransferImage() override;
 
   Result Initialize(VkImageUsageFlags usage);
   VkImage GetVkImage() const { return image_; }
@@ -75,4 +75,4 @@ class Image : public Resource {
 }  // namespace vulkan
 }  // namespace amber
 
-#endif  // SRC_VULKAN_IMAGE_H_
+#endif  // SRC_VULKAN_TRANSFER_IMAGE_H_


### PR DESCRIPTION
Similar to the vulkan/transfer_buffer class the transfer_image class is
responsible for transfering data to/from the GPU for images. This CL
renames Image to TransferImage to make that clearer.