### PR TITLE
[vulkan] Remove memory pointer from Buffer.

### DIFF
--- a/src/amber.cc
+++ b/src/amber.cc
@@ -41,7 +41,7 @@ Result GetFrameBuffer(Buffer* buffer, std::vector<Value>* values) {
     return Result("GetFrameBuffer Unsupported buffer format");
   }
 
-  const uint8_t* cpu_memory = static_cast<const uint8_t*>(buffer->GetMemPtr());
+  const uint8_t* cpu_memory = buffer->ValuePtr()->data();
   if (!cpu_memory)
     return Result("GetFrameBuffer missing memory pointer");
 
@@ -192,7 +192,7 @@ amber::Result Amber::ExecuteWithShaderData(const amber::Recipe* recipe,
     if (!buffer)
       break;
 
-    const uint8_t* ptr = static_cast<const uint8_t*>(buffer->GetMemPtr());
+    const uint8_t* ptr = buffer->ValuePtr()->data();
     auto& values = buffer_info.values;
     for (size_t i = 0; i < buffer->GetSize(); ++i) {
       values.emplace_back();

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -85,21 +85,8 @@ class Buffer {
   /// size of the data provided.
   virtual Result SetData(std::vector<Value>&& data) = 0;
 
-  void SetMemPtr(void* ptr) { mem_ptr_ = ptr; }
-
-  const void* GetMemPtr() const {
-    if (mem_ptr_ == nullptr && !values_.empty())
-      return values_.data();
-    return mem_ptr_;
-  }
-
-  void* GetMemPtr() {
-    if (mem_ptr_ == nullptr && !values_.empty())
-      return values_.data();
-    return mem_ptr_;
-  }
-
   std::vector<uint8_t>* ValuePtr() { return &values_; }
+  const std::vector<uint8_t>* ValuePtr() const { return &values_; }
 
   template <typename T>
   const T* GetValues() const {
@@ -119,7 +106,6 @@ class Buffer {
   uint32_t width_ = 0;
   uint32_t height_ = 0;
   uint8_t location_ = 0;
-  void* mem_ptr_ = nullptr;
 };
 
 /// A buffer class where the data is described by a |DatumType| object.

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -76,21 +76,19 @@ Result Executor::Execute(Engine* engine,
 
       auto* buffer = cmd->AsProbe()->GetBuffer()->AsFormatBuffer();
       assert(buffer);
-      assert(buffer->GetMemPtr());
 
       r = verifier_.Probe(cmd->AsProbe(), &buffer->GetFormat(),
                           buffer->GetTexelStride(), buffer->GetRowStride(),
                           buffer->GetWidth(), buffer->GetHeight(),
-                          buffer->GetMemPtr());
+                          buffer->ValuePtr()->data());
     } else if (cmd->IsProbeSSBO()) {
       auto probe_ssbo = cmd->AsProbeSSBO();
 
       const auto* buffer = cmd->AsProbe()->GetBuffer();
       assert(buffer);
-      assert(buffer->GetMemPtr());
 
       r = verifier_.ProbeSSBO(probe_ssbo, buffer->GetSize(),
-                              buffer->GetMemPtr());
+                              buffer->ValuePtr()->data());
     } else if (cmd->IsClear()) {
       r = engine->DoClear(cmd->AsClear());
     } else if (cmd->IsClearColor()) {

--- a/src/vulkan/buffer_descriptor.cc
+++ b/src/vulkan/buffer_descriptor.cc
@@ -148,7 +148,7 @@ Result BufferDescriptor::AddToBuffer(DataType type,
   }
 
   BufferInput in{offset, size_in_bytes, type, values};
-  in.UpdateBufferWithValues(amber_buffer_->GetMemPtr());
+  in.UpdateBufferWithValues(amber_buffer_->ValuePtr()->data());
 
   return {};
 }

--- a/src/vulkan/frame_buffer.cc
+++ b/src/vulkan/frame_buffer.cc
@@ -76,7 +76,6 @@ Result FrameBuffer::Initialize(
         return r;
 
       attachments[info->location] = color_images_.back()->GetVkImageView();
-      info->buffer->SetMemPtr(color_images_.back()->HostAccessibleMemoryPtr());
     }
   }
 
@@ -182,6 +181,17 @@ Result FrameBuffer::CopyColorImagesToHost(CommandBuffer* command) {
       return r;
   }
   return {};
+}
+
+void FrameBuffer::CopyImagesToBuffers() {
+  for (size_t i = 0; i < color_images_.size(); ++i) {
+    auto& img = color_images_[i];
+    auto* info = color_attachments_[i];
+    auto* values = info->buffer->ValuePtr();
+    values->resize(info->buffer->GetSizeInBytes());
+    std::memcpy(values->data(), img->HostAccessibleMemoryPtr(),
+                info->buffer->GetSizeInBytes());
+  }
 }
 
 }  // namespace vulkan

--- a/src/vulkan/frame_buffer.cc
+++ b/src/vulkan/frame_buffer.cc
@@ -15,6 +15,7 @@
 #include "src/vulkan/frame_buffer.h"
 
 #include <algorithm>
+#include <cstring>
 #include <limits>
 #include <vector>
 

--- a/src/vulkan/frame_buffer.h
+++ b/src/vulkan/frame_buffer.h
@@ -58,6 +58,8 @@ class FrameBuffer {
   // of the command must be done later.
   Result CopyColorImagesToHost(CommandBuffer* command);
 
+  void CopyImagesToBuffers();
+
   uint32_t GetWidth() const { return width_; }
   uint32_t GetHeight() const { return height_; }
 

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -814,7 +814,12 @@ Result GraphicsPipeline::ClearBuffer(const VkClearValue& clear_value,
   if (!r.IsSuccess())
     return r;
 
-  return cmd_buf_guard.Submit(GetFenceTimeout());
+  r = cmd_buf_guard.Submit(GetFenceTimeout());
+  if (!r.IsSuccess())
+    return r;
+
+  frame_->CopyImagesToBuffers();
+  return {};
 }
 
 Result GraphicsPipeline::Draw(const DrawArraysCommand* command,
@@ -911,6 +916,8 @@ Result GraphicsPipeline::Draw(const DrawArraysCommand* command,
   r = ReadbackDescriptorsToHostDataQueue();
   if (!r.IsSuccess())
     return r;
+
+  frame_->CopyImagesToBuffers();
 
   device_->GetPtrs()->vkDestroyPipeline(device_->GetVkDevice(), pipeline,
                                         nullptr);


### PR DESCRIPTION
This CL removes the memory pointer from the buffer object and copies the
host accessible memory into the value vector.