### PR TITLE
[vulkan] simplify image transition code.

### DIFF
--- a/src/vulkan/frame_buffer.h
+++ b/src/vulkan/frame_buffer.h
@@ -42,9 +42,12 @@ class FrameBuffer {
       uint32_t height);
   ~FrameBuffer();
 
-  Result Initialize(VkRenderPass render_pass, const Format& depth_format);
+  Result Initialize(CommandBuffer* command_buffer,
+                    VkRenderPass render_pass,
+                    const Format& depth_format);
 
-  Result ChangeFrameImageLayout(CommandBuffer* command, FrameImageState layout);
+  void ChangeFrameToDrawLayout(CommandBuffer* command);
+  void ChangeFrameToProbeLayout(CommandBuffer* command);
 
   VkFramebuffer GetVkFrameBuffer() const { return frame_; }
   const void* GetColorBufferPtr(size_t idx) const {
@@ -54,7 +57,7 @@ class FrameBuffer {
   // Only record the command for copying the image that backs this
   // framebuffer to the host accessible buffer. The actual submission
   // of the command must be done later.
-  void CopyColorImagesToHost(CommandBuffer* command);
+  void TransferColorImagesToHost(CommandBuffer* command);
 
   void CopyImagesToBuffers();
 
@@ -70,6 +73,7 @@ class FrameBuffer {
   uint32_t width_ = 0;
   uint32_t height_ = 0;
   uint32_t depth_ = 1;
+
   FrameImageState frame_image_layout_ = FrameImageState::kInit;
 };
 

--- a/src/vulkan/transfer_image.cc
+++ b/src/vulkan/transfer_image.cc
@@ -34,12 +34,11 @@ const VkImageCreateInfo kDefaultImageInfo = {
     1,                                   /* arrayLayers */
     VK_SAMPLE_COUNT_1_BIT,               /* samples */
     VK_IMAGE_TILING_OPTIMAL,             /* tiling */
-    VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
-        VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, /* usage */
-    VK_SHARING_MODE_EXCLUSIVE,               /* sharingMode */
-    0,                                       /* queueFamilyIndexCount */
-    nullptr,                                 /* pQueueFamilyIndices */
-    VK_IMAGE_LAYOUT_UNDEFINED,               /* initialLayout */
+    0,                                   /* usage */
+    VK_SHARING_MODE_EXCLUSIVE,           /* sharingMode */
+    0,                                   /* queueFamilyIndexCount */
+    nullptr,                             /* pQueueFamilyIndices */
+    VK_IMAGE_LAYOUT_UNDEFINED,           /* initialLayout */
 };
 
 }  // namespace
@@ -180,11 +179,8 @@ void TransferImage::CopyToHost(CommandBuffer* command) {
   MemoryBarrier(command);
 }
 
-void TransferImage::ChangeLayout(CommandBuffer* command,
-                                 VkImageLayout old_layout,
-                                 VkImageLayout new_layout,
-                                 VkPipelineStageFlags from,
-                                 VkPipelineStageFlags to) {
+VkImageMemoryBarrier TransferImage::CreateBarrier(VkImageLayout old_layout,
+                                                  VkImageLayout new_layout) {
   VkImageMemoryBarrier barrier = VkImageMemoryBarrier();
   barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
   barrier.oldLayout = old_layout;
@@ -254,7 +250,13 @@ void TransferImage::ChangeLayout(CommandBuffer* command,
       barrier.dstAccessMask = 0;
       break;
   }
+  return barrier;
+}
 
+void TransferImage::ImageBarrier(CommandBuffer* command,
+                                 VkImageMemoryBarrier barrier,
+                                 VkPipelineStageFlags from,
+                                 VkPipelineStageFlags to) const {
   device_->GetPtrs()->vkCmdPipelineBarrier(command->GetVkCommandBuffer(), from,
                                            to, 0, 0, NULL, 0, NULL, 1,
                                            &barrier);

--- a/src/vulkan/transfer_image.h
+++ b/src/vulkan/transfer_image.h
@@ -39,11 +39,12 @@ class TransferImage : public Resource {
   Result Initialize(VkImageUsageFlags usage);
   VkImageView GetVkImageView() const { return view_; }
 
-  void ChangeLayout(CommandBuffer* command,
-                    VkImageLayout old_layout,
-                    VkImageLayout new_layout,
+  VkImageMemoryBarrier CreateBarrier(VkImageLayout old_layout,
+                                     VkImageLayout new_layout);
+  void ImageBarrier(CommandBuffer* command,
+                    VkImageMemoryBarrier barrier,
                     VkPipelineStageFlags from,
-                    VkPipelineStageFlags to);
+                    VkPipelineStageFlags to) const;
 
   // Only record the command for copying this image to its secondary
   // host-accessible buffer. The actual submission of the command


### PR DESCRIPTION
This CL splits the ChangeLayout method into a method to change to Draw
mode and a method to change to Probe mode. The framebuffer is always
transitioned to Draw mode after initialization. The RenderPassGuard now
transitions the framebuffer into draw layout on initialize and out of
draw layout on shutdown.