### PR TITLE
 [vulkan] Wrap render pass into RAII object.

### DIFF
--- a/src/vulkan/command_buffer.h
+++ b/src/vulkan/command_buffer.h
@@ -40,7 +40,7 @@ class CommandBuffer {
   ~CommandBuffer();
 
   Result Initialize();
-  VkCommandBuffer GetCommandBuffer() const { return command_; }
+  VkCommandBuffer GetVkCommandBuffer() const { return command_; }
 
   // Do nothing and return if it is already ready to record. If it is in
   // initial state, call command begin API and make it ready to record.

--- a/src/vulkan/compute_pipeline.cc
+++ b/src/vulkan/compute_pipeline.cc
@@ -113,8 +113,8 @@ Result ComputePipeline::Compute(uint32_t x, uint32_t y, uint32_t z) {
     return r;
 
   device_->GetPtrs()->vkCmdBindPipeline(
-      command_->GetCommandBuffer(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
-  device_->GetPtrs()->vkCmdDispatch(command_->GetCommandBuffer(), x, y, z);
+      command_->GetVkCommandBuffer(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
+  device_->GetPtrs()->vkCmdDispatch(command_->GetVkCommandBuffer(), x, y, z);
 
   r = command_->End();
   if (!r.IsSuccess())

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -348,7 +348,7 @@ VkBlendOp ToVkBlendOp(BlendOp op) {
 
 class RenderPassGuard {
  public:
-  RenderPassGuard(GraphicsPipeline* pipeline) : pipeline_(pipeline) {
+  explicit RenderPassGuard(GraphicsPipeline* pipeline) : pipeline_(pipeline) {
     auto* frame = pipeline->GetFrame();
     auto* cmd = pipeline->GetCommandBuffer();
     result_ = frame->ChangeFrameImageLayout(cmd, FrameImageState::kClearOrDraw);

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -49,6 +49,9 @@ class GraphicsPipeline : public Pipeline {
       const std::vector<VkPipelineShaderStageCreateInfo>&);
   ~GraphicsPipeline() override;
 
+  // Pipeline
+  void Shutdown() override;
+
   Result Initialize(uint32_t width,
                     uint32_t height,
                     CommandPool* pool,
@@ -66,7 +69,8 @@ class GraphicsPipeline : public Pipeline {
 
   Result Draw(const DrawArraysCommand* command, VertexBuffer* vertex_buffer);
 
-  const FrameBuffer* GetFrame() const { return frame_.get(); }
+  VkRenderPass GetRenderPass() const { return render_pass_; }
+  FrameBuffer* GetFrame() const { return frame_.get(); }
 
   uint32_t GetWidth() const { return frame_width_; }
   uint32_t GetHeight() const { return frame_height_; }
@@ -75,15 +79,7 @@ class GraphicsPipeline : public Pipeline {
     patch_control_points_ = points;
   }
 
-  // Pipeline
-  void Shutdown() override;
-
- private:
-  enum class RenderPassState : uint8_t {
-    kActive = 0,
-    kInactive,
-  };
-
+private:
   Result CreateVkGraphicsPipeline(const PipelineData* pipeline_data,
                                   VkPrimitiveTopology topology,
                                   const VertexBuffer* vertex_buffer,
@@ -91,8 +87,6 @@ class GraphicsPipeline : public Pipeline {
                                   VkPipeline* pipeline);
 
   Result CreateRenderPass();
-  Result ActivateRenderPassIfNeeded();
-  void DeactivateRenderPassIfNeeded();
 
   Result SendVertexBufferDataIfNeeded(VertexBuffer* vertex_buffer);
 
@@ -110,7 +104,6 @@ class GraphicsPipeline : public Pipeline {
       const PipelineData* pipeline_data);
 
   VkRenderPass render_pass_ = VK_NULL_HANDLE;
-  RenderPassState render_pass_state_ = RenderPassState::kInactive;
 
   std::unique_ptr<FrameBuffer> frame_;
 

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -79,7 +79,7 @@ class GraphicsPipeline : public Pipeline {
     patch_control_points_ = points;
   }
 
-private:
+ private:
   Result CreateVkGraphicsPipeline(const PipelineData* pipeline_data,
                                   VkPrimitiveTopology topology,
                                   const VertexBuffer* vertex_buffer,

--- a/src/vulkan/index_buffer.cc
+++ b/src/vulkan/index_buffer.cc
@@ -63,7 +63,7 @@ Result IndexBuffer::BindToCommandBuffer(CommandBuffer* command) {
         "IndexBuffer::BindToCommandBuffer |transfer_buffer_| is nullptr");
   }
 
-  device_->GetPtrs()->vkCmdBindIndexBuffer(command->GetCommandBuffer(),
+  device_->GetPtrs()->vkCmdBindIndexBuffer(command->GetVkCommandBuffer(),
                                            transfer_buffer_->GetVkBuffer(), 0,
                                            VK_INDEX_TYPE_UINT32);
   return {};

--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -371,7 +371,7 @@ void Pipeline::BindVkDescriptorSets(const VkPipelineLayout& pipeline_layout) {
       continue;
 
     device_->GetPtrs()->vkCmdBindDescriptorSets(
-        command_->GetCommandBuffer(),
+        command_->GetVkCommandBuffer(),
         IsGraphics() ? VK_PIPELINE_BIND_POINT_GRAPHICS
                      : VK_PIPELINE_BIND_POINT_COMPUTE,
         pipeline_layout, static_cast<uint32_t>(i), 1,

--- a/src/vulkan/pipeline.h
+++ b/src/vulkan/pipeline.h
@@ -67,6 +67,9 @@ class Pipeline {
   // the command buffer.
   Result ProcessCommands();
 
+  CommandBuffer* GetCommandBuffer() const { return command_.get(); }
+  Device* GetDevice() const { return device_; }
+
   virtual void Shutdown();
 
  protected:

--- a/src/vulkan/push_constant.cc
+++ b/src/vulkan/push_constant.cc
@@ -93,7 +93,7 @@ Result PushConstant::RecordPushConstantVkCommand(
   assert(push_const_range.offset % 4U == 0 && push_const_range.size % 4U == 0);
 
   device_->GetPtrs()->vkCmdPushConstants(
-      command->GetCommandBuffer(), pipeline_layout, VK_SHADER_STAGE_ALL,
+      command->GetVkCommandBuffer(), pipeline_layout, VK_SHADER_STAGE_ALL,
       push_const_range.offset, push_const_range.size,
       memory_.data() + push_const_range.offset);
   return {};

--- a/src/vulkan/resource.cc
+++ b/src/vulkan/resource.cc
@@ -250,7 +250,7 @@ void Resource::MemoryBarrier(CommandBuffer* command) {
   // ReadOnly Descriptors          host w         shader r
   //                           transfer w       transfer r
   device_->GetPtrs()->vkCmdPipelineBarrier(
-      command->GetCommandBuffer(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+      command->GetVkCommandBuffer(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
       VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 1, &kMemoryBarrierForAll, 0,
       nullptr, 0, nullptr);
 }

--- a/src/vulkan/transfer_image.cc
+++ b/src/vulkan/transfer_image.cc
@@ -175,8 +175,9 @@ Result TransferImage::CopyToHost(CommandBuffer* command) {
                              image_info_.extent.height, 1};
 
   device_->GetPtrs()->vkCmdCopyImageToBuffer(
-      command->GetCommandBuffer(), image_, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-      host_accessible_buffer_, 1, &copy_region);
+      command->GetVkCommandBuffer(), image_,
+      VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, host_accessible_buffer_, 1,
+      &copy_region);
 
   MemoryBarrier(command);
   return {};
@@ -257,8 +258,9 @@ void TransferImage::ChangeLayout(CommandBuffer* command,
       break;
   }
 
-  device_->GetPtrs()->vkCmdPipelineBarrier(
-      command->GetCommandBuffer(), from, to, 0, 0, NULL, 0, NULL, 1, &barrier);
+  device_->GetPtrs()->vkCmdPipelineBarrier(command->GetVkCommandBuffer(), from,
+                                           to, 0, 0, NULL, 0, NULL, 1,
+                                           &barrier);
 }
 
 Result TransferImage::AllocateAndBindMemoryToVkImage(

--- a/src/vulkan/vertex_buffer.cc
+++ b/src/vulkan/vertex_buffer.cc
@@ -265,8 +265,8 @@ void VertexBuffer::BindToCommandBuffer(CommandBuffer* command) {
   const VkDeviceSize offset = 0;
   const VkBuffer buffer = transfer_buffer_->GetVkBuffer();
   // TODO(jaebaek): Support multiple binding
-  device_->GetPtrs()->vkCmdBindVertexBuffers(command->GetCommandBuffer(), 0, 1,
-                                             &buffer, &offset);
+  device_->GetPtrs()->vkCmdBindVertexBuffers(command->GetVkCommandBuffer(), 0,
+                                             1, &buffer, &offset);
 }
 
 Result VertexBuffer::SendVertexData(


### PR DESCRIPTION
This Cl wraps the begin/end render pass calls inside a RAII object.
This removes the possibility of having called begin render pass without
subsequently calling end.