### PR TITLE
Move config helper to use destructor

### DIFF
--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -467,7 +467,5 @@ int main(int argc, const char** argv) {
               << failures.size() << " fail" << std::endl;
   }
 
-  config_helper.Shutdown();
-
   return !failures.empty();
 }

--- a/samples/config_helper.cc
+++ b/samples/config_helper.cc
@@ -72,10 +72,4 @@ amber::Result ConfigHelper::CreateConfig(
       disable_validation_layer, show_version_info, config);
 }
 
-amber::Result ConfigHelper::Shutdown() {
-  if (!impl_)
-    return {};
-  return impl_->Shutdown();
-}
-
 }  // namespace sample

--- a/samples/config_helper.h
+++ b/samples/config_helper.h
@@ -41,9 +41,6 @@ class ConfigHelperImpl {
       bool disable_validation_layer,
       bool show_version_info,
       std::unique_ptr<amber::EngineConfig>* config) = 0;
-
-  // Destroy instance and device.
-  virtual amber::Result Shutdown() = 0;
 };
 
 // Wrapper of ConfigHelperImpl.
@@ -67,9 +64,6 @@ class ConfigHelper {
       bool disable_validation_layer,
       bool show_version_info,
       std::unique_ptr<amber::EngineConfig>* config);
-
-  // Destroy instance and device.
-  amber::Result Shutdown();
 
  private:
   std::unique_ptr<ConfigHelperImpl> impl_;

--- a/samples/config_helper_dawn.cc
+++ b/samples/config_helper_dawn.cc
@@ -58,9 +58,4 @@ amber::Result ConfigHelperDawn::CreateConfig(
   return {};
 }
 
-amber::Result ConfigHelperDawn::Shutdown() {
-  dawn_device_ = {};
-  return {};
-}
-
 }  // namespace sample

--- a/samples/config_helper_dawn.h
+++ b/samples/config_helper_dawn.h
@@ -47,9 +47,6 @@ class ConfigHelperDawn : public ConfigHelperImpl {
       bool show_version_info,
       std::unique_ptr<amber::EngineConfig>* config) override;
 
-  // Destroy Dawn instance and device.
-  amber::Result Shutdown() override;
-
  private:
   ::dawn_native::Instance dawn_instance_;
   ::dawn::Device dawn_device_;

--- a/samples/config_helper_vulkan.cc
+++ b/samples/config_helper_vulkan.cc
@@ -610,7 +610,7 @@ ConfigHelperVulkan::~ConfigHelperVulkan() {
                                   "vkDestroyDebugReportCallbackEXT"));
     if (vkDestroyDebugReportCallbackEXT) {
       vkDestroyDebugReportCallbackEXT(vulkan_instance_, vulkan_callback_,
-                                    nullptr);
+                                      nullptr);
     }
   }
 

--- a/samples/config_helper_vulkan.h
+++ b/samples/config_helper_vulkan.h
@@ -51,9 +51,6 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
       bool show_version_info,
       std::unique_ptr<amber::EngineConfig>* config) override;
 
-  // Destroy Vulkan instance and device.
-  amber::Result Shutdown() override;
-
  private:
   // Create Vulkan instance.
   amber::Result CreateVulkanInstance(


### PR DESCRIPTION
This CL moves the config helper Shutdown code into the destructor and
removes the shutdown methods.

Issue #42.