### PR TITLE
[amberscript] Allow buffer data on same line as declaration.

### DIFF
--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -850,15 +850,11 @@ Result Parser::ParseBufferInitializerSeries(DataBuffer* buffer,
 }
 
 Result Parser::ParseBufferInitializerData(DataBuffer* buffer) {
-  auto token = tokenizer_->NextToken();
-  if (!token->IsEOL())
-    return Result("extra parameters after BUFFER data command");
-
   auto& type = buffer->GetDatumType();
   bool is_double_type = type.IsFloat() || type.IsDouble();
 
   std::vector<Value> values;
-  for (token = tokenizer_->NextToken();; token = tokenizer_->NextToken()) {
+  for (auto token = tokenizer_->NextToken();; token = tokenizer_->NextToken()) {
     if (token->IsEOL())
       continue;
     if (token->IsEOS())
@@ -866,10 +862,10 @@ Result Parser::ParseBufferInitializerData(DataBuffer* buffer) {
     if (token->IsString() && token->AsString() == "END")
       break;
     if (!token->IsInteger() && !token->IsDouble() && !token->IsHex())
-      return Result("invalid BUFFER data value");
+      return Result("invalid BUFFER data value: " + token->ToOriginalString());
 
     if (!is_double_type && token->IsDouble())
-      return Result("invalid BUFFER data value");
+      return Result("invalid BUFFER data value: " + token->ToOriginalString());
 
     Value v;
     if (is_double_type) {


### PR DESCRIPTION
This CL extends the BUFFER DATA parsing to allow giving the data on the
same line as the declaration. This can make having similar buffers in a
row easier to read.

```
BUFFER my_buffer1 DATA_TYPE uint32 DATA 1 2 3 4 END
BUFFER my_buffer2 DATA_TYPE uint32 DATA 5 6 7 8 END
```