### PR TITLE
Simplify vulkan/resource classes.

### DIFF
--- a/src/vulkan/push_constant.cc
+++ b/src/vulkan/push_constant.cc
@@ -117,5 +117,21 @@ Result PushConstant::AddBufferData(const BufferCommand* command) {
   return {};
 }
 
+Result PushConstant::UpdateMemoryWithInput(const BufferInput& input) {
+  if (static_cast<size_t>(input.offset) >= GetSizeInBytes()) {
+    return Result(
+        "Vulkan: UpdateMemoryWithInput BufferInput offset exceeds memory size");
+  }
+
+  if (input.size_in_bytes > (GetSizeInBytes() - input.offset)) {
+    return Result(
+        "Vulkan: UpdateMemoryWithInput BufferInput offset + size_in_bytes "
+        " exceeds memory size");
+  }
+
+  input.UpdateBufferWithValues(HostAccessibleMemoryPtr());
+  return {};
+}
+
 }  // namespace vulkan
 }  // namespace amber

--- a/src/vulkan/push_constant.h
+++ b/src/vulkan/push_constant.h
@@ -59,13 +59,16 @@ class PushConstant : public Resource {
   Result AddBufferData(const BufferCommand* command);
 
   // Resource
-  VkDeviceMemory GetHostAccessMemory() const override { return VK_NULL_HANDLE; }
   Result CopyToHost(CommandBuffer*) override {
     return Result("Vulkan: should not call CopyToHost() for PushConstant");
   }
   void Shutdown() override {}
 
  private:
+  // Fill memory from |offset| of |data| to |offset| + |size_in_bytes|
+  // of |data| with |values| of |data|.
+  Result UpdateMemoryWithInput(const BufferInput& input);
+
   // maxPushConstantsSize of VkPhysicalDeviceLimits, which is an
   // element of VkPhysicalDeviceProperties getting from
   // vkGetPhysicalDeviceProperties().

--- a/src/vulkan/resource.h
+++ b/src/vulkan/resource.h
@@ -47,22 +47,10 @@ class Resource {
  public:
   virtual ~Resource();
 
-  virtual VkDeviceMemory GetHostAccessMemory() const {
-    return host_accessible_memory_;
-  }
-
   virtual Result CopyToHost(CommandBuffer* command) = 0;
+  virtual void Shutdown() = 0;
 
-  virtual void Shutdown();
-
-  // Fill |memory_ptr_| from |offset| of |data| to |offset| + |size_in_bytes|
-  // of |data| with |values| of |data|.
-  Result UpdateMemoryWithInput(const BufferInput& input);
-
-  // Fill |memory_ptr_| from 0 to |raw_data.size()| with |raw_data|.
-  void UpdateMemoryWithRawData(const std::vector<uint8_t>& raw_data);
-
-  virtual void* HostAccessibleMemoryPtr() const { return memory_ptr_; }
+  void* HostAccessibleMemoryPtr() const { return memory_ptr_; }
 
   uint32_t GetSizeInBytes() const { return size_in_bytes_; }
 
@@ -70,10 +58,7 @@ class Resource {
   Resource(Device* device,
            uint32_t size,
            const VkPhysicalDeviceMemoryProperties& properties);
-  Result Initialize();
   Result CreateVkBuffer(VkBuffer* buffer, VkBufferUsageFlags usage);
-
-  VkBuffer GetHostAccessibleBuffer() const { return host_accessible_buffer_; }
 
   Result AllocateAndBindMemoryToVkBuffer(VkBuffer buffer,
                                          VkDeviceMemory* memory,
@@ -113,8 +98,6 @@ class Resource {
   uint32_t size_in_bytes_ = 0;
   VkPhysicalDeviceMemoryProperties physical_memory_properties_;
 
-  VkBuffer host_accessible_buffer_ = VK_NULL_HANDLE;
-  VkDeviceMemory host_accessible_memory_ = VK_NULL_HANDLE;
   void* memory_ptr_ = nullptr;
 };
 

--- a/src/vulkan/transfer_buffer.cc
+++ b/src/vulkan/transfer_buffer.cc
@@ -14,6 +14,8 @@
 
 #include "src/vulkan/transfer_buffer.h"
 
+#include <cstring>
+
 #include "src/vulkan/command_buffer.h"
 #include "src/vulkan/device.h"
 
@@ -111,8 +113,13 @@ void TransferBuffer::Shutdown() {
 
   if (buffer_ != VK_NULL_HANDLE)
     device_->GetPtrs()->vkDestroyBuffer(device_->GetDevice(), buffer_, nullptr);
+}
 
-  Resource::Shutdown();
+void TransferBuffer::UpdateMemoryWithRawData(
+    const std::vector<uint8_t>& raw_data) {
+  size_t effective_size =
+      raw_data.size() > GetSizeInBytes() ? GetSizeInBytes() : raw_data.size();
+  std::memcpy(HostAccessibleMemoryPtr(), raw_data.data(), effective_size);
 }
 
 }  // namespace vulkan

--- a/src/vulkan/transfer_buffer.h
+++ b/src/vulkan/transfer_buffer.h
@@ -15,6 +15,8 @@
 #ifndef SRC_VULKAN_TRANSFER_BUFFER_H_
 #define SRC_VULKAN_TRANSFER_BUFFER_H_
 
+#include <vector>
+
 #include "amber/result.h"
 #include "amber/vulkan_header.h"
 #include "src/vulkan/resource.h"
@@ -51,8 +53,8 @@ class TransferBuffer : public Resource {
   // make it available to device domain.
   virtual Result CopyToDevice(CommandBuffer* command);
 
-  // Resource
-  VkDeviceMemory GetHostAccessMemory() const override { return memory_; }
+  // Fill memory from 0 to |raw_data.size()| with |raw_data|.
+  void UpdateMemoryWithRawData(const std::vector<uint8_t>& raw_data);
 
   // Since |buffer_| is mapped to host accessible and host coherent
   // memory |memory_|, this method only conducts memory barrier to

--- a/src/vulkan/transfer_image.h
+++ b/src/vulkan/transfer_image.h
@@ -64,6 +64,9 @@ class TransferImage : public Resource {
                                         uint32_t* memory_type_index);
   const VkMemoryRequirements GetVkImageMemoryRequirements(VkImage image) const;
 
+  VkBuffer host_accessible_buffer_ = VK_NULL_HANDLE;
+  VkDeviceMemory host_accessible_memory_ = VK_NULL_HANDLE;
+
   VkImageCreateInfo image_info_;
   VkImageAspectFlags aspect_;
 

--- a/src/vulkan/vertex_buffer_test.cc
+++ b/src/vulkan/vertex_buffer_test.cc
@@ -36,17 +36,14 @@ class BufferForTest : public TransferBuffer {
                 const VkPhysicalDeviceMemoryProperties& properties)
       : TransferBuffer(device, size_in_bytes, properties) {
     memory_.resize(4096);
-    memory_ptr_ = memory_.data();
+    SetMemoryPtr(memory_.data());
   }
   ~BufferForTest() override = default;
-
-  void* HostAccessibleMemoryPtr() const override { return memory_ptr_; }
 
   Result CopyToDevice(CommandBuffer*) override { return Result(); }
 
  private:
   std::vector<uint8_t> memory_;
-  void* memory_ptr_ = nullptr;
 };
 
 class VertexBufferTest : public testing::Test {


### PR DESCRIPTION
This CL moves code from the Resource class to the single subclass which
uses that code. This simplifies the resource class and makes it clearer
where memory is used.