### PR TITLE
Change depth format for test.

### DIFF
--- a/tests/cases/draw_triangle_list_with_depth.vkscript
+++ b/tests/cases/draw_triangle_list_with_depth.vkscript
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 [require]
-depthstencil D24_UNORM_S8_UINT
+depthstencil D32_SFLOAT_S8_UINT
 
 [vertex shader]
 #version 430


### PR DESCRIPTION
This CL changes the depth format for the draw_triangle_list_with_depth
test to be D32_SFLOAT_S8_UINT which is understood by MoltenVK. The
D24_UNORM_S8_UINT format is not supported on MoltenVK.

Issue #216.