### PR TITLE
[vulkan] Remove redundant record and submit commands.

### DIFF
--- a/src/vulkan/compute_pipeline.cc
+++ b/src/vulkan/compute_pipeline.cc
@@ -69,15 +69,7 @@ Result ComputePipeline::CreateVkComputePipeline(
 }
 
 Result ComputePipeline::Compute(uint32_t x, uint32_t y, uint32_t z) {
-  Result r = command_->BeginIfNotInRecording();
-  if (!r.IsSuccess())
-    return r;
-
-  r = SendDescriptorDataToDeviceIfNeeded();
-  if (!r.IsSuccess())
-    return r;
-
-  r = command_->SubmitAndReset(GetFenceTimeout());
+  Result r = SendDescriptorDataToDeviceIfNeeded();
   if (!r.IsSuccess())
     return r;
 

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -822,15 +822,7 @@ Result GraphicsPipeline::ClearBuffer(const VkClearValue& clear_value,
 
 Result GraphicsPipeline::Draw(const DrawArraysCommand* command,
                               VertexBuffer* vertex_buffer) {
-  Result r = command_->BeginIfNotInRecording();
-  if (!r.IsSuccess())
-    return r;
-
-  r = SendDescriptorDataToDeviceIfNeeded();
-  if (!r.IsSuccess())
-    return r;
-
-  r = command_->SubmitAndReset(GetFenceTimeout());
+  Result r = SendDescriptorDataToDeviceIfNeeded();
   if (!r.IsSuccess())
     return r;
 

--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -355,6 +355,9 @@ Result Pipeline::SendDescriptorDataToDeviceIfNeeded() {
     }
   }
 
+  r = command_->SubmitAndReset(GetFenceTimeout());
+  if (!r.IsSuccess())
+    return r;
   return {};
 }
 
@@ -406,14 +409,6 @@ const char* Pipeline::GetEntryPointName(VkShaderStageFlagBits stage) const {
     return it->second.c_str();
 
   return kDefaultEntryPointName;
-}
-
-Result Pipeline::ProcessCommands() {
-  Result r = command_->BeginIfNotInRecording();
-  if (!r.IsSuccess())
-    return r;
-
-  return command_->SubmitAndReset(GetFenceTimeout());
 }
 
 }  // namespace vulkan

--- a/src/vulkan/pipeline.h
+++ b/src/vulkan/pipeline.h
@@ -62,11 +62,6 @@ class Pipeline {
     entry_points_[stage] = entry;
   }
 
-  // End recording command buffer if it is in recording state. This
-  // method also submits commands in the command buffer and reset
-  // the command buffer.
-  Result ProcessCommands();
-
   CommandBuffer* GetCommandBuffer() const { return command_.get(); }
   Device* GetDevice() const { return device_; }
 


### PR DESCRIPTION
The SendDescriptorDataToDevice method always begins and submits
recording. This Cl removes the calls to begin/submit recording which
wrap around the SendDescriptorDataToDevice method.