### PR TITLE
Move engine shutdown to destructor

### DIFF
--- a/src/amber.cc
+++ b/src/amber.cc
@@ -201,15 +201,12 @@ amber::Result Amber::ExecuteWithShaderData(const amber::Recipe* recipe,
     }
   }
 
-  if (!executor_result.IsSuccess()) {
-    engine->Shutdown();
+  if (!executor_result.IsSuccess())
     return executor_result;
-  }
-  if (!r.IsSuccess()) {
-    engine->Shutdown();
+  if (!r.IsSuccess())
     return r;
-  }
-  return engine->Shutdown();
+
+  return {};
 }
 
 }  // namespace amber

--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -200,11 +200,6 @@ Result EngineDawn::Initialize(EngineConfig* config,
   return {};
 }
 
-Result EngineDawn::Shutdown() {
-  device_ = nullptr;
-  return {};
-}
-
 Result EngineDawn::CreatePipeline(Pipeline* pipeline) {
   for (const auto& shader_info : pipeline->GetShaders()) {
     Result r = SetShader(shader_info.GetShaderType(), shader_info.GetData());

--- a/src/dawn/engine_dawn.h
+++ b/src/dawn/engine_dawn.h
@@ -42,7 +42,6 @@ class EngineDawn : public Engine {
                     const std::vector<std::string>& instance_extensions,
                     const std::vector<std::string>& device_extensions) override;
 
-  Result Shutdown() override;
   // Record info for a pipeline.  The Dawn render pipeline will be created
   // later.  Assumes necessary shader modules have been created.  A compute
   // pipeline requires a compute shader.  A graphics pipeline requires a vertex

--- a/src/engine.h
+++ b/src/engine.h
@@ -54,9 +54,6 @@ class Engine {
       const std::vector<std::string>& instance_extensions,
       const std::vector<std::string>& device_extensions) = 0;
 
-  /// Shutdown the engine and cleanup any resources.
-  virtual Result Shutdown() = 0;
-
   /// Create graphics pipeline.
   virtual Result CreatePipeline(Pipeline* pipeline) = 0;
 

--- a/src/executor_test.cc
+++ b/src/executor_test.cc
@@ -44,8 +44,6 @@ class EngineStub : public Engine {
     return {};
   }
 
-  Result Shutdown() override { return {}; }
-
   const std::vector<std::string>& GetFeatures() const { return features_; }
   const std::vector<std::string>& GetDeviceExtensions() const {
     return device_extensions_;

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -44,7 +44,6 @@ class EngineVulkan : public Engine {
                     const std::vector<std::string>& features,
                     const std::vector<std::string>& instance_extensions,
                     const std::vector<std::string>& device_extensions) override;
-  Result Shutdown() override;
   Result CreatePipeline(amber::Pipeline* type) override;
 
   Result DoClearColor(const ClearColorCommand* cmd) override;


### PR DESCRIPTION
This CL removes code from the engine Shutdown methods and puts it into
the destructor instead.

Issue #42.