### PR TITLE
Remove unused descriptor code

### DIFF
--- a/src/vulkan/buffer_descriptor.h
+++ b/src/vulkan/buffer_descriptor.h
@@ -60,15 +60,13 @@ class BufferDescriptor : public Descriptor {
 
  private:
   VkBufferUsageFlagBits GetVkBufferUsage() const {
-    return IsStorageBuffer()
-               ? VK_BUFFER_USAGE_STORAGE_BUFFER_BIT
-               : VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+    return IsStorageBuffer() ? VK_BUFFER_USAGE_STORAGE_BUFFER_BIT
+                             : VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
   }
 
   VkDescriptorType GetVkDescriptorType() const {
-    return IsStorageBuffer()
-               ? VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
-               : VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    return IsStorageBuffer() ? VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
+                             : VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
   }
 
   Buffer* amber_buffer_ = nullptr;

--- a/src/vulkan/buffer_descriptor.h
+++ b/src/vulkan/buffer_descriptor.h
@@ -33,8 +33,8 @@ namespace vulkan {
 class CommandBuffer;
 class Device;
 
-// Among Vulkan descriptor types, this class handles Storage Buffer
-// a.k.a. SSBO and Uniform Buffer a.k.a. UBO.
+// Among Vulkan descriptor types, this class handles Storage Buffers
+// and Uniform Buffers.
 class BufferDescriptor : public Descriptor {
  public:
   BufferDescriptor(Buffer* buffer,
@@ -60,13 +60,13 @@ class BufferDescriptor : public Descriptor {
 
  private:
   VkBufferUsageFlagBits GetVkBufferUsage() const {
-    return GetType() == DescriptorType::kStorageBuffer
+    return IsStorageBuffer()
                ? VK_BUFFER_USAGE_STORAGE_BUFFER_BIT
                : VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
   }
 
   VkDescriptorType GetVkDescriptorType() const {
-    return GetType() == DescriptorType::kStorageBuffer
+    return IsStorageBuffer()
                ? VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
                : VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
   }

--- a/src/vulkan/descriptor.cc
+++ b/src/vulkan/descriptor.cc
@@ -23,28 +23,10 @@ namespace vulkan {
 
 VkDescriptorType ToVkDescriptorType(DescriptorType type) {
   switch (type) {
-    case DescriptorType::kStorageImage:
-      return VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-    case DescriptorType::kSampler:
-      return VK_DESCRIPTOR_TYPE_SAMPLER;
-    case DescriptorType::kSampledImage:
-      return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-    case DescriptorType::kCombinedImageSampler:
-      return VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    case DescriptorType::kUniformTexelBuffer:
-      return VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
-    case DescriptorType::kStorageTexelBuffer:
-      return VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
     case DescriptorType::kStorageBuffer:
       return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
     case DescriptorType::kUniformBuffer:
       return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    case DescriptorType::kDynamicUniformBuffer:
-      return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
-    case DescriptorType::kDynamicStorageBuffer:
-      return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC;
-    case DescriptorType::kInputAttachment:
-      return VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
   }
 
   assert(false && "Unknown resource type");
@@ -92,50 +74,6 @@ Result Descriptor::UpdateDescriptorSetForBuffer(
       return Result(
           "Vulkan::UpdateDescriptorSetForBuffer not descriptor based on "
           "buffer");
-  }
-
-  UpdateVkDescriptorSet(write);
-  return {};
-}
-
-Result Descriptor::UpdateDescriptorSetForImage(
-    VkDescriptorSet descriptor_set,
-    VkDescriptorType descriptor_type,
-    const VkDescriptorImageInfo& image_info) {
-  VkWriteDescriptorSet write =
-      GetWriteDescriptorSet(descriptor_set, descriptor_type);
-  switch (descriptor_type) {
-    case VK_DESCRIPTOR_TYPE_SAMPLER:
-    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-    case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-    case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-      write.pImageInfo = &image_info;
-      break;
-    default:
-      return Result(
-          "Vulkan::UpdateDescriptorSetForImage not descriptor based on image");
-  }
-
-  UpdateVkDescriptorSet(write);
-  return {};
-}
-
-Result Descriptor::UpdateDescriptorSetForBufferView(
-    VkDescriptorSet descriptor_set,
-    VkDescriptorType descriptor_type,
-    const VkBufferView& texel_view) {
-  VkWriteDescriptorSet write =
-      GetWriteDescriptorSet(descriptor_set, descriptor_type);
-  switch (descriptor_type) {
-    case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-      write.pTexelBufferView = &texel_view;
-      break;
-    default:
-      return Result(
-          "Vulkan::UpdateDescriptorSetForImage not descriptor based on buffer "
-          "view");
   }
 
   UpdateVkDescriptorSet(write);

--- a/src/vulkan/descriptor.h
+++ b/src/vulkan/descriptor.h
@@ -28,17 +28,8 @@ namespace amber {
 namespace vulkan {
 
 enum class DescriptorType : uint8_t {
-  kStorageImage = 0,
-  kSampler,
-  kSampledImage,
-  kCombinedImageSampler,
-  kUniformTexelBuffer,
-  kStorageTexelBuffer,
-  kStorageBuffer,
+  kStorageBuffer = 0,
   kUniformBuffer,
-  kDynamicUniformBuffer,
-  kDynamicStorageBuffer,
-  kInputAttachment,
 };
 
 class CommandBuffer;
@@ -60,29 +51,11 @@ class Descriptor {
 
   DescriptorType GetType() const { return type_; }
 
-  bool IsStorageImage() const { return type_ == DescriptorType::kStorageImage; }
-  bool IsSampler() const { return type_ == DescriptorType::kSampler; }
-  bool IsSampledImage() const { return type_ == DescriptorType::kSampledImage; }
-  bool IsCombinedImageSampler() const {
-    return type_ == DescriptorType::kCombinedImageSampler;
-  }
-  bool IsUniformTexelBuffer() const {
-    return type_ == DescriptorType::kUniformTexelBuffer;
-  }
-  bool IsStorageTexelBuffer() const {
-    return type_ == DescriptorType::kStorageTexelBuffer;
-  }
   bool IsStorageBuffer() const {
     return type_ == DescriptorType::kStorageBuffer;
   }
   bool IsUniformBuffer() const {
     return type_ == DescriptorType::kUniformBuffer;
-  }
-  bool IsDynamicUniformBuffer() const {
-    return type_ == DescriptorType::kDynamicUniformBuffer;
-  }
-  bool IsDynamicStorageBuffer() const {
-    return type_ == DescriptorType::kDynamicStorageBuffer;
   }
 
   // Call vkUpdateDescriptorSets() to update the backing resource
@@ -122,12 +95,6 @@ class Descriptor {
       VkDescriptorSet descriptor_set,
       VkDescriptorType descriptor_type,
       const VkDescriptorBufferInfo& buffer_info);
-  Result UpdateDescriptorSetForImage(VkDescriptorSet descriptor_set,
-                                     VkDescriptorType descriptor_type,
-                                     const VkDescriptorImageInfo& image_info);
-  Result UpdateDescriptorSetForBufferView(VkDescriptorSet descriptor_set,
-                                          VkDescriptorType descriptor_type,
-                                          const VkBufferView& texel_view);
 
   void SetUpdateDescriptorSetNeeded() {
     is_descriptor_set_update_needed_ = true;
@@ -146,7 +113,7 @@ class Descriptor {
       VkDescriptorType descriptor_type) const;
   void UpdateVkDescriptorSet(const VkWriteDescriptorSet& write);
 
-  DescriptorType type_ = DescriptorType::kSampledImage;
+  DescriptorType type_ = DescriptorType::kStorageBuffer;
 
   bool is_descriptor_set_update_needed_ = false;
 };


### PR DESCRIPTION
Once we support images and other types of buffers we'll probably bring this back but, remove until we need it. This makes it easier to understand what's currently happening.