### PR TITLE
[vulkan] Move GetFrameBuffer out of engine code.

### DIFF
--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -442,9 +442,5 @@ Result EngineDawn::CreateFramebufferIfNeeded() {
   return {};
 }
 
-Result EngineDawn::GetFrameBuffer(Buffer*, std::vector<Value>*) {
-  return Result("Dawn::GetFrameBuffer not implemented");
-}
-
 }  // namespace dawn
 }  // namespace amber

--- a/src/dawn/engine_dawn.h
+++ b/src/dawn/engine_dawn.h
@@ -60,7 +60,6 @@ class EngineDawn : public Engine {
   Result DoPatchParameterVertices(
       const PatchParameterVerticesCommand* cmd) override;
   Result DoBuffer(const BufferCommand* cmd) override;
-  Result GetFrameBuffer(Buffer*, std::vector<Value>* values) override;
 
  private:
   // Creates a command buffer builder if it doesn't already exist.

--- a/src/engine.h
+++ b/src/engine.h
@@ -93,10 +93,6 @@ class Engine {
   /// This covers both Vulkan buffers and images.
   virtual Result DoBuffer(const BufferCommand* cmd) = 0;
 
-  /// Copy the content of the framebuffer into |values|, each value is a pixel
-  /// in R8G8B8A8 format.
-  virtual Result GetFrameBuffer(Buffer* buffer, std::vector<Value>* values) = 0;
-
   /// Sets the engine data to use.
   void SetEngineData(const EngineData& data) { engine_data_ = data; }
 

--- a/src/executor_test.cc
+++ b/src/executor_test.cc
@@ -160,8 +160,6 @@ class EngineStub : public Engine {
     return {};
   }
 
-  Result GetFrameBuffer(Buffer*, std::vector<Value>*) override { return {}; }
-
  private:
   bool fail_clear_command_ = false;
   bool fail_clear_color_command_ = false;

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -29,8 +29,6 @@ namespace amber {
 namespace vulkan {
 namespace {
 
-const FormatType kDefaultFramebufferFormat = FormatType::kB8G8R8A8_UNORM;
-
 Result ToVkShaderStage(ShaderType type, VkShaderStageFlagBits* ret) {
   switch (type) {
     case kShaderTypeGeometry:
@@ -422,37 +420,6 @@ Result EngineVulkan::DoPatchParameterVertices(
 
   info.vk_pipeline->AsGraphics()->SetPatchControlPoints(
       command->GetControlPointCount());
-  return {};
-}
-
-Result EngineVulkan::GetFrameBuffer(Buffer* buffer,
-                                    std::vector<Value>* values) {
-  values->clear();
-
-  // TODO(jaebaek): Support other formats
-  if (buffer->AsFormatBuffer()->GetFormat().GetFormatType() !=
-      kDefaultFramebufferFormat) {
-    return Result("Vulkan::GetFrameBuffer Unsupported buffer format");
-  }
-
-  const uint8_t* cpu_memory = static_cast<const uint8_t*>(buffer->GetMemPtr());
-  if (!cpu_memory)
-    return Result("Vulkan::GetFrameBuffer missing memory pointer");
-
-  const auto texel_stride = buffer->AsFormatBuffer()->GetTexelStride();
-  const auto row_stride = buffer->AsFormatBuffer()->GetRowStride();
-
-  for (uint32_t y = 0; y < buffer->GetHeight(); ++y) {
-    for (uint32_t x = 0; x < buffer->GetWidth(); ++x) {
-      Value pixel;
-
-      const uint8_t* ptr_8 = cpu_memory + (row_stride * y) + (texel_stride * x);
-      const uint32_t* ptr_32 = reinterpret_cast<const uint32_t*>(ptr_8);
-      pixel.SetIntValue(*ptr_32);
-      values->push_back(pixel);
-    }
-  }
-
   return {};
 }
 

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -58,7 +58,6 @@ class EngineVulkan : public Engine {
   Result DoPatchParameterVertices(
       const PatchParameterVerticesCommand* cmd) override;
   Result DoBuffer(const BufferCommand* cmd) override;
-  Result GetFrameBuffer(Buffer* buffer, std::vector<Value>* values) override;
 
  private:
   struct PipelineInfo {


### PR DESCRIPTION
This CL moves the GetFrameBuffer code up into the Amber object and
removes from the engine code. There should be no engine specific work
involved in retrieving the framebuffer.