### PR TITLE
[vulkan] Move pipeline shutdown to destructor

### DIFF
--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -87,9 +87,6 @@ EngineVulkan::~EngineVulkan() {
         device_->GetPtrs()->vkDestroyShaderModule(vk_device, mod_it->second,
                                                   nullptr);
     }
-
-    if (info.vk_pipeline != VK_NULL_HANDLE)
-      info.vk_pipeline->Shutdown();
   }
 }
 

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -402,7 +402,12 @@ GraphicsPipeline::GraphicsPipeline(
     color_buffers_.push_back(&info);
 }
 
-GraphicsPipeline::~GraphicsPipeline() = default;
+GraphicsPipeline::~GraphicsPipeline() {
+  if (render_pass_) {
+    device_->GetPtrs()->vkDestroyRenderPass(device_->GetVkDevice(),
+                                            render_pass_, nullptr);
+  }
+}
 
 Result GraphicsPipeline::CreateRenderPass() {
   VkSubpassDescription subpass_desc = VkSubpassDescription();
@@ -917,17 +922,6 @@ Result GraphicsPipeline::Draw(const DrawArraysCommand* command,
   device_->GetPtrs()->vkDestroyPipelineLayout(device_->GetVkDevice(),
                                               pipeline_layout, nullptr);
   return {};
-}
-
-void GraphicsPipeline::Shutdown() {
-  index_buffer_ = nullptr;
-  Pipeline::Shutdown();
-  frame_ = nullptr;
-
-  if (render_pass_ != VK_NULL_HANDLE) {
-    device_->GetPtrs()->vkDestroyRenderPass(device_->GetVkDevice(),
-                                            render_pass_, nullptr);
-  }
 }
 
 }  // namespace vulkan

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -49,9 +49,6 @@ class GraphicsPipeline : public Pipeline {
       const std::vector<VkPipelineShaderStageCreateInfo>&);
   ~GraphicsPipeline() override;
 
-  // Pipeline
-  void Shutdown() override;
-
   Result Initialize(uint32_t width,
                     uint32_t height,
                     CommandPool* pool,

--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -63,25 +63,9 @@ Pipeline::Pipeline(
       shader_stage_info_(shader_stage_info),
       fence_timeout_ms_(fence_timeout_ms) {}
 
-Pipeline::~Pipeline() = default;
-
-GraphicsPipeline* Pipeline::AsGraphics() {
-  return static_cast<GraphicsPipeline*>(this);
-}
-
-ComputePipeline* Pipeline::AsCompute() {
-  return static_cast<ComputePipeline*>(this);
-}
-
-Result Pipeline::Initialize(CommandPool* pool, VkQueue queue) {
-  push_constant_ = MakeUnique<PushConstant>(
-      device_, physical_device_properties_.limits.maxPushConstantsSize);
-
-  command_ = MakeUnique<CommandBuffer>(device_, pool, queue);
-  return command_->Initialize();
-}
-
-void Pipeline::Shutdown() {
+Pipeline::~Pipeline() {
+  // Command must be reset before we destroy descriptors or we get a validation
+  // error.
   command_ = nullptr;
 
   for (auto& info : descriptor_set_info_) {
@@ -98,6 +82,22 @@ void Pipeline::Shutdown() {
                                                   info.pool, nullptr);
     }
   }
+}
+
+GraphicsPipeline* Pipeline::AsGraphics() {
+  return static_cast<GraphicsPipeline*>(this);
+}
+
+ComputePipeline* Pipeline::AsCompute() {
+  return static_cast<ComputePipeline*>(this);
+}
+
+Result Pipeline::Initialize(CommandPool* pool, VkQueue queue) {
+  push_constant_ = MakeUnique<PushConstant>(
+      device_, physical_device_properties_.limits.maxPushConstantsSize);
+
+  command_ = MakeUnique<CommandBuffer>(device_, pool, queue);
+  return command_->Initialize();
 }
 
 Result Pipeline::CreateDescriptorSetLayouts() {

--- a/src/vulkan/pipeline.h
+++ b/src/vulkan/pipeline.h
@@ -65,8 +65,6 @@ class Pipeline {
   CommandBuffer* GetCommandBuffer() const { return command_.get(); }
   Device* GetDevice() const { return device_; }
 
-  virtual void Shutdown();
-
  protected:
   Pipeline(
       PipelineType type,


### PR DESCRIPTION
This CL removes the pipeline shutdown method and uses the destructor
instead.

Issue #42.