### PR TITLE
[vulkan] Cleanup device methods for properties

### DIFF
--- a/src/vulkan/buffer_descriptor.cc
+++ b/src/vulkan/buffer_descriptor.cc
@@ -41,8 +41,7 @@ BufferDescriptor::BufferDescriptor(Buffer* buffer,
 
 BufferDescriptor::~BufferDescriptor() = default;
 
-Result BufferDescriptor::CreateResourceIfNeeded(
-    const VkPhysicalDeviceMemoryProperties& properties) {
+Result BufferDescriptor::CreateResourceIfNeeded() {
   if (transfer_buffer_) {
     return Result(
         "Vulkan: BufferDescriptor::CreateResourceIfNeeded() must be called "
@@ -55,8 +54,7 @@ Result BufferDescriptor::CreateResourceIfNeeded(
   uint32_t size_in_bytes =
       amber_buffer_ ? static_cast<uint32_t>(amber_buffer_->ValuePtr()->size())
                     : 0;
-  transfer_buffer_ =
-      MakeUnique<TransferBuffer>(device_, size_in_bytes, properties);
+  transfer_buffer_ = MakeUnique<TransferBuffer>(device_, size_in_bytes);
 
   Result r = transfer_buffer_->Initialize(
       (IsStorageBuffer() ? VK_BUFFER_USAGE_STORAGE_BUFFER_BIT

--- a/src/vulkan/buffer_descriptor.h
+++ b/src/vulkan/buffer_descriptor.h
@@ -60,8 +60,7 @@ class BufferDescriptor {
     return type_ == DescriptorType::kUniformBuffer;
   }
 
-  Result CreateResourceIfNeeded(
-      const VkPhysicalDeviceMemoryProperties& properties);
+  Result CreateResourceIfNeeded();
   void RecordCopyDataToResourceIfNeeded(CommandBuffer* command);
   Result RecordCopyDataToHost(CommandBuffer* command);
   Result MoveResourceToBufferOutput();

--- a/src/vulkan/compute_pipeline.cc
+++ b/src/vulkan/compute_pipeline.cc
@@ -22,14 +22,10 @@ namespace vulkan {
 
 ComputePipeline::ComputePipeline(
     Device* device,
-    const VkPhysicalDeviceProperties& properties,
-    const VkPhysicalDeviceMemoryProperties& memory_properties,
     uint32_t fence_timeout_ms,
     const std::vector<VkPipelineShaderStageCreateInfo>& shader_stage_info)
     : Pipeline(PipelineType::kCompute,
                device,
-               properties,
-               memory_properties,
                fence_timeout_ms,
                shader_stage_info) {}
 

--- a/src/vulkan/compute_pipeline.h
+++ b/src/vulkan/compute_pipeline.h
@@ -28,8 +28,6 @@ class ComputePipeline : public Pipeline {
  public:
   ComputePipeline(
       Device* device,
-      const VkPhysicalDeviceProperties& properties,
-      const VkPhysicalDeviceMemoryProperties& memory_properties,
       uint32_t fence_timeout_ms,
       const std::vector<VkPipelineShaderStageCreateInfo>& shader_stage_info);
   ~ComputePipeline() override;

--- a/src/vulkan/device.cc
+++ b/src/vulkan/device.cc
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "src/make_unique.h"
+#include "src/vulkan/format_data.h"
 
 namespace amber {
 namespace vulkan {
@@ -458,6 +459,61 @@ Result Device::Initialize(
                                             &physical_memory_properties_);
 
   return {};
+}
+
+bool Device::IsFormatSupportedByPhysicalDevice(const Format& format,
+                                               BufferType type) {
+  VkFormat vk_format = ToVkFormat(format.GetFormatType());
+  VkFormatProperties properties = VkFormatProperties();
+  GetPtrs()->vkGetPhysicalDeviceFormatProperties(physical_device_, vk_format,
+                                                 &properties);
+
+  VkFormatFeatureFlagBits flag = VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT;
+  bool is_buffer_type_image = false;
+  switch (type) {
+    case BufferType::kColor:
+      flag = VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT;
+      is_buffer_type_image = true;
+      break;
+    case BufferType::kDepth:
+      flag = VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT;
+      is_buffer_type_image = true;
+      break;
+    case BufferType::kSampled:
+      flag = VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
+      is_buffer_type_image = true;
+      break;
+    case BufferType::kVertex:
+      flag = VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT;
+      is_buffer_type_image = false;
+      break;
+    default:
+      return false;
+  }
+
+  return ((is_buffer_type_image ? properties.optimalTilingFeatures
+                                : properties.bufferFeatures) &
+          flag) == flag;
+}
+
+bool Device::HasMemoryFlags(uint32_t memory_type_index,
+                            const VkMemoryPropertyFlags flags) const {
+  return (physical_memory_properties_.memoryTypes[memory_type_index]
+              .propertyFlags &
+          flags) == flags;
+}
+
+bool Device::IsMemoryHostAccessible(uint32_t memory_type_index) const {
+  return HasMemoryFlags(memory_type_index, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+}
+
+bool Device::IsMemoryHostCoherent(uint32_t memory_type_index) const {
+  return HasMemoryFlags(memory_type_index,
+                        VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+}
+
+uint32_t Device::GetMaxPushConstants() const {
+  return physical_device_properties_.limits.maxPushConstantsSize;
 }
 
 }  // namespace vulkan

--- a/src/vulkan/device.h
+++ b/src/vulkan/device.h
@@ -23,6 +23,8 @@
 #include "amber/amber.h"
 #include "amber/result.h"
 #include "amber/vulkan_header.h"
+#include "src/buffer_data.h"
+#include "src/format.h"
 
 namespace amber {
 namespace vulkan {
@@ -48,19 +50,21 @@ class Device {
                     const VkPhysicalDeviceFeatures2KHR& available_features2,
                     const std::vector<std::string>& available_extensions);
 
+  bool IsFormatSupportedByPhysicalDevice(const Format& format, BufferType type);
+
   VkInstance GetVkInstance() const { return instance_; }
   VkPhysicalDevice GetVkPhysicalDevice() { return physical_device_; }
   VkDevice GetVkDevice() const { return device_; }
   VkPhysicalDevice GetVkPhysicalDevice() const { return physical_device_; }
   uint32_t GetQueueFamilyIndex() const { return queue_family_index_; }
   VkQueue GetVkQueue() const { return queue_; }
-  const VkPhysicalDeviceProperties& GetVkPhysicalDeviceProperties() const {
-    return physical_device_properties_;
-  }
-  const VkPhysicalDeviceMemoryProperties& GetVkPhysicalMemoryProperties()
-      const {
-    return physical_memory_properties_;
-  }
+
+  uint32_t GetMaxPushConstants() const;
+
+  bool HasMemoryFlags(uint32_t memory_type_index,
+                      const VkMemoryPropertyFlags flags) const;
+  bool IsMemoryHostAccessible(uint32_t memory_type_index) const;
+  bool IsMemoryHostCoherent(uint32_t memory_type_index) const;
 
   const VulkanPtrs* GetPtrs() const { return &ptrs_; }
 

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -135,12 +135,6 @@ Result EngineVulkan::Initialize(
   return {};
 }
 
-bool EngineVulkan::VerifyFormatAvailable(const Format& format,
-                                         BufferType type) {
-  return IsFormatSupportedByPhysicalDevice(type, device_->GetVkPhysicalDevice(),
-                                           ToVkFormat(format.GetFormatType()));
-}
-
 Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
   // Create the pipeline data early so we can access them as needed.
   pipeline_map_[pipeline] = PipelineInfo();
@@ -155,15 +149,18 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
 
   for (const auto& colour_info : pipeline->GetColorAttachments()) {
     auto& fmt = colour_info.buffer->AsFormatBuffer()->GetFormat();
-    if (!VerifyFormatAvailable(fmt, colour_info.buffer->GetBufferType()))
+    if (!device_->IsFormatSupportedByPhysicalDevice(
+            fmt, colour_info.buffer->GetBufferType())) {
       return Result("Vulkan color attachment format is not supported");
+    }
   }
 
   FormatType depth_buffer_format = FormatType::kUnknown;
   if (pipeline->GetDepthBuffer().buffer) {
     const auto& depth_info = pipeline->GetDepthBuffer();
     auto& depth_fmt = depth_info.buffer->AsFormatBuffer()->GetFormat();
-    if (!VerifyFormatAvailable(depth_fmt, depth_info.buffer->GetBufferType()))
+    if (!device_->IsFormatSupportedByPhysicalDevice(
+            depth_fmt, depth_info.buffer->GetBufferType()))
       return Result("Vulkan depth attachment format is not supported");
 
     depth_buffer_format = depth_fmt.GetFormatType();
@@ -178,19 +175,16 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
   std::unique_ptr<Pipeline> vk_pipeline;
   if (pipeline->GetType() == PipelineType::kCompute) {
     vk_pipeline = MakeUnique<ComputePipeline>(
-        device_.get(), device_->GetVkPhysicalDeviceProperties(),
-        device_->GetVkPhysicalMemoryProperties(), engine_data.fence_timeout_ms,
-        stage_create_info);
+        device_.get(), engine_data.fence_timeout_ms, stage_create_info);
     r = vk_pipeline->AsCompute()->Initialize(pool_.get(),
                                              device_->GetVkQueue());
     if (!r.IsSuccess())
       return r;
   } else {
     vk_pipeline = MakeUnique<GraphicsPipeline>(
-        device_.get(), device_->GetVkPhysicalDeviceProperties(),
-        device_->GetVkPhysicalMemoryProperties(),
-        pipeline->GetColorAttachments(), ToVkFormat(depth_buffer_format),
-        engine_data.fence_timeout_ms, stage_create_info);
+        device_.get(), pipeline->GetColorAttachments(),
+        ToVkFormat(depth_buffer_format), engine_data.fence_timeout_ms,
+        stage_create_info);
 
     r = vk_pipeline->AsGraphics()->Initialize(
         pipeline->GetFramebufferWidth(), pipeline->GetFramebufferHeight(),
@@ -205,7 +199,8 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
     auto& fmt = vtex_info.buffer->IsFormatBuffer()
                     ? vtex_info.buffer->AsFormatBuffer()->GetFormat()
                     : Format();
-    if (!VerifyFormatAvailable(fmt, vtex_info.buffer->GetBufferType()))
+    if (!device_->IsFormatSupportedByPhysicalDevice(
+            fmt, vtex_info.buffer->GetBufferType()))
       return Result("Vulkan vertex buffer format is not supported");
 
     if (!info.vertex_buffer)
@@ -428,42 +423,6 @@ Result EngineVulkan::DoBuffer(const BufferCommand* cmd) {
         "device");
   }
   return info.vk_pipeline->AddDescriptor(cmd);
-}
-
-bool EngineVulkan::IsFormatSupportedByPhysicalDevice(
-    BufferType type,
-    VkPhysicalDevice physical_device,
-    VkFormat format) {
-  VkFormatProperties properties = VkFormatProperties();
-  device_->GetPtrs()->vkGetPhysicalDeviceFormatProperties(physical_device,
-                                                          format, &properties);
-
-  VkFormatFeatureFlagBits flag = VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT;
-  bool is_buffer_type_image = false;
-  switch (type) {
-    case BufferType::kColor:
-      flag = VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT;
-      is_buffer_type_image = true;
-      break;
-    case BufferType::kDepth:
-      flag = VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT;
-      is_buffer_type_image = true;
-      break;
-    case BufferType::kSampled:
-      flag = VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
-      is_buffer_type_image = true;
-      break;
-    case BufferType::kVertex:
-      flag = VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT;
-      is_buffer_type_image = false;
-      break;
-    default:
-      return false;
-  }
-
-  return ((is_buffer_type_image ? properties.optimalTilingFeatures
-                                : properties.bufferFeatures) &
-          flag) == flag;
 }
 
 bool EngineVulkan::IsDescriptorSetInBounds(VkPhysicalDevice physical_device,

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -75,7 +75,6 @@ class EngineVulkan : public Engine {
                                          VkFormat format);
   bool IsDescriptorSetInBounds(VkPhysicalDevice physical_device,
                                uint32_t descriptor_set);
-  bool VerifyFormatAvailable(const Format& format, BufferType type);
 
   Result SetShader(amber::Pipeline* pipeline,
                    ShaderType type,

--- a/src/vulkan/frame_buffer.cc
+++ b/src/vulkan/frame_buffer.cc
@@ -44,10 +44,8 @@ FrameBuffer::~FrameBuffer() {
   }
 }
 
-Result FrameBuffer::Initialize(
-    VkRenderPass render_pass,
-    VkFormat depth_format,
-    const VkPhysicalDeviceMemoryProperties& properties) {
+Result FrameBuffer::Initialize(VkRenderPass render_pass,
+                               VkFormat depth_format) {
   std::vector<VkImageView> attachments;
 
   if (!color_attachments_.empty()) {
@@ -68,7 +66,7 @@ Result FrameBuffer::Initialize(
           device_,
           ToVkFormat(
               info->buffer->AsFormatBuffer()->GetFormat().GetFormatType()),
-          VK_IMAGE_ASPECT_COLOR_BIT, width_, height_, depth_, properties));
+          VK_IMAGE_ASPECT_COLOR_BIT, width_, height_, depth_));
 
       Result r =
           color_images_.back()->Initialize(VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
@@ -87,7 +85,7 @@ Result FrameBuffer::Initialize(
             VkFormatHasStencilComponent(depth_format)
                 ? VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT
                 : VK_IMAGE_ASPECT_DEPTH_BIT),
-        width_, height_, depth_, properties);
+        width_, height_, depth_);
 
     Result r =
         depth_image_->Initialize(VK_IMAGE_USAGE_TRANSFER_SRC_BIT |

--- a/src/vulkan/frame_buffer.h
+++ b/src/vulkan/frame_buffer.h
@@ -42,9 +42,7 @@ class FrameBuffer {
       uint32_t height);
   ~FrameBuffer();
 
-  Result Initialize(VkRenderPass render_pass,
-                    VkFormat depth_format,
-                    const VkPhysicalDeviceMemoryProperties& properties);
+  Result Initialize(VkRenderPass render_pass, VkFormat depth_format);
 
   Result ChangeFrameImageLayout(CommandBuffer* command, FrameImageState layout);
 

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -385,16 +385,12 @@ class RenderPassGuard {
 
 GraphicsPipeline::GraphicsPipeline(
     Device* device,
-    const VkPhysicalDeviceProperties& properties,
-    const VkPhysicalDeviceMemoryProperties& memory_properties,
     const std::vector<amber::Pipeline::BufferInfo>& color_buffers,
     VkFormat depth_stencil_format,
     uint32_t fence_timeout_ms,
     const std::vector<VkPipelineShaderStageCreateInfo>& shader_stage_info)
     : Pipeline(PipelineType::kGraphics,
                device,
-               properties,
-               memory_properties,
                fence_timeout_ms,
                shader_stage_info),
       depth_stencil_format_(depth_stencil_format) {
@@ -700,8 +696,7 @@ Result GraphicsPipeline::Initialize(uint32_t width,
     return r;
 
   frame_ = MakeUnique<FrameBuffer>(device_, color_buffers_, width, height);
-  r = frame_->Initialize(render_pass_, depth_stencil_format_,
-                         memory_properties_);
+  r = frame_->Initialize(render_pass_, depth_stencil_format_);
   if (!r.IsSuccess())
     return r;
 
@@ -715,7 +710,7 @@ Result GraphicsPipeline::SendVertexBufferDataIfNeeded(
     VertexBuffer* vertex_buffer) {
   if (!vertex_buffer || vertex_buffer->VertexDataSent())
     return {};
-  return vertex_buffer->SendVertexData(command_.get(), memory_properties_);
+  return vertex_buffer->SendVertexData(command_.get());
 }
 
 Result GraphicsPipeline::SetIndexBuffer(Buffer* buffer) {
@@ -731,8 +726,7 @@ Result GraphicsPipeline::SetIndexBuffer(Buffer* buffer) {
   if (!guard.IsRecording())
     return guard.GetResult();
 
-  Result r =
-      index_buffer_->SendIndexData(command_.get(), memory_properties_, buffer);
+  Result r = index_buffer_->SendIndexData(command_.get(), buffer);
   if (!r.IsSuccess())
     return r;
 

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -41,8 +41,6 @@ class GraphicsPipeline : public Pipeline {
  public:
   GraphicsPipeline(
       Device* device,
-      const VkPhysicalDeviceProperties& properties,
-      const VkPhysicalDeviceMemoryProperties& memory_properties,
       const std::vector<amber::Pipeline::BufferInfo>& color_buffers,
       VkFormat depth_stencil_format,
       uint32_t fence_timeout_ms,

--- a/src/vulkan/index_buffer.cc
+++ b/src/vulkan/index_buffer.cc
@@ -28,10 +28,7 @@ IndexBuffer::IndexBuffer(Device* device) : device_(device) {}
 
 IndexBuffer::~IndexBuffer() = default;
 
-Result IndexBuffer::SendIndexData(
-    CommandBuffer* command,
-    const VkPhysicalDeviceMemoryProperties& properties,
-    Buffer* buffer) {
+Result IndexBuffer::SendIndexData(CommandBuffer* command, Buffer* buffer) {
   if (transfer_buffer_) {
     return Result(
         "IndexBuffer::SendIndexData must be called once when it is created");
@@ -41,7 +38,7 @@ Result IndexBuffer::SendIndexData(
     return Result("IndexBuffer::SendIndexData |buffer| is empty");
 
   transfer_buffer_ =
-      MakeUnique<TransferBuffer>(device_, buffer->GetSizeInBytes(), properties);
+      MakeUnique<TransferBuffer>(device_, buffer->GetSizeInBytes());
   Result r = transfer_buffer_->Initialize(VK_BUFFER_USAGE_INDEX_BUFFER_BIT |
                                           VK_BUFFER_USAGE_TRANSFER_DST_BIT);
   if (!r.IsSuccess())

--- a/src/vulkan/index_buffer.h
+++ b/src/vulkan/index_buffer.h
@@ -43,9 +43,7 @@ class IndexBuffer {
   // Assuming that |buffer_| is nullptr and |values| is not empty,
   // it creates |buffer_| whose size is |sizeof(uint32_t) * values.size()|
   // and coverts |values| as uint32 values and copies them to |buffer_|.
-  Result SendIndexData(CommandBuffer* command,
-                       const VkPhysicalDeviceMemoryProperties& properties,
-                       Buffer* buffer);
+  Result SendIndexData(CommandBuffer* command, Buffer* buffer);
 
   // Bind |buffer_| as index buffer if it is not nullptr.
   Result BindToCommandBuffer(CommandBuffer* command);

--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -37,14 +37,10 @@ const char* kDefaultEntryPointName = "main";
 Pipeline::Pipeline(
     PipelineType type,
     Device* device,
-    const VkPhysicalDeviceProperties& properties,
-    const VkPhysicalDeviceMemoryProperties& memory_properties,
     uint32_t fence_timeout_ms,
     const std::vector<VkPipelineShaderStageCreateInfo>& shader_stage_info)
     : device_(device),
-      memory_properties_(memory_properties),
       pipeline_type_(type),
-      physical_device_properties_(properties),
       shader_stage_info_(shader_stage_info),
       fence_timeout_ms_(fence_timeout_ms) {}
 
@@ -78,8 +74,7 @@ ComputePipeline* Pipeline::AsCompute() {
 }
 
 Result Pipeline::Initialize(CommandPool* pool, VkQueue queue) {
-  push_constant_ = MakeUnique<PushConstant>(
-      device_, physical_device_properties_.limits.maxPushConstantsSize);
+  push_constant_ = MakeUnique<PushConstant>(device_);
 
   command_ = MakeUnique<CommandBuffer>(device_, pool, queue);
   return command_->Initialize();
@@ -319,7 +314,7 @@ Result Pipeline::SendDescriptorDataToDeviceIfNeeded() {
 
     for (auto& info : descriptor_set_info_) {
       for (auto& desc : info.buffer_descriptors) {
-        Result r = desc->CreateResourceIfNeeded(memory_properties_);
+        Result r = desc->CreateResourceIfNeeded();
         if (!r.IsSuccess())
           return r;
       }

--- a/src/vulkan/pipeline.h
+++ b/src/vulkan/pipeline.h
@@ -69,8 +69,6 @@ class Pipeline {
   Pipeline(
       PipelineType type,
       Device* device,
-      const VkPhysicalDeviceProperties& properties,
-      const VkPhysicalDeviceMemoryProperties& memory_properties,
       uint32_t fence_timeout_ms,
       const std::vector<VkPipelineShaderStageCreateInfo>& shader_stage_info);
 
@@ -96,7 +94,6 @@ class Pipeline {
   Result CreateVkPipelineLayout(VkPipelineLayout* pipeline_layout);
 
   Device* device_ = nullptr;
-  VkPhysicalDeviceMemoryProperties memory_properties_;
   std::unique_ptr<CommandBuffer> command_;
 
  private:
@@ -118,7 +115,6 @@ class Pipeline {
   Result CreateDescriptorSets();
 
   PipelineType pipeline_type_;
-  VkPhysicalDeviceProperties physical_device_properties_;
   std::vector<DescriptorSetInfo> descriptor_set_info_;
   std::vector<VkPipelineShaderStageCreateInfo> shader_stage_info_;
 

--- a/src/vulkan/push_constant.cc
+++ b/src/vulkan/push_constant.cc
@@ -24,9 +24,8 @@
 namespace amber {
 namespace vulkan {
 
-PushConstant::PushConstant(Device* device, uint32_t max_push_constant_size)
-    : device_(device), max_push_constant_size_(max_push_constant_size) {
-  memory_.resize(max_push_constant_size_);
+PushConstant::PushConstant(Device* device) : device_(device) {
+  memory_.resize(device_->GetMaxPushConstants());
 }
 
 PushConstant::~PushConstant() = default;
@@ -76,7 +75,7 @@ Result PushConstant::RecordPushConstantVkCommand(
 
   auto push_const_range = GetVkPushConstantRange();
   if (push_const_range.offset + push_const_range.size >
-      max_push_constant_size_) {
+      device_->GetMaxPushConstants()) {
     return Result(
         "PushConstant::RecordPushConstantVkCommand push constant size in bytes "
         "exceeds maxPushConstantsSize of VkPhysicalDeviceLimits");
@@ -117,12 +116,12 @@ Result PushConstant::AddBufferData(const BufferCommand* command) {
 }
 
 Result PushConstant::UpdateMemoryWithInput(const BufferInput& input) {
-  if (static_cast<size_t>(input.offset) >= max_push_constant_size_) {
+  if (static_cast<size_t>(input.offset) >= device_->GetMaxPushConstants()) {
     return Result(
         "Vulkan: UpdateMemoryWithInput BufferInput offset exceeds memory size");
   }
 
-  if (input.size_in_bytes > (max_push_constant_size_ - input.offset)) {
+  if (input.size_in_bytes > (device_->GetMaxPushConstants() - input.offset)) {
     return Result(
         "Vulkan: UpdateMemoryWithInput BufferInput offset + size_in_bytes "
         " exceeds memory size");

--- a/src/vulkan/push_constant.h
+++ b/src/vulkan/push_constant.h
@@ -36,7 +36,7 @@ class PushConstant {
   // maxPushConstantsSize of VkPhysicalDeviceLimits, which is an
   // element of VkPhysicalDeviceProperties getting from
   // vkGetPhysicalDeviceProperties().
-  PushConstant(Device* device, uint32_t max_push_constant_size);
+  explicit PushConstant(Device* device);
   ~PushConstant();
 
   // Return a VkPushConstantRange structure whose shader stage flag
@@ -64,11 +64,6 @@ class PushConstant {
   Result UpdateMemoryWithInput(const BufferInput& input);
 
   Device* device_;
-
-  // maxPushConstantsSize of VkPhysicalDeviceLimits, which is an
-  // element of VkPhysicalDeviceProperties getting from
-  // vkGetPhysicalDeviceProperties().
-  uint32_t max_push_constant_size_ = 0;
 
   // Keep the information of what and how to conduct push constant.
   // These are applied from lowest index to highest index, so that

--- a/src/vulkan/resource.cc
+++ b/src/vulkan/resource.cc
@@ -95,12 +95,8 @@ void BufferInput::UpdateBufferWithValues(void* buffer) const {
   }
 }
 
-Resource::Resource(Device* device,
-                   uint32_t size_in_bytes,
-                   const VkPhysicalDeviceMemoryProperties& properties)
-    : device_(device),
-      size_in_bytes_(size_in_bytes),
-      physical_memory_properties_(properties) {}
+Resource::Resource(Device* device, uint32_t size_in_bytes)
+    : device_(device), size_in_bytes_(size_in_bytes) {}
 
 Resource::~Resource() = default;
 
@@ -137,11 +133,8 @@ uint32_t Resource::ChooseMemory(uint32_t memory_type_bits,
       if (first_non_zero == std::numeric_limits<uint32_t>::max())
         first_non_zero = memory_type_index;
 
-      if ((physical_memory_properties_.memoryTypes[memory_type_index]
-               .propertyFlags &
-           flags) == flags) {
+      if (device_->HasMemoryFlags(memory_type_index, flags))
         return memory_type_index;
-      }
     }
 
     ++memory_type_index;

--- a/src/vulkan/resource.h
+++ b/src/vulkan/resource.h
@@ -54,9 +54,7 @@ class Resource {
   uint32_t GetSizeInBytes() const { return size_in_bytes_; }
 
  protected:
-  Resource(Device* device,
-           uint32_t size,
-           const VkPhysicalDeviceMemoryProperties& properties);
+  Resource(Device* device, uint32_t size);
   Result CreateVkBuffer(VkBuffer* buffer, VkBufferUsageFlags usage);
 
   Result AllocateAndBindMemoryToVkBuffer(VkBuffer buffer,
@@ -77,10 +75,6 @@ class Resource {
   // prevent hazards caused by out-of-order execution.
   void MemoryBarrier(CommandBuffer* command);
 
-  const VkPhysicalDeviceMemoryProperties& GetVkMemoryProperties() const {
-    return physical_memory_properties_;
-  }
-
   uint32_t ChooseMemory(uint32_t memory_type_bits,
                         VkMemoryPropertyFlags flags,
                         bool force_flags);
@@ -95,7 +89,6 @@ class Resource {
       VkBuffer buffer) const;
 
   uint32_t size_in_bytes_ = 0;
-  VkPhysicalDeviceMemoryProperties physical_memory_properties_;
 
   void* memory_ptr_ = nullptr;
 };

--- a/src/vulkan/transfer_buffer.cc
+++ b/src/vulkan/transfer_buffer.cc
@@ -21,29 +21,9 @@
 
 namespace amber {
 namespace vulkan {
-namespace {
 
-bool IsMemoryHostAccessible(const VkPhysicalDeviceMemoryProperties& props,
-                            uint32_t memory_type_index) {
-  return (props.memoryTypes[memory_type_index].propertyFlags &
-          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) ==
-         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
-}
-
-bool IsMemoryHostCoherent(const VkPhysicalDeviceMemoryProperties& props,
-                          uint32_t memory_type_index) {
-  return (props.memoryTypes[memory_type_index].propertyFlags &
-          VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) ==
-         VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-}
-
-}  // namespace
-
-TransferBuffer::TransferBuffer(
-    Device* device,
-    uint32_t size_in_bytes,
-    const VkPhysicalDeviceMemoryProperties& properties)
-    : Resource(device, size_in_bytes, properties) {}
+TransferBuffer::TransferBuffer(Device* device, uint32_t size_in_bytes)
+    : Resource(device, size_in_bytes) {}
 
 TransferBuffer::~TransferBuffer() {
   if (view_ != VK_NULL_HANDLE) {
@@ -74,8 +54,8 @@ Result TransferBuffer::Initialize(const VkBufferUsageFlags usage) {
   if (!r.IsSuccess())
     return r;
 
-  if (!IsMemoryHostAccessible(GetVkMemoryProperties(), memory_type_index) ||
-      !IsMemoryHostCoherent(GetVkMemoryProperties(), memory_type_index)) {
+  if (!device_->IsMemoryHostAccessible(memory_type_index) ||
+      !device_->IsMemoryHostCoherent(memory_type_index)) {
     return Result(
         "Vulkan: TransferBuffer::Initialize() buffer is not host accessible or"
         " not host coherent.");

--- a/src/vulkan/transfer_buffer.h
+++ b/src/vulkan/transfer_buffer.h
@@ -33,9 +33,7 @@ class Device;
 // to |buffer_|.
 class TransferBuffer : public Resource {
  public:
-  TransferBuffer(Device* device,
-                 uint32_t size_in_bytes,
-                 const VkPhysicalDeviceMemoryProperties& properties);
+  TransferBuffer(Device* device, uint32_t size_in_bytes);
   ~TransferBuffer() override;
 
   // Create |buffer_| whose usage is |usage| and allocate |memory_|

--- a/src/vulkan/transfer_image.cc
+++ b/src/vulkan/transfer_image.cc
@@ -50,9 +50,8 @@ TransferImage::TransferImage(Device* device,
                              VkImageAspectFlags aspect,
                              uint32_t x,
                              uint32_t y,
-                             uint32_t z,
-                             const VkPhysicalDeviceMemoryProperties& properties)
-    : Resource(device, x * y * z * VkFormatToByteSize(format), properties),
+                             uint32_t z)
+    : Resource(device, x * y * z * VkFormatToByteSize(format)),
       image_info_(kDefaultImageInfo),
       aspect_(aspect) {
   image_info_.format = format;

--- a/src/vulkan/transfer_image.h
+++ b/src/vulkan/transfer_image.h
@@ -32,8 +32,7 @@ class TransferImage : public Resource {
                 VkImageAspectFlags aspect,
                 uint32_t x,
                 uint32_t y,
-                uint32_t z,
-                const VkPhysicalDeviceMemoryProperties& properties);
+                uint32_t z);
   ~TransferImage() override;
 
   Result Initialize(VkImageUsageFlags usage);

--- a/src/vulkan/vertex_buffer.cc
+++ b/src/vulkan/vertex_buffer.cc
@@ -68,9 +68,7 @@ void VertexBuffer::BindToCommandBuffer(CommandBuffer* command) {
                                              1, &buffer, &offset);
 }
 
-Result VertexBuffer::SendVertexData(
-    CommandBuffer* command,
-    const VkPhysicalDeviceMemoryProperties& properties) {
+Result VertexBuffer::SendVertexData(CommandBuffer* command) {
   if (!is_vertex_data_pending_)
     return Result("Vulkan::Vertices data was already sent");
 
@@ -81,7 +79,7 @@ Result VertexBuffer::SendVertexData(
   uint32_t bytes = Get4BytesAlignedStride() * n_vertices;
 
   if (!transfer_buffer_) {
-    transfer_buffer_ = MakeUnique<TransferBuffer>(device_, bytes, properties);
+    transfer_buffer_ = MakeUnique<TransferBuffer>(device_, bytes);
     Result r = transfer_buffer_->Initialize(VK_BUFFER_USAGE_VERTEX_BUFFER_BIT |
                                             VK_BUFFER_USAGE_TRANSFER_DST_BIT);
     if (!r.IsSuccess())

--- a/src/vulkan/vertex_buffer.h
+++ b/src/vulkan/vertex_buffer.h
@@ -36,8 +36,7 @@ class VertexBuffer {
   explicit VertexBuffer(Device* device);
   ~VertexBuffer();
 
-  Result SendVertexData(CommandBuffer* command,
-                        const VkPhysicalDeviceMemoryProperties& properties);
+  Result SendVertexData(CommandBuffer* command);
   bool VertexDataSent() const { return !is_vertex_data_pending_; }
 
   void SetData(uint8_t location, FormatBuffer* buffer);

--- a/src/vulkan/vertex_buffer_test.cc
+++ b/src/vulkan/vertex_buffer_test.cc
@@ -26,15 +26,10 @@ namespace amber {
 namespace vulkan {
 namespace {
 
-const VkPhysicalDeviceMemoryProperties kMemoryProperties =
-    VkPhysicalDeviceMemoryProperties();
-
 class BufferForTest : public TransferBuffer {
  public:
-  BufferForTest(Device* device,
-                uint32_t size_in_bytes,
-                const VkPhysicalDeviceMemoryProperties& properties)
-      : TransferBuffer(device, size_in_bytes, properties) {
+  BufferForTest(Device* device, uint32_t size_in_bytes)
+      : TransferBuffer(device, size_in_bytes) {
     memory_.resize(4096);
     SetMemoryPtr(memory_.data());
   }
@@ -52,7 +47,7 @@ class VertexBufferTest : public testing::Test {
     vertex_buffer_ = MakeUnique<VertexBuffer>(nullptr);
 
     std::unique_ptr<TransferBuffer> buffer =
-        MakeUnique<BufferForTest>(nullptr, 0U, kMemoryProperties);
+        MakeUnique<BufferForTest>(nullptr, 0U);
     buffer_memory_ = buffer->HostAccessibleMemoryPtr();
     vertex_buffer_->SetBufferForTest(std::move(buffer));
   }
@@ -67,7 +62,7 @@ class VertexBufferTest : public testing::Test {
     buffer->SetData(std::move(values));
 
     vertex_buffer_->SetData(location, buffer.get());
-    return vertex_buffer_->SendVertexData(nullptr, kMemoryProperties);
+    return vertex_buffer_->SendVertexData(nullptr);
   }
 
   Result SetDoubleData(uint8_t location,
@@ -78,7 +73,7 @@ class VertexBufferTest : public testing::Test {
     buffer->SetData(std::move(values));
 
     vertex_buffer_->SetData(location, buffer.get());
-    return vertex_buffer_->SendVertexData(nullptr, kMemoryProperties);
+    return vertex_buffer_->SendVertexData(nullptr);
   }
 
   const void* GetVkBufferPtr() const { return buffer_memory_; }


### PR DESCRIPTION
This Cl removes the methods to retrieve the physical_memory and
physical_device properties from the vulkan::Device class. Methods are
added to query the properties.