### PR TITLE
Change cmake to use PYTHON_EXECUTABLE.

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -53,7 +53,7 @@ amber_default_compile_options(amber)
 add_custom_command(
     OUTPUT ${CMAKE_BINARY_DIR}/src/build-versions.h.fake
     COMMAND
-      ${PYTHON_EXE}
+      ${PYTHON_EXECUTABLE}
         ${PROJECT_SOURCE_DIR}/tools/update_build_version.py
         ${CMAKE_BINARY_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/vulkan/CMakeLists.txt
+++ b/src/vulkan/CMakeLists.txt
@@ -53,7 +53,7 @@ endif()
 add_custom_command(
     OUTPUT ${CMAKE_BINARY_DIR}/src/vk-wrappers.inc.fake
     COMMAND
-      ${PYTHON_EXE}
+      ${PYTHON_EXECUTABLE}
         ${PROJECT_SOURCE_DIR}/tools/update_vk_wrappers.py
         ${CMAKE_BINARY_DIR}
         ${PROJECT_SOURCE_DIR}


### PR DESCRIPTION
Different versions of Cmake set PYTHON_EXE or PYTHON_EXECUTABLE. From
the documentation PYTHON_EXECUTABLE is the one which is always set.

Fixes #398.