### PR TITLE
[vulkan] Change vulkan generation location.

### DIFF
--- a/src/vulkan/device.cc
+++ b/src/vulkan/device.cc
@@ -365,7 +365,7 @@ Result Device::LoadVulkanPointers(PFN_vkGetInstanceProcAddr getInstanceProcAddr,
   if (delegate && delegate->LogGraphicsCalls())
     delegate->Log("Loading Vulkan Pointers");
 
-#include "src/vk-wrappers.inc"
+#include "vk-wrappers.inc"
 
   return {};
 }

--- a/src/vulkan/device.h
+++ b/src/vulkan/device.h
@@ -28,7 +28,7 @@ namespace amber {
 namespace vulkan {
 
 struct VulkanPtrs {
-#include "vk-wrappers.h" #NOLINT(build / include)
+#include "vk-wrappers.h"  // NOLINT(build/include)
 };
 
 class Device {

--- a/src/vulkan/device.h
+++ b/src/vulkan/device.h
@@ -28,7 +28,7 @@ namespace amber {
 namespace vulkan {
 
 struct VulkanPtrs {
-#include "src/vk-wrappers.h"
+#include "vk-wrappers.h" #NOLINT(build / include)
 };
 
 class Device {

--- a/tools/update_vk_wrappers.py
+++ b/tools/update_vk_wrappers.py
@@ -201,7 +201,7 @@ def main():
     wrapper_content = gen_direct(data)
     header_content = gen_direct_headers(data)
 
-  outfile = os.path.join(outdir, 'src', 'vk-wrappers.inc')
+  outfile = os.path.join(outdir, 'vk-wrappers.inc')
   if os.path.isfile(outfile):
     with open(outfile, 'r') as f:
       if wrapper_content == f.read():
@@ -209,7 +209,7 @@ def main():
   with open(outfile, 'w') as f:
     f.write(wrapper_content)
 
-  hdrfile = os.path.join(outdir, 'src', 'vk-wrappers.h')
+  hdrfile = os.path.join(outdir, 'vk-wrappers.h')
   if os.path.isfile(hdrfile):
     with open(hdrfile, 'r') as f:
       if header_content == f.read():


### PR DESCRIPTION
The src/ folder does not always exist when building the vulkan wrappers.
This CL changes the generation script to write to the binary directory
instead of <binary directory>/src.