### PR TITLE
[vulkan] Rename methods returning vulkan objects.

### DIFF
--- a/src/vulkan/command_buffer.cc
+++ b/src/vulkan/command_buffer.cc
@@ -27,29 +27,29 @@ CommandBuffer::CommandBuffer(Device* device, CommandPool* pool, VkQueue queue)
 
 CommandBuffer::~CommandBuffer() {
   if (fence_ != VK_NULL_HANDLE)
-    device_->GetPtrs()->vkDestroyFence(device_->GetDevice(), fence_, nullptr);
+    device_->GetPtrs()->vkDestroyFence(device_->GetVkDevice(), fence_, nullptr);
 
   if (command_ != VK_NULL_HANDLE) {
     device_->GetPtrs()->vkFreeCommandBuffers(
-        device_->GetDevice(), pool_->GetCommandPool(), 1, &command_);
+        device_->GetVkDevice(), pool_->GetVkCommandPool(), 1, &command_);
   }
 }
 
 Result CommandBuffer::Initialize() {
   VkCommandBufferAllocateInfo command_info = VkCommandBufferAllocateInfo();
   command_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
-  command_info.commandPool = pool_->GetCommandPool();
+  command_info.commandPool = pool_->GetVkCommandPool();
   command_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
   command_info.commandBufferCount = 1;
 
   if (device_->GetPtrs()->vkAllocateCommandBuffers(
-          device_->GetDevice(), &command_info, &command_) != VK_SUCCESS) {
+          device_->GetVkDevice(), &command_info, &command_) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkAllocateCommandBuffers Fail");
   }
 
   VkFenceCreateInfo fence_info = VkFenceCreateInfo();
   fence_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-  if (device_->GetPtrs()->vkCreateFence(device_->GetDevice(), &fence_info,
+  if (device_->GetPtrs()->vkCreateFence(device_->GetVkDevice(), &fence_info,
                                         nullptr, &fence_) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateFence Fail");
   }
@@ -73,7 +73,7 @@ Result CommandBuffer::SubmitAndReset(uint32_t timeout_ms) {
   if (device_->GetPtrs()->vkEndCommandBuffer(command_) != VK_SUCCESS)
     return Result("Vulkan::Calling vkEndCommandBuffer Fail");
 
-  if (device_->GetPtrs()->vkResetFences(device_->GetDevice(), 1, &fence_) !=
+  if (device_->GetPtrs()->vkResetFences(device_->GetVkDevice(), 1, &fence_) !=
       VK_SUCCESS) {
     return Result("Vulkan::Calling vkResetFences Fail");
   }
@@ -88,7 +88,7 @@ Result CommandBuffer::SubmitAndReset(uint32_t timeout_ms) {
   }
 
   VkResult r = device_->GetPtrs()->vkWaitForFences(
-      device_->GetDevice(), 1, &fence_, VK_TRUE,
+      device_->GetVkDevice(), 1, &fence_, VK_TRUE,
       static_cast<uint64_t>(timeout_ms) * 1000ULL * 1000ULL /* nanosecond */);
   if (r == VK_TIMEOUT)
     return Result("Vulkan::Calling vkWaitForFences Timeout");

--- a/src/vulkan/command_pool.cc
+++ b/src/vulkan/command_pool.cc
@@ -25,7 +25,7 @@ CommandPool::~CommandPool() {
   if (pool_ == VK_NULL_HANDLE)
     return;
 
-  device_->GetPtrs()->vkDestroyCommandPool(device_->GetDevice(), pool_,
+  device_->GetPtrs()->vkDestroyCommandPool(device_->GetVkDevice(), pool_,
                                            nullptr);
 }
 
@@ -35,8 +35,8 @@ Result CommandPool::Initialize(uint32_t queue_family_index) {
   pool_info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
   pool_info.queueFamilyIndex = queue_family_index;
 
-  if (device_->GetPtrs()->vkCreateCommandPool(device_->GetDevice(), &pool_info,
-                                              nullptr, &pool_) != VK_SUCCESS) {
+  if (device_->GetPtrs()->vkCreateCommandPool(
+          device_->GetVkDevice(), &pool_info, nullptr, &pool_) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateCommandPool Fail");
   }
 

--- a/src/vulkan/command_pool.h
+++ b/src/vulkan/command_pool.h
@@ -29,7 +29,7 @@ class CommandPool {
   ~CommandPool();
 
   Result Initialize(uint32_t queue_family_index);
-  VkCommandPool GetCommandPool() const { return pool_; }
+  VkCommandPool GetVkCommandPool() const { return pool_; }
 
  private:
   Device* device_ = nullptr;

--- a/src/vulkan/compute_pipeline.cc
+++ b/src/vulkan/compute_pipeline.cc
@@ -42,7 +42,7 @@ Result ComputePipeline::Initialize(CommandPool* pool, VkQueue queue) {
 Result ComputePipeline::CreateVkComputePipeline(
     const VkPipelineLayout& pipeline_layout,
     VkPipeline* pipeline) {
-  auto shader_stage_info = GetShaderStageInfo();
+  auto shader_stage_info = GetVkShaderStageInfo();
   if (shader_stage_info.size() != 1) {
     return Result(
         "Vulkan::CreateVkComputePipeline number of shaders given to compute "
@@ -60,7 +60,7 @@ Result ComputePipeline::CreateVkComputePipeline(
   pipeline_info.layout = pipeline_layout;
 
   if (device_->GetPtrs()->vkCreateComputePipelines(
-          device_->GetDevice(), VK_NULL_HANDLE, 1, &pipeline_info, nullptr,
+          device_->GetVkDevice(), VK_NULL_HANDLE, 1, &pipeline_info, nullptr,
           pipeline) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateComputePipelines Fail");
   }
@@ -115,9 +115,9 @@ Result ComputePipeline::Compute(uint32_t x, uint32_t y, uint32_t z) {
   if (!r.IsSuccess())
     return r;
 
-  device_->GetPtrs()->vkDestroyPipeline(device_->GetDevice(), pipeline,
+  device_->GetPtrs()->vkDestroyPipeline(device_->GetVkDevice(), pipeline,
                                         nullptr);
-  device_->GetPtrs()->vkDestroyPipelineLayout(device_->GetDevice(),
+  device_->GetPtrs()->vkDestroyPipelineLayout(device_->GetVkDevice(),
                                               pipeline_layout, nullptr);
 
   return {};

--- a/src/vulkan/descriptor.cc
+++ b/src/vulkan/descriptor.cc
@@ -81,8 +81,8 @@ Result Descriptor::UpdateDescriptorSetForBuffer(
 }
 
 void Descriptor::UpdateVkDescriptorSet(const VkWriteDescriptorSet& write) {
-  device_->GetPtrs()->vkUpdateDescriptorSets(device_->GetDevice(), 1, &write, 0,
-                                             nullptr);
+  device_->GetPtrs()->vkUpdateDescriptorSets(device_->GetVkDevice(), 1, &write,
+                                             0, nullptr);
   is_descriptor_set_update_needed_ = false;
 }
 

--- a/src/vulkan/device.h
+++ b/src/vulkan/device.h
@@ -48,16 +48,17 @@ class Device {
                     const VkPhysicalDeviceFeatures2KHR& available_features2,
                     const std::vector<std::string>& available_extensions);
 
-  VkInstance GetInstance() const { return instance_; }
-  VkPhysicalDevice GetPhysicalDevice() { return physical_device_; }
-  VkDevice GetDevice() const { return device_; }
-  VkPhysicalDevice GetPhysicalDevice() const { return physical_device_; }
+  VkInstance GetVkInstance() const { return instance_; }
+  VkPhysicalDevice GetVkPhysicalDevice() { return physical_device_; }
+  VkDevice GetVkDevice() const { return device_; }
+  VkPhysicalDevice GetVkPhysicalDevice() const { return physical_device_; }
   uint32_t GetQueueFamilyIndex() const { return queue_family_index_; }
-  VkQueue GetQueue() const { return queue_; }
-  const VkPhysicalDeviceProperties& GetPhysicalDeviceProperties() const {
+  VkQueue GetVkQueue() const { return queue_; }
+  const VkPhysicalDeviceProperties& GetVkPhysicalDeviceProperties() const {
     return physical_device_properties_;
   }
-  const VkPhysicalDeviceMemoryProperties& GetPhysicalMemoryProperties() const {
+  const VkPhysicalDeviceMemoryProperties& GetVkPhysicalMemoryProperties()
+      const {
     return physical_memory_properties_;
   }
 

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -68,7 +68,7 @@ class EngineVulkan : public Engine {
         shaders;
   };
 
-  std::vector<VkPipelineShaderStageCreateInfo> GetShaderStageInfo(
+  std::vector<VkPipelineShaderStageCreateInfo> GetVkShaderStageInfo(
       amber::Pipeline* pipeline);
   bool IsFormatSupportedByPhysicalDevice(BufferType type,
                                          VkPhysicalDevice physical_device,

--- a/src/vulkan/frame_buffer.cc
+++ b/src/vulkan/frame_buffer.cc
@@ -39,7 +39,7 @@ FrameBuffer::FrameBuffer(
 
 FrameBuffer::~FrameBuffer() {
   if (frame_ != VK_NULL_HANDLE) {
-    device_->GetPtrs()->vkDestroyFramebuffer(device_->GetDevice(), frame_,
+    device_->GetPtrs()->vkDestroyFramebuffer(device_->GetVkDevice(), frame_,
                                              nullptr);
   }
 }
@@ -108,7 +108,7 @@ Result FrameBuffer::Initialize(
   frame_buffer_info.height = height_;
   frame_buffer_info.layers = 1;
 
-  if (device_->GetPtrs()->vkCreateFramebuffer(device_->GetDevice(),
+  if (device_->GetPtrs()->vkCreateFramebuffer(device_->GetVkDevice(),
                                               &frame_buffer_info, nullptr,
                                               &frame_) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateFramebuffer Fail");

--- a/src/vulkan/frame_buffer.h
+++ b/src/vulkan/frame_buffer.h
@@ -48,7 +48,7 @@ class FrameBuffer {
 
   Result ChangeFrameImageLayout(CommandBuffer* command, FrameImageState layout);
 
-  VkFramebuffer GetFrameBuffer() const { return frame_; }
+  VkFramebuffer GetVkFrameBuffer() const { return frame_; }
   const void* GetColorBufferPtr(size_t idx) const {
     return color_images_[idx]->HostAccessibleMemoryPtr();
   }

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -357,8 +357,8 @@ class RenderPassGuard {
 
     VkRenderPassBeginInfo render_begin_info = VkRenderPassBeginInfo();
     render_begin_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-    render_begin_info.renderPass = pipeline->GetRenderPass();
-    render_begin_info.framebuffer = frame->GetFrameBuffer();
+    render_begin_info.renderPass = pipeline->GetVkRenderPass();
+    render_begin_info.framebuffer = frame->GetVkFrameBuffer();
     render_begin_info.renderArea = {{0, 0},
                                     {frame->GetWidth(), frame->GetHeight()}};
     pipeline->GetDevice()->GetPtrs()->vkCmdBeginRenderPass(
@@ -454,7 +454,7 @@ Result GraphicsPipeline::CreateRenderPass() {
   render_pass_info.subpassCount = 1;
   render_pass_info.pSubpasses = &subpass_desc;
 
-  if (device_->GetPtrs()->vkCreateRenderPass(device_->GetDevice(),
+  if (device_->GetPtrs()->vkCreateRenderPass(device_->GetVkDevice(),
                                              &render_pass_info, nullptr,
                                              &render_pass_) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateRenderPass Fail");
@@ -464,7 +464,7 @@ Result GraphicsPipeline::CreateRenderPass() {
 }
 
 VkPipelineDepthStencilStateCreateInfo
-GraphicsPipeline::GetPipelineDepthStencilInfo(
+GraphicsPipeline::GetVkPipelineDepthStencilInfo(
     const PipelineData* pipeline_data) {
   VkPipelineDepthStencilStateCreateInfo depthstencil_info =
       VkPipelineDepthStencilStateCreateInfo();
@@ -508,7 +508,7 @@ GraphicsPipeline::GetPipelineDepthStencilInfo(
 }
 
 VkPipelineColorBlendAttachmentState
-GraphicsPipeline::GetPipelineColorBlendAttachmentState(
+GraphicsPipeline::GetVkPipelineColorBlendAttachmentState(
     const PipelineData* pipeline_data) {
   VkPipelineColorBlendAttachmentState colorblend_attachment =
       VkPipelineColorBlendAttachmentState();
@@ -550,8 +550,8 @@ Result GraphicsPipeline::CreateVkGraphicsPipeline(
   VkVertexInputBindingDescription vertex_binding_desc =
       VkVertexInputBindingDescription();
   if (vertex_buffer != nullptr) {
-    vertex_binding_desc = vertex_buffer->GetVertexInputBinding();
-    const auto& vertex_attr_desc = vertex_buffer->GetVertexInputAttr();
+    vertex_binding_desc = vertex_buffer->GetVkVertexInputBinding();
+    const auto& vertex_attr_desc = vertex_buffer->GetVkVertexInputAttr();
 
     vertex_input_info.pVertexBindingDescriptions = &vertex_binding_desc;
     vertex_input_info.vertexAttributeDescriptionCount =
@@ -590,7 +590,7 @@ Result GraphicsPipeline::CreateVkGraphicsPipeline(
   viewport_info.scissorCount = 1;
   viewport_info.pScissors = &scissor;
 
-  auto shader_stage_info = GetShaderStageInfo();
+  auto shader_stage_info = GetVkShaderStageInfo();
   bool is_tessellation_needed = false;
   for (auto& info : shader_stage_info) {
     info.pName = GetEntryPointName(info.stage);
@@ -651,7 +651,7 @@ Result GraphicsPipeline::CreateVkGraphicsPipeline(
 
   VkPipelineDepthStencilStateCreateInfo depthstencil_info;
   if (depth_stencil_format_ != VK_FORMAT_UNDEFINED) {
-    depthstencil_info = GetPipelineDepthStencilInfo(pipeline_data);
+    depthstencil_info = GetVkPipelineDepthStencilInfo(pipeline_data);
     pipeline_info.pDepthStencilState = &depthstencil_info;
   }
 
@@ -659,7 +659,7 @@ Result GraphicsPipeline::CreateVkGraphicsPipeline(
       VkPipelineColorBlendStateCreateInfo();
   VkPipelineColorBlendAttachmentState colorblend_attachment;
 
-  colorblend_attachment = GetPipelineColorBlendAttachmentState(pipeline_data);
+  colorblend_attachment = GetVkPipelineColorBlendAttachmentState(pipeline_data);
 
   colorblend_info.sType =
       VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
@@ -674,7 +674,7 @@ Result GraphicsPipeline::CreateVkGraphicsPipeline(
   pipeline_info.subpass = 0;
 
   if (device_->GetPtrs()->vkCreateGraphicsPipelines(
-          device_->GetDevice(), VK_NULL_HANDLE, 1, &pipeline_info, nullptr,
+          device_->GetVkDevice(), VK_NULL_HANDLE, 1, &pipeline_info, nullptr,
           pipeline) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateGraphicsPipelines Fail");
   }
@@ -912,9 +912,9 @@ Result GraphicsPipeline::Draw(const DrawArraysCommand* command,
   if (!r.IsSuccess())
     return r;
 
-  device_->GetPtrs()->vkDestroyPipeline(device_->GetDevice(), pipeline,
+  device_->GetPtrs()->vkDestroyPipeline(device_->GetVkDevice(), pipeline,
                                         nullptr);
-  device_->GetPtrs()->vkDestroyPipelineLayout(device_->GetDevice(),
+  device_->GetPtrs()->vkDestroyPipelineLayout(device_->GetVkDevice(),
                                               pipeline_layout, nullptr);
   return {};
 }
@@ -925,8 +925,8 @@ void GraphicsPipeline::Shutdown() {
   frame_ = nullptr;
 
   if (render_pass_ != VK_NULL_HANDLE) {
-    device_->GetPtrs()->vkDestroyRenderPass(device_->GetDevice(), render_pass_,
-                                            nullptr);
+    device_->GetPtrs()->vkDestroyRenderPass(device_->GetVkDevice(),
+                                            render_pass_, nullptr);
   }
 }
 

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -69,7 +69,7 @@ class GraphicsPipeline : public Pipeline {
 
   Result Draw(const DrawArraysCommand* command, VertexBuffer* vertex_buffer);
 
-  VkRenderPass GetRenderPass() const { return render_pass_; }
+  VkRenderPass GetVkRenderPass() const { return render_pass_; }
   FrameBuffer* GetFrame() const { return frame_.get(); }
 
   uint32_t GetWidth() const { return frame_width_; }
@@ -98,9 +98,9 @@ class GraphicsPipeline : public Pipeline {
                       const uint32_t height,
                       const ProbeCommand* command);
 
-  VkPipelineDepthStencilStateCreateInfo GetPipelineDepthStencilInfo(
+  VkPipelineDepthStencilStateCreateInfo GetVkPipelineDepthStencilInfo(
       const PipelineData* pipeline_data);
-  VkPipelineColorBlendAttachmentState GetPipelineColorBlendAttachmentState(
+  VkPipelineColorBlendAttachmentState GetVkPipelineColorBlendAttachmentState(
       const PipelineData* pipeline_data);
 
   VkRenderPass render_pass_ = VK_NULL_HANDLE;

--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -72,7 +72,7 @@ void Pipeline::Shutdown() {
 
   for (auto& info : descriptor_set_info_) {
     if (info.layout != VK_NULL_HANDLE) {
-      device_->GetPtrs()->vkDestroyDescriptorSetLayout(device_->GetDevice(),
+      device_->GetPtrs()->vkDestroyDescriptorSetLayout(device_->GetVkDevice(),
                                                        info.layout, nullptr);
     }
 
@@ -80,7 +80,7 @@ void Pipeline::Shutdown() {
       continue;
 
     if (info.pool != VK_NULL_HANDLE) {
-      device_->GetPtrs()->vkDestroyDescriptorPool(device_->GetDevice(),
+      device_->GetPtrs()->vkDestroyDescriptorPool(device_->GetVkDevice(),
                                                   info.pool, nullptr);
     }
   }
@@ -106,7 +106,7 @@ Result Pipeline::CreateDescriptorSetLayouts() {
     desc_info.pBindings = bindings.data();
 
     if (device_->GetPtrs()->vkCreateDescriptorSetLayout(
-            device_->GetDevice(), &desc_info, nullptr, &info.layout) !=
+            device_->GetVkDevice(), &desc_info, nullptr, &info.layout) !=
         VK_SUCCESS) {
       return Result("Vulkan::Calling vkCreateDescriptorSetLayout Fail");
     }
@@ -143,7 +143,7 @@ Result Pipeline::CreateDescriptorPools() {
     pool_info.poolSizeCount = static_cast<uint32_t>(pool_sizes.size());
     pool_info.pPoolSizes = pool_sizes.data();
 
-    if (device_->GetPtrs()->vkCreateDescriptorPool(device_->GetDevice(),
+    if (device_->GetPtrs()->vkCreateDescriptorPool(device_->GetVkDevice(),
                                                    &pool_info, nullptr,
                                                    &info.pool) != VK_SUCCESS) {
       return Result("Vulkan::Calling vkCreateDescriptorPool Fail");
@@ -166,7 +166,7 @@ Result Pipeline::CreateDescriptorSets() {
 
     VkDescriptorSet desc_set = VK_NULL_HANDLE;
     if (device_->GetPtrs()->vkAllocateDescriptorSets(
-            device_->GetDevice(), &desc_set_info, &desc_set) != VK_SUCCESS) {
+            device_->GetVkDevice(), &desc_set_info, &desc_set) != VK_SUCCESS) {
       return Result("Vulkan::Calling vkAllocateDescriptorSets Fail");
     }
     descriptor_set_info_[i].vk_desc_set = desc_set;
@@ -191,14 +191,15 @@ Result Pipeline::CreateVkPipelineLayout(VkPipelineLayout* pipeline_layout) {
       static_cast<uint32_t>(descriptor_set_layouts.size());
   pipeline_layout_info.pSetLayouts = descriptor_set_layouts.data();
 
-  VkPushConstantRange push_const_range = push_constant_->GetPushConstantRange();
+  VkPushConstantRange push_const_range =
+      push_constant_->GetVkPushConstantRange();
   if (push_const_range.size) {
     pipeline_layout_info.pushConstantRangeCount = 1U;
     pipeline_layout_info.pPushConstantRanges = &push_const_range;
   }
 
   if (device_->GetPtrs()->vkCreatePipelineLayout(
-          device_->GetDevice(), &pipeline_layout_info, nullptr,
+          device_->GetVkDevice(), &pipeline_layout_info, nullptr,
           pipeline_layout) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreatePipelineLayout Fail");
   }

--- a/src/vulkan/pipeline.h
+++ b/src/vulkan/pipeline.h
@@ -87,7 +87,7 @@ class Pipeline {
   // Record a Vulkan command for push contant.
   Result RecordPushConstant(const VkPipelineLayout& pipeline_layout);
 
-  const std::vector<VkPipelineShaderStageCreateInfo>& GetShaderStageInfo()
+  const std::vector<VkPipelineShaderStageCreateInfo>& GetVkShaderStageInfo()
       const {
     return shader_stage_info_;
   }

--- a/src/vulkan/push_constant.cc
+++ b/src/vulkan/push_constant.cc
@@ -31,7 +31,7 @@ PushConstant::PushConstant(Device* device, uint32_t max_push_constant_size)
 
 PushConstant::~PushConstant() = default;
 
-VkPushConstantRange PushConstant::GetPushConstantRange() {
+VkPushConstantRange PushConstant::GetVkPushConstantRange() {
   if (push_constant_data_.empty())
     return VkPushConstantRange();
 
@@ -74,7 +74,7 @@ Result PushConstant::RecordPushConstantVkCommand(
   if (push_constant_data_.empty())
     return {};
 
-  auto push_const_range = GetPushConstantRange();
+  auto push_const_range = GetVkPushConstantRange();
   if (push_const_range.offset + push_const_range.size >
       max_push_constant_size_) {
     return Result(

--- a/src/vulkan/push_constant.h
+++ b/src/vulkan/push_constant.h
@@ -44,7 +44,7 @@ class PushConstant {
   // in |push_constant_data_| rounded down by 4, and size is maximum
   // |offset| + |size_in_bytes| among elements in |push_constant_data_|
   // rounded up by 4.
-  VkPushConstantRange GetPushConstantRange();
+  VkPushConstantRange GetVkPushConstantRange();
 
   // Call vkCmdPushConstants() to record a command for push constant
   // if size in bytes of push constant is not larger than

--- a/src/vulkan/resource.cc
+++ b/src/vulkan/resource.cc
@@ -114,7 +114,7 @@ Result Resource::CreateVkBuffer(VkBuffer* buffer, VkBufferUsageFlags usage) {
   buffer_info.size = size_in_bytes_;
   buffer_info.usage = usage;
 
-  if (device_->GetPtrs()->vkCreateBuffer(device_->GetDevice(), &buffer_info,
+  if (device_->GetPtrs()->vkCreateBuffer(device_->GetVkDevice(), &buffer_info,
                                          nullptr, buffer) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateBuffer Fail");
   }
@@ -157,7 +157,7 @@ uint32_t Resource::ChooseMemory(uint32_t memory_type_bits,
 const VkMemoryRequirements Resource::GetVkBufferMemoryRequirements(
     VkBuffer buffer) const {
   VkMemoryRequirements requirement;
-  device_->GetPtrs()->vkGetBufferMemoryRequirements(device_->GetDevice(),
+  device_->GetPtrs()->vkGetBufferMemoryRequirements(device_->GetVkDevice(),
                                                     buffer, &requirement);
   return requirement;
 }
@@ -191,7 +191,7 @@ Result Resource::AllocateAndBindMemoryToVkBuffer(VkBuffer buffer,
   if (!r.IsSuccess())
     return r;
 
-  if (device_->GetPtrs()->vkBindBufferMemory(device_->GetDevice(), buffer,
+  if (device_->GetPtrs()->vkBindBufferMemory(device_->GetVkDevice(), buffer,
                                              *memory, 0) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkBindBufferMemory Fail");
   }
@@ -206,7 +206,7 @@ Result Resource::AllocateMemory(VkDeviceMemory* memory,
   alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
   alloc_info.allocationSize = size;
   alloc_info.memoryTypeIndex = memory_type_index;
-  if (device_->GetPtrs()->vkAllocateMemory(device_->GetDevice(), &alloc_info,
+  if (device_->GetPtrs()->vkAllocateMemory(device_->GetVkDevice(), &alloc_info,
                                            nullptr, memory) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkAllocateMemory Fail");
   }
@@ -215,7 +215,7 @@ Result Resource::AllocateMemory(VkDeviceMemory* memory,
 }
 
 Result Resource::MapMemory(VkDeviceMemory memory) {
-  if (device_->GetPtrs()->vkMapMemory(device_->GetDevice(), memory, 0,
+  if (device_->GetPtrs()->vkMapMemory(device_->GetVkDevice(), memory, 0,
                                       VK_WHOLE_SIZE, 0,
                                       &memory_ptr_) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkMapMemory Fail");
@@ -225,7 +225,7 @@ Result Resource::MapMemory(VkDeviceMemory memory) {
 }
 
 void Resource::UnMapMemory(VkDeviceMemory memory) {
-  device_->GetPtrs()->vkUnmapMemory(device_->GetDevice(), memory);
+  device_->GetPtrs()->vkUnmapMemory(device_->GetVkDevice(), memory);
 }
 
 void Resource::MemoryBarrier(CommandBuffer* command) {

--- a/src/vulkan/resource.h
+++ b/src/vulkan/resource.h
@@ -77,7 +77,7 @@ class Resource {
   // prevent hazards caused by out-of-order execution.
   void MemoryBarrier(CommandBuffer* command);
 
-  const VkPhysicalDeviceMemoryProperties& GetMemoryProperties() const {
+  const VkPhysicalDeviceMemoryProperties& GetVkMemoryProperties() const {
     return physical_memory_properties_;
   }
 

--- a/src/vulkan/transfer_buffer.cc
+++ b/src/vulkan/transfer_buffer.cc
@@ -47,17 +47,18 @@ TransferBuffer::TransferBuffer(
 
 TransferBuffer::~TransferBuffer() {
   if (view_ != VK_NULL_HANDLE) {
-    device_->GetPtrs()->vkDestroyBufferView(device_->GetDevice(), view_,
+    device_->GetPtrs()->vkDestroyBufferView(device_->GetVkDevice(), view_,
                                             nullptr);
   }
 
   if (memory_ != VK_NULL_HANDLE) {
     UnMapMemory(memory_);
-    device_->GetPtrs()->vkFreeMemory(device_->GetDevice(), memory_, nullptr);
+    device_->GetPtrs()->vkFreeMemory(device_->GetVkDevice(), memory_, nullptr);
   }
 
   if (buffer_ != VK_NULL_HANDLE)
-    device_->GetPtrs()->vkDestroyBuffer(device_->GetDevice(), buffer_, nullptr);
+    device_->GetPtrs()->vkDestroyBuffer(device_->GetVkDevice(), buffer_,
+                                        nullptr);
 }
 
 Result TransferBuffer::Initialize(const VkBufferUsageFlags usage) {
@@ -73,8 +74,8 @@ Result TransferBuffer::Initialize(const VkBufferUsageFlags usage) {
   if (!r.IsSuccess())
     return r;
 
-  if (!IsMemoryHostAccessible(GetMemoryProperties(), memory_type_index) ||
-      !IsMemoryHostCoherent(GetMemoryProperties(), memory_type_index)) {
+  if (!IsMemoryHostAccessible(GetVkMemoryProperties(), memory_type_index) ||
+      !IsMemoryHostCoherent(GetVkMemoryProperties(), memory_type_index)) {
     return Result(
         "Vulkan: TransferBuffer::Initialize() buffer is not host accessible or"
         " not host coherent.");
@@ -90,7 +91,7 @@ Result TransferBuffer::CreateVkBufferView(VkFormat format) {
   buffer_view_info.format = format;
   buffer_view_info.offset = 0;
   buffer_view_info.range = VK_WHOLE_SIZE;
-  if (device_->GetPtrs()->vkCreateBufferView(device_->GetDevice(),
+  if (device_->GetPtrs()->vkCreateBufferView(device_->GetVkDevice(),
                                              &buffer_view_info, nullptr,
                                              &view_) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateBufferView Fail");

--- a/src/vulkan/transfer_image.cc
+++ b/src/vulkan/transfer_image.cc
@@ -61,24 +61,24 @@ TransferImage::TransferImage(Device* device,
 
 TransferImage::~TransferImage() {
   if (view_ != VK_NULL_HANDLE) {
-    device_->GetPtrs()->vkDestroyImageView(device_->GetDevice(), view_,
+    device_->GetPtrs()->vkDestroyImageView(device_->GetVkDevice(), view_,
                                            nullptr);
   }
 
   if (image_ != VK_NULL_HANDLE)
-    device_->GetPtrs()->vkDestroyImage(device_->GetDevice(), image_, nullptr);
+    device_->GetPtrs()->vkDestroyImage(device_->GetVkDevice(), image_, nullptr);
 
   if (memory_ != VK_NULL_HANDLE)
-    device_->GetPtrs()->vkFreeMemory(device_->GetDevice(), memory_, nullptr);
+    device_->GetPtrs()->vkFreeMemory(device_->GetVkDevice(), memory_, nullptr);
 
   if (host_accessible_memory_ != VK_NULL_HANDLE) {
     UnMapMemory(host_accessible_memory_);
-    device_->GetPtrs()->vkFreeMemory(device_->GetDevice(),
+    device_->GetPtrs()->vkFreeMemory(device_->GetVkDevice(),
                                      host_accessible_memory_, nullptr);
   }
 
   if (host_accessible_buffer_ != VK_NULL_HANDLE) {
-    device_->GetPtrs()->vkDestroyBuffer(device_->GetDevice(),
+    device_->GetPtrs()->vkDestroyBuffer(device_->GetVkDevice(),
                                         host_accessible_buffer_, nullptr);
   }
 }
@@ -89,7 +89,7 @@ Result TransferImage::Initialize(VkImageUsageFlags usage) {
 
   image_info_.usage = usage;
 
-  if (device_->GetPtrs()->vkCreateImage(device_->GetDevice(), &image_info_,
+  if (device_->GetPtrs()->vkCreateImage(device_->GetVkDevice(), &image_info_,
                                         nullptr, &image_) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateImage Fail");
   }
@@ -148,7 +148,7 @@ Result TransferImage::CreateVkImageView() {
       1,       /* layerCount */
   };
 
-  if (device_->GetPtrs()->vkCreateImageView(device_->GetDevice(),
+  if (device_->GetPtrs()->vkCreateImageView(device_->GetVkDevice(),
                                             &image_view_info, nullptr,
                                             &view_) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkCreateImageView Fail");
@@ -294,7 +294,7 @@ Result TransferImage::AllocateAndBindMemoryToVkImage(
   if (!r.IsSuccess())
     return r;
 
-  if (device_->GetPtrs()->vkBindImageMemory(device_->GetDevice(), image,
+  if (device_->GetPtrs()->vkBindImageMemory(device_->GetVkDevice(), image,
                                             *memory, 0) != VK_SUCCESS) {
     return Result("Vulkan::Calling vkBindImageMemory Fail");
   }
@@ -305,8 +305,8 @@ Result TransferImage::AllocateAndBindMemoryToVkImage(
 const VkMemoryRequirements TransferImage::GetVkImageMemoryRequirements(
     VkImage image) const {
   VkMemoryRequirements requirement;
-  device_->GetPtrs()->vkGetImageMemoryRequirements(device_->GetDevice(), image,
-                                                   &requirement);
+  device_->GetPtrs()->vkGetImageMemoryRequirements(device_->GetVkDevice(),
+                                                   image, &requirement);
   return requirement;
 }
 

--- a/src/vulkan/vertex_buffer.h
+++ b/src/vulkan/vertex_buffer.h
@@ -43,12 +43,12 @@ class VertexBuffer {
                const Format& format,
                const std::vector<Value>& values);
 
-  const std::vector<VkVertexInputAttributeDescription>& GetVertexInputAttr()
+  const std::vector<VkVertexInputAttributeDescription>& GetVkVertexInputAttr()
       const {
     return vertex_attr_desc_;
   }
 
-  VkVertexInputBindingDescription GetVertexInputBinding() const {
+  VkVertexInputBindingDescription GetVkVertexInputBinding() const {
     VkVertexInputBindingDescription vertex_binding_desc =
         VkVertexInputBindingDescription();
     vertex_binding_desc.binding = 0;


### PR DESCRIPTION
This CL renames methods returning vulkan objects to have an explicit Vk
in the names. This makes it clearer when a vulkan object is getting
returned vs an amber object.