### PR TITLE
[vulkan] Unhook push_constant from resource.

### DIFF
--- a/src/vulkan/push_constant.cc
+++ b/src/vulkan/push_constant.cc
@@ -25,12 +25,8 @@ namespace amber {
 namespace vulkan {
 
 PushConstant::PushConstant(Device* device, uint32_t max_push_constant_size)
-    : Resource(device,
-               max_push_constant_size,
-               VkPhysicalDeviceMemoryProperties()),
-      max_push_constant_size_(max_push_constant_size) {
+    : device_(device), max_push_constant_size_(max_push_constant_size) {
   memory_.resize(max_push_constant_size_);
-  SetMemoryPtr(static_cast<void*>(memory_.data()));
 }
 
 PushConstant::~PushConstant() = default;
@@ -118,18 +114,18 @@ Result PushConstant::AddBufferData(const BufferCommand* command) {
 }
 
 Result PushConstant::UpdateMemoryWithInput(const BufferInput& input) {
-  if (static_cast<size_t>(input.offset) >= GetSizeInBytes()) {
+  if (static_cast<size_t>(input.offset) >= max_push_constant_size_) {
     return Result(
         "Vulkan: UpdateMemoryWithInput BufferInput offset exceeds memory size");
   }
 
-  if (input.size_in_bytes > (GetSizeInBytes() - input.offset)) {
+  if (input.size_in_bytes > (max_push_constant_size_ - input.offset)) {
     return Result(
         "Vulkan: UpdateMemoryWithInput BufferInput offset + size_in_bytes "
         " exceeds memory size");
   }
 
-  input.UpdateBufferWithValues(HostAccessibleMemoryPtr());
+  input.UpdateBufferWithValues(memory_.data());
   return {};
 }
 

--- a/src/vulkan/push_constant.h
+++ b/src/vulkan/push_constant.h
@@ -30,14 +30,14 @@ class CommandBuffer;
 class Device;
 
 // Class to handle push constant.
-class PushConstant : public Resource {
+class PushConstant {
  public:
   // |max_push_constant_size| must be the same value with
   // maxPushConstantsSize of VkPhysicalDeviceLimits, which is an
   // element of VkPhysicalDeviceProperties getting from
   // vkGetPhysicalDeviceProperties().
   PushConstant(Device* device, uint32_t max_push_constant_size);
-  ~PushConstant() override;
+  ~PushConstant();
 
   // Return a VkPushConstantRange structure whose shader stage flag
   // is VK_SHADER_STAGE_ALL, offset is minimum |offset| among elements
@@ -58,16 +58,12 @@ class PushConstant : public Resource {
   // to be used on the next pipeline execution.
   Result AddBufferData(const BufferCommand* command);
 
-  // Resource
-  Result CopyToHost(CommandBuffer*) override {
-    return Result("Vulkan: should not call CopyToHost() for PushConstant");
-  }
-  void Shutdown() override {}
-
  private:
   // Fill memory from |offset| of |data| to |offset| + |size_in_bytes|
   // of |data| with |values| of |data|.
   Result UpdateMemoryWithInput(const BufferInput& input);
+
+  Device* device_;
 
   // maxPushConstantsSize of VkPhysicalDeviceLimits, which is an
   // element of VkPhysicalDeviceProperties getting from


### PR DESCRIPTION
This CL removes the parent class from PushConstant. There was nothing in
Resource which the PushConstant code used other than storing a few
variables.