### PR TITLE
[vulkan] Use LOAD_OP_LOAD for the default attachment description

### DIFF
--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -27,11 +27,10 @@ namespace vulkan {
 namespace {
 
 const VkAttachmentDescription kDefaultAttachmentDesc = {
-    0,                     /* flags */
-    VK_FORMAT_UNDEFINED,   /* format */
-    VK_SAMPLE_COUNT_1_BIT, /* samples */
-    // TODO(jaebaek): Set up proper loadOp, StoreOp.
-    VK_ATTACHMENT_LOAD_OP_DONT_CARE,      /* loadOp */
+    0,                                    /* flags */
+    VK_FORMAT_UNDEFINED,                  /* format */
+    VK_SAMPLE_COUNT_1_BIT,                /* samples */
+    VK_ATTACHMENT_LOAD_OP_LOAD,           /* loadOp */
     VK_ATTACHMENT_STORE_OP_STORE,         /* storeOp */
     VK_ATTACHMENT_LOAD_OP_LOAD,           /* stencilLoadOp */
     VK_ATTACHMENT_STORE_OP_STORE,         /* stencilStoreOp */

--- a/tests/cases/clear_partial_overwrite.vkscript
+++ b/tests/cases/clear_partial_overwrite.vkscript
@@ -1,0 +1,52 @@
+# Copyright 2019 Google LLC.
+# Copyright 2019 The Khronos Group Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[vertex shader]
+#version 430
+
+layout(location = 0) in vec4 position_in;
+layout(location = 1) in vec4 color_in;
+layout(location = 0) flat out vec4 color_out;
+
+void main() {
+  gl_Position = position_in;
+  color_out = color_in;
+}
+
+[fragment shader]
+#version 430
+
+layout(location = 0) flat in vec4 color_in;
+layout(location = 0) out vec4 color_out;
+
+void main() {
+  color_out = color_in;
+}
+
+[vertex data]
+# Provoking vertices are all red.
+0/R32G32B32_SFLOAT  1/R8G8B8A8_UNORM
+-1.0 -0.5  0.0       255   0    0   255 # line 0
+ 1.0 -0.5  0.0        0   255   0   255
+-1.0  0.5  0.0       255   0    0   255 # line 1
+ 1.0  0.5  0.0        0   255   0   255
+
+[test]
+# Clear color buffer to red and check the drawing doesn't
+# add any other colors from non-provoking vertices.
+clear color 255 0 0 255
+clear
+draw arrays LINE_LIST 0 4
+probe all rgb 1.0, 0.0, 0.0


### PR DESCRIPTION
This CL changes the default attachment description from
LOAD_OP_DONT_CARE to LOAD_OP_LOAD. We want image data in the framebuffer
to persist over render calls.

Fixes #436