### PR TITLE
[vulkan] Fixup width of draw commands.

### DIFF
--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -920,6 +920,8 @@ Result Parser::ParseRun() {
       return Result("missing X position for RUN command");
 
     auto cmd = MakeUnique<DrawRectCommand>(pipeline, PipelineData{});
+    cmd->EnableOrtho();
+
     Result r = token->ConvertToDouble();
     if (!r.IsSuccess())
       return r;

--- a/src/amberscript/parser_test.cc
+++ b/src/amberscript/parser_test.cc
@@ -3128,7 +3128,7 @@ RUN my_pipeline DRAW_RECT POS 2 4 SIZE 10 20)";
 
   auto* cmd = commands[0].get();
   ASSERT_TRUE(cmd->IsDrawRect());
-  EXPECT_FALSE(cmd->AsDrawRect()->IsOrtho());
+  EXPECT_TRUE(cmd->AsDrawRect()->IsOrtho());
   EXPECT_FALSE(cmd->AsDrawRect()->IsPatch());
   EXPECT_FLOAT_EQ(2.f, cmd->AsDrawRect()->GetX());
   EXPECT_FLOAT_EQ(4.f, cmd->AsDrawRect()->GetY());

--- a/src/verifier.cc
+++ b/src/verifier.cc
@@ -520,13 +520,10 @@ Result Verifier::Probe(const ProbeCommand* command,
                        const void* buf) {
   if (!command)
     return Result("Verifier::Probe given ProbeCommand is nullptr");
-
   if (!framebuffer_format)
     return Result("Verifier::Probe given texel's Format is nullptr");
-
   if (framebuffer_format->GetFormatType() == FormatType::kUnknown)
     return Result("Verifier::Probe given texel's Format is unknown");
-
   if (!buf)
     return Result("Verifier::Probe given buffer to probe is nullptr");
 

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -326,14 +326,13 @@ Result EngineVulkan::DoDrawRect(const DrawRectCommand* command) {
   float width = command->GetWidth();
   float height = command->GetHeight();
 
-  const float frame_width = static_cast<float>(graphics->GetWidth());
-  const float frame_height = static_cast<float>(graphics->GetHeight());
   if (command->IsOrtho()) {
+    const float frame_width = static_cast<float>(graphics->GetWidth());
+    const float frame_height = static_cast<float>(graphics->GetHeight());
     x = ((x / frame_width) * 2.0f) - 1.0f;
     y = ((y / frame_height) * 2.0f) - 1.0f;
-  } else {
-    width = width * frame_width;
-    height = height * frame_height;
+    width = (width / frame_width) * 2.0f;
+    height = (height / frame_height) * 2.0f;
   }
 
   std::vector<Value> values(8);

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -324,13 +324,15 @@ Result EngineVulkan::DoDrawRect(const DrawRectCommand* command) {
   float y = command->GetY();
   float width = command->GetWidth();
   float height = command->GetHeight();
+
+  const float frame_width = static_cast<float>(graphics->GetWidth());
+  const float frame_height = static_cast<float>(graphics->GetHeight());
   if (command->IsOrtho()) {
-    const float frame_width = static_cast<float>(graphics->GetWidth());
-    const float frame_height = static_cast<float>(graphics->GetHeight());
     x = ((x / frame_width) * 2.0f) - 1.0f;
     y = ((y / frame_height) * 2.0f) - 1.0f;
-    width = ((width / frame_width) * 2.0f) - 1.0f;
-    height = ((height / frame_height) * 2.0f) - 1.0f;
+  } else {
+    width = width * frame_width;
+    height = height * frame_height;
   }
 
   std::vector<Value> values(8);

--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -260,7 +260,6 @@ Result Pipeline::AddPushConstant(const BufferCommand* command) {
 Result Pipeline::AddDescriptor(const BufferCommand* cmd) {
   if (cmd == nullptr)
     return Result("Pipeline::AddDescriptor BufferCommand is nullptr");
-
   if (!cmd->IsSSBO() && !cmd->IsUniform())
     return Result("Pipeline::AddDescriptor not supported buffer type");
 

--- a/tests/cases/draw_rect.amber
+++ b/tests/cases/draw_rect.amber
@@ -1,0 +1,34 @@
+#!amber
+# Copyright 2019 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHADER vertex vert_shader PASSTHROUGH
+SHADER fragment frag_shader GLSL
+#version 430
+layout(location = 0) out vec4 color_out;
+void main() {
+  color_out = vec4(1.0, 0.0, 0.0, 1.0);
+}
+END
+
+BUFFER framebuffer FORMAT B8G8R8A8_UNORM
+
+PIPELINE graphics my_pipeline
+  ATTACH vert_shader
+  ATTACH frag_shader
+  BIND BUFFER framebuffer AS color LOCATION 0
+END
+
+RUN my_pipeline DRAW_RECT POS 0 0 SIZE 250 250
+EXPECT framebuffer IDX 0 0 SIZE 250 250 EQ_RGBA 1 0 0 1

--- a/tests/cases/draw_rect.vkscript
+++ b/tests/cases/draw_rect.vkscript
@@ -1,0 +1,30 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[require]
+vertexPipelineStoresAndAtomics
+
+[vertex shader passthrough]
+[fragment shader]
+#version 430
+
+layout(location = 0) out vec4 final_color;
+
+void main() {
+  final_color = vec4(1, 0, 0, 1);
+}
+
+[test]
+draw rect -1 -1 1 1
+probe rect rgba (0.0, 0.0, 250, 250) (1.0, 0, 0, 1.0)

--- a/tests/cases/draw_rect.vkscript
+++ b/tests/cases/draw_rect.vkscript
@@ -26,5 +26,5 @@ void main() {
 }
 
 [test]
-draw rect -1 -1 1 1
+draw rect -1 -1 2 2
 probe rect rgba (0.0, 0.0, 250, 250) (1.0, 0, 0, 1.0)

--- a/tests/cases/draw_rect_and_ortho.vkscript
+++ b/tests/cases/draw_rect_and_ortho.vkscript
@@ -1,0 +1,25 @@
+[require]
+vertexPipelineStoresAndAtomics
+
+[vertex shader passthrough]
+[fragment shader]
+#version 430
+
+layout(location = 0) out vec4 final_color;
+
+void main() {
+  final_color = vec4(1, 0, 0, 1);
+}
+
+[test]
+clear
+draw rect 0.0 0.0 0.6 0.6
+probe rect rgba (0, 0, 125, 125) (0.0, 0, 0, 0.0)
+probe rect rgba (125, 125, 75, 75) (1.0, 0, 0, 1.0)
+probe rect rgba (200, 200, 50, 50) (0.0, 0, 0, 0.0)
+
+clear
+draw rect ortho 125 125 75 75
+probe rect rgba (0, 0, 125, 125) (0.0, 0, 0, 0.0)
+probe rect rgba (125, 125, 75, 75) (1.0, 0, 0, 1.0)
+probe rect rgba (200, 200, 50, 50) (0.0, 0, 0, 0.0)

--- a/tests/cases/draw_rect_orth.vkscript
+++ b/tests/cases/draw_rect_orth.vkscript
@@ -1,0 +1,30 @@
+# Copyright 2018 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[require]
+vertexPipelineStoresAndAtomics
+
+[vertex shader passthrough]
+[fragment shader]
+#version 430
+
+layout(location = 0) out vec4 final_color;
+
+void main() {
+  final_color = vec4(1, 0, 0, 1);
+}
+
+[test]
+draw rect ortho 0 0 250 250
+probe rect rgba (0.0, 0.0, 250, 250) (1.0, 0, 0, 1.0)


### PR DESCRIPTION
The draw command expects the width and heigth passed into the Draw Rect
command to be the full width/height we want to draw. Not a scale of -1
to 1. This means that we would only draw one corner of the screen
instead of the entire screen.