### PR TITLE
Dawn engine: refactor

### DIFF
--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -299,7 +299,7 @@ Result EngineDawn::DoClear(const ClearCommand* command) {
     return result;
 
   // TODO(sarahM0): Adapt this to the case where there might be many colour
-  // attachments. Also whne there is a depth/stencil attachment.
+  // attachments. Also when there is a depth/stencil attachment.
 
   // Record a render pass in a command on the command buffer.
   //

--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -24,6 +24,7 @@
 
 #include "amber/amber_dawn.h"
 #include "dawn/dawncpp.h"
+#include "src/dawn/pipeline_info.h"
 #include "src/format.h"
 #include "src/sleep.h"
 
@@ -32,9 +33,6 @@ namespace dawn {
 
 namespace {
 
-// The dimensions of the framebuffer.  The code also assumes the framebuffer
-// is 2D and does not have any array layers.
-const uint32_t kFramebufferWidth = 250, kFramebufferHeight = 250;
 // The minimum multiple row pitch observed on Dawn on Metal.  Increase this
 // as needed for other Dawn backends.
 const uint32_t kMinimumImageRowPitch = 256;
@@ -46,13 +44,15 @@ const auto kAmberFramebufferFormatType = FormatType::kR8G8B8A8_UNORM;
 // is not null.  Returns a result code.
 Result MakeFramebufferTexture(const ::dawn::Device& device,
                               ::dawn::TextureFormat format,
+                              uint32_t width,
+                              uint32_t height,
                               ::dawn::Texture* result_ptr) {
   assert(device);
   assert(result_ptr);
   ::dawn::TextureDescriptor descriptor;
   descriptor.dimension = ::dawn::TextureDimension::e2D;
-  descriptor.size.width = kFramebufferWidth;
-  descriptor.size.height = kFramebufferHeight;
+  descriptor.size.width = width;
+  descriptor.size.height = height;
   descriptor.size.depth = 1;
   descriptor.arrayLayerCount = 1;
   descriptor.format = format;
@@ -71,17 +71,19 @@ Result MakeFramebufferTexture(const ::dawn::Device& device,
 // |result_ptr|. The buffer will be used as a transfer destination and
 // for mapping-for-read.  Returns a result code.
 Result MakeFramebufferBuffer(const ::dawn::Device& device,
+                             uint32_t width,
+                             uint32_t height,
                              ::dawn::TextureFormat format,
                              ::dawn::Buffer* result_ptr,
                              uint32_t* texel_stride_ptr,
                              uint32_t* row_stride_ptr,
-                             uint32_t* num_rows_ptr,
                              uint32_t* size_ptr) {
   assert(device);
+  assert(width > 0);
+  assert(height > 0);
   assert(result_ptr);
   assert(texel_stride_ptr);
   assert(row_stride_ptr);
-  assert(num_rows_ptr);
   assert(size_ptr);
 
   // TODO(dneto): Handle other formats.
@@ -91,9 +93,7 @@ Result MakeFramebufferBuffer(const ::dawn::Device& device,
   // Number of bytes for each texel in the default format.
   const uint32_t default_texel_bytes = 4;
 
-  const uint32_t num_rows = kFramebufferHeight;
-
-  uint32_t row_stride = default_texel_bytes * kFramebufferWidth;
+  uint32_t row_stride = default_texel_bytes * width;
   {
     // Round up the stride to the minimum image row pitch.
     const uint32_t spillover = row_stride % kMinimumImageRowPitch;
@@ -103,13 +103,12 @@ Result MakeFramebufferBuffer(const ::dawn::Device& device,
   }
 
   ::dawn::BufferDescriptor descriptor;
-  descriptor.size = row_stride * num_rows;
+  descriptor.size = row_stride * height;
   descriptor.usage =
       ::dawn::BufferUsageBit::TransferDst | ::dawn::BufferUsageBit::MapRead;
   *result_ptr = device.CreateBuffer(&descriptor);
   *texel_stride_ptr = default_texel_bytes;
   *row_stride_ptr = row_stride;
-  *num_rows_ptr = num_rows;
   *size_ptr = descriptor.size;
   return {};
 }
@@ -202,7 +201,7 @@ Result EngineDawn::Initialize(EngineConfig* config,
   return {};
 }
 
-Result EngineDawn::CreatePipeline(Pipeline* pipeline) {
+Result EngineDawn::CreatePipeline(::amber::Pipeline* pipeline) {
   for (const auto& shader_info : pipeline->GetShaders()) {
     Result r = SetShader(shader_info.GetShaderType(), shader_info.GetData());
     if (!r.IsSuccess())
@@ -214,7 +213,8 @@ Result EngineDawn::CreatePipeline(Pipeline* pipeline) {
       auto module = module_for_type_[kShaderTypeCompute];
       if (!module)
         return Result("CreatePipeline: no compute shader provided");
-      compute_pipeline_info_ = ComputePipelineInfo(module);
+      pipeline_map_[pipeline].compute_pipeline.reset(
+          new ComputePipelineInfo(pipeline, module));
       break;
     }
 
@@ -230,7 +230,8 @@ Result EngineDawn::CreatePipeline(Pipeline* pipeline) {
         return Result(
             "CreatePipeline: no vertex shader provided for graphics pipeline");
       }
-      render_pipeline_info_ = RenderPipelineInfo(vs, fs);
+      pipeline_map_[pipeline].render_pipeline.reset(
+          new RenderPipelineInfo(pipeline, vs, fs));
       break;
     }
   }
@@ -259,79 +260,95 @@ Result EngineDawn::SetShader(ShaderType type,
 }
 
 Result EngineDawn::DoClearColor(const ClearColorCommand* command) {
-  render_pipeline_info_.clear_color_value = ::dawn::Color{
+  RenderPipelineInfo* render_pipeline = GetRenderPipeline(command);
+  if (!render_pipeline)
+    return Result("ClearColor invoked on invalid or missing render pipeline");
+
+  render_pipeline->clear_color_value = ::dawn::Color{
       command->GetR(), command->GetG(), command->GetB(), command->GetA()};
   return {};
 }
 
 Result EngineDawn::DoClearStencil(const ClearStencilCommand* command) {
-  render_pipeline_info_.clear_stencil_value = command->GetValue();
+  RenderPipelineInfo* render_pipeline = GetRenderPipeline(command);
+  if (!render_pipeline)
+    return Result("ClearStencil invoked on invalid or missing render pipeline");
+
+  render_pipeline->clear_stencil_value = command->GetValue();
   return {};
 }
 
 Result EngineDawn::DoClearDepth(const ClearDepthCommand* command) {
-  render_pipeline_info_.clear_depth_value = command->GetValue();
+  RenderPipelineInfo* render_pipeline = GetRenderPipeline(command);
+  if (!render_pipeline)
+    return Result("ClearDepth invoked on invalid or missing render pipeline");
+
+  render_pipeline->clear_depth_value = command->GetValue();
   return {};
 }
 
 Result EngineDawn::DoClear(const ClearCommand* command) {
-  Result result = CreateRenderObjectsIfNeeded();
+  RenderPipelineInfo* render_pipeline = GetRenderPipeline(command);
+  if (!render_pipeline)
+    return Result("Clear invoked on invalid or missing render pipeline");
+
+  // TODO(dneto): Likely, we can create the render objects during
+  // CreatePipeline.
+  Result result = CreateRenderObjectsIfNeeded(render_pipeline);
   if (!result.IsSuccess())
     return result;
 
-  // TODO(sarahM0): Refactor this code later.  This backend is in transition
-  // between the old design and the new design of how Amber operates.
+  // TODO(sarahM0): Adapt this to the case where there might be many colour
+  // attachments. Also whne there is a depth/stencil attachment.
 
+  // Record a render pass in a command on the command buffer.
+  //
+  // First describe the color attachments, and how they are initialized
+  // via the load op. The load op is "clear" to the clear colour.
   ::dawn::RenderPassColorAttachmentDescriptor color_attachment =
       ::dawn::RenderPassColorAttachmentDescriptor();
-  color_attachment.attachment =
-      render_pipeline_info_.fb_texture.CreateDefaultView();
+  color_attachment.attachment = render_pipeline->fb_texture.CreateDefaultView();
   color_attachment.resolveTarget = nullptr;
-  color_attachment.clearColor = render_pipeline_info_.clear_color_value;
+  color_attachment.clearColor = render_pipeline->clear_color_value;
   color_attachment.loadOp = ::dawn::LoadOp::Clear;
   color_attachment.storeOp = ::dawn::StoreOp::Store;
 
+  // Attach that colour attachment to the render pass.
   ::dawn::RenderPassColorAttachmentDescriptor* rpca[] = {&color_attachment};
   ::dawn::RenderPassDescriptor rpd;
   rpd.colorAttachmentCount = 1;
   rpd.colorAttachments = rpca;
   rpd.depthStencilAttachment = nullptr;
-  ::dawn::RenderPassEncoder pass =
-      command_buffer_builder_.BeginRenderPass(&rpd);
+
+  // Record the render pass as a command.
+  auto encoder = device_->CreateCommandEncoder();
+  ::dawn::RenderPassEncoder pass = encoder.BeginRenderPass(&rpd);
   pass.EndPass();
 
-  // Make sure we have a queue.
-  if (!queue_)
-    queue_ = device_->CreateQueue();
+  // Finish recording the command buffer.  It only has one command.
+  auto command_buffer = encoder.Finish();
 
-  // Now run the commands.
-  ::dawn::Buffer& fb_buffer = render_pipeline_info_.fb_buffer;
-  auto command_buffer = command_buffer_builder_.Finish();
+  // Submit the command.
+  auto queue = device_->CreateQueue();
+  queue.Submit(1, &command_buffer);
 
-  if (render_pipeline_info_.fb_data != nullptr) {
-    fb_buffer.Unmap();
-    render_pipeline_info_.fb_data = nullptr;
-  }
-
-  queue_.Submit(1, &command_buffer);
-
-  auto* pipeline = command->GetPipeline();
-  const std::vector<amber::Pipeline::BufferInfo>& out_color_attachment =
-      pipeline->GetColorAttachments();
-
-  // And any further commands start afresh.
-  DestroyCommandBufferBuilder();
+  // Copy the framebuffer contents back into the host-side framebuffer-buffer.
+  ::dawn::Buffer& fb_buffer = render_pipeline->fb_buffer;
   MapResult map = MapBuffer(*device_, fb_buffer);
-
+  // For now, we assume there is only one colour attachment, and that
+  // corresponds to the framebuffer texture.
+  const std::vector<amber::Pipeline::BufferInfo>& out_color_attachment =
+      render_pipeline->pipeline->GetColorAttachments();
   for (size_t i = 0; i < 1; ++i) {
-    auto& img = map;
     auto& info = out_color_attachment[i];
     auto* values = info.buffer->ValuePtr();
-    values->resize(info.buffer->GetSizeInBytes());
+    values->resize(map.dataLength);
     // TODO(sarahM0): Resolve the difference between the Dawn buffer's size
     // and the Amber buffer's size.
-    std::memcpy(values->data(), img.data, info.buffer->GetSizeInBytes());
+    std::memcpy(values->data(), map.data, map.dataLength);
   }
+  // Always unmap the buffer at the end of the engine's command.
+  fb_buffer.Unmap();
 
   return map.result;
 }
@@ -339,6 +356,7 @@ Result EngineDawn::DoClear(const ClearCommand* command) {
 Result EngineDawn::DoDrawRect(const DrawRectCommand*) {
   Result result;
 
+#if 0
   // Add one more command to the command buffer builder, which is to
   // copy the framebuffer texture to the framebuffer host-side buffer.
   ::dawn::Buffer& fb_buffer = render_pipeline_info_.fb_buffer;
@@ -394,6 +412,8 @@ Result EngineDawn::DoDrawRect(const DrawRectCommand*) {
   MapResult map = MapBuffer(*device_, fb_buffer);
   render_pipeline_info_.fb_data = map.data;
   return map.result;
+#endif
+  return Result("Dawn:DoDrawRect not implemented");
 }
 
 Result EngineDawn::DoDrawArrays(const DrawArraysCommand*) {
@@ -417,64 +437,52 @@ Result EngineDawn::DoBuffer(const BufferCommand*) {
   return Result("Dawn:DoBuffer not implemented");
 }
 
-Result EngineDawn::CreateCommandBufferBuilderIfNeeded() {
-  if (command_buffer_builder_)
-    return {};
-
-  // Create the command buffer builder because it doesn't exist yet.
-  if (!device_) {
-    return Result(
-        "EngineDawn: Can't create command buffer builder: device is not "
-        "initialized");
-  }
-  command_buffer_builder_ = device_->CreateCommandEncoder();
-  if (command_buffer_builder_)
-    return {};
-  return Result("EngineDawn: Can't create command buffer builder");
+Result EngineDawn::CreateRenderObjectsIfNeeded(
+    RenderPipelineInfo* render_pipeline) {
+  return CreateFramebufferIfNeeded(render_pipeline);
 }
 
-void EngineDawn::DestroyCommandBufferBuilder() {
-  command_buffer_builder_ = ::dawn::CommandEncoder();
-}
-
-Result EngineDawn::CreateRenderObjectsIfNeeded() {
-  Result result = CreateCommandBufferBuilderIfNeeded();
-  if (!result.IsSuccess())
-    return result;
-  return CreateFramebufferIfNeeded();
-}
-
-Result EngineDawn::CreateFramebufferIfNeeded() {
+Result EngineDawn::CreateFramebufferIfNeeded(
+    RenderPipelineInfo* render_pipeline) {
   Result result;
+
+  const uint32_t width = render_pipeline->pipeline->GetFramebufferWidth();
+  const uint32_t height = render_pipeline->pipeline->GetFramebufferHeight();
+
+  // First make the Dawn color attachment textures that the render pipeline will
+  // write into.
   {
     ::dawn::Texture fb_texture;
-    result = MakeFramebufferTexture(*device_, kFramebufferFormat, &fb_texture);
+
+    result = MakeFramebufferTexture(*device_, kFramebufferFormat, width, height,
+                                    &fb_texture);
     if (!result.IsSuccess())
       return result;
-    render_pipeline_info_.fb_texture = std::move(fb_texture);
+    render_pipeline->fb_texture = std::move(fb_texture);
   }
 
+  // Now create the Dawn buffer to hold the framebuffer contents, but on the
+  // host side.  This has to match dimensions of the framebuffer, but also
+  // be linearly addressible by the CPU.
   {
     ::dawn::Buffer fb_buffer;
     uint32_t texel_stride = 0;
     uint32_t row_stride = 0;
-    uint32_t num_rows = 0;
     uint32_t size = 0;
     result =
-        MakeFramebufferBuffer(*device_, kFramebufferFormat, &fb_buffer,
-                              &texel_stride, &row_stride, &num_rows, &size);
+        MakeFramebufferBuffer(*device_, width, height, kFramebufferFormat,
+                              &fb_buffer, &texel_stride, &row_stride, &size);
     if (!result.IsSuccess())
       return result;
-    render_pipeline_info_.fb_buffer = std::move(fb_buffer);
-    render_pipeline_info_.fb_texel_stride = texel_stride;
-    render_pipeline_info_.fb_row_stride = row_stride;
-    render_pipeline_info_.fb_num_rows = num_rows;
-    render_pipeline_info_.fb_size = size;
-    render_pipeline_info_.fb_data = nullptr;
+    render_pipeline->fb_buffer = std::move(fb_buffer);
+    render_pipeline->fb_texel_stride = texel_stride;
+    render_pipeline->fb_row_stride = row_stride;
+    render_pipeline->fb_num_rows = height;
+    render_pipeline->fb_size = size;
 
     // TODO(dneto): support other formats
-    render_pipeline_info_.fb_format = ::amber::Format();
-    render_pipeline_info_.fb_format.SetFormatType(kAmberFramebufferFormatType);
+    render_pipeline->fb_format = ::amber::Format();
+    render_pipeline->fb_format.SetFormatType(kAmberFramebufferFormatType);
   }
   return {};
 }

--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -294,7 +294,7 @@ Result EngineDawn::DoClear(const ClearCommand* command) {
 
   // TODO(dneto): Likely, we can create the render objects during
   // CreatePipeline.
-  Result result = CreateRenderObjectsIfNeeded(render_pipeline);
+  Result result = CreateFramebufferIfNeeded(render_pipeline);
   if (!result.IsSuccess())
     return result;
 
@@ -435,11 +435,6 @@ Result EngineDawn::DoPatchParameterVertices(
 
 Result EngineDawn::DoBuffer(const BufferCommand*) {
   return Result("Dawn:DoBuffer not implemented");
-}
-
-Result EngineDawn::CreateRenderObjectsIfNeeded(
-    RenderPipelineInfo* render_pipeline) {
-  return CreateFramebufferIfNeeded(render_pipeline);
 }
 
 Result EngineDawn::CreateFramebufferIfNeeded(

--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -474,10 +474,6 @@ Result EngineDawn::CreateFramebufferIfNeeded(
     render_pipeline->fb_row_stride = row_stride;
     render_pipeline->fb_num_rows = height;
     render_pipeline->fb_size = size;
-
-    // TODO(dneto): support other formats
-    render_pipeline->fb_format = ::amber::Format();
-    render_pipeline->fb_format.SetFormatType(kAmberFramebufferFormatType);
   }
   return {};
 }

--- a/src/dawn/engine_dawn.h
+++ b/src/dawn/engine_dawn.h
@@ -61,7 +61,7 @@ class EngineDawn : public Engine {
   Result DoBuffer(const BufferCommand* cmd) override;
 
  private:
-  // Returns the Dawn-specific render pipepline for the given command,
+  // Returns the Dawn-specific render pipeline for the given command,
   // if it exists.  Returns nullptr otherwise.
   RenderPipelineInfo* GetRenderPipeline(
       const ::amber::PipelineCommand* command) {

--- a/src/dawn/engine_dawn.h
+++ b/src/dawn/engine_dawn.h
@@ -68,15 +68,12 @@ class EngineDawn : public Engine {
     return pipeline_map_[command->GetPipeline()].render_pipeline.get();
   }
 
-  // Creates Dawn objects necessary for a render pipeline.  This creates
-  // a framebuffer texture, a framebuffer buffer, and a command buffer
-  // builder.  Returns a result code.
-  Result CreateRenderObjectsIfNeeded(RenderPipelineInfo* render_pipeline);
   // If they don't already exist, creates the framebuffer texture for use
   // on the device, the buffer on the host that will eventually hold the
   // resulting pixels for use in checking expectations, and bookkeeping info
   // for that host-side buffer.
   Result CreateFramebufferIfNeeded(RenderPipelineInfo* render_pipeline);
+
   Result SetShader(ShaderType type, const std::vector<uint32_t>& data);
 
   ::dawn::Device* device_ = nullptr;  // Borrowed from the engine config.

--- a/src/dawn/engine_dawn.h
+++ b/src/dawn/engine_dawn.h
@@ -74,6 +74,7 @@ class EngineDawn : public Engine {
   // for that host-side buffer.
   Result CreateFramebufferIfNeeded(RenderPipelineInfo* render_pipeline);
 
+  // TODO(dneto): Remove this. Shaders are attached to the pipeline.
   Result SetShader(ShaderType type, const std::vector<uint32_t>& data);
 
   ::dawn::Device* device_ = nullptr;  // Borrowed from the engine config.
@@ -82,6 +83,7 @@ class EngineDawn : public Engine {
   // pipelines.
   std::unordered_map<amber::Pipeline*, ::amber::dawn::Pipeline> pipeline_map_;
 
+  // TODO(dneto): Remove this. Shaders are attached to the pipeline.
   std::unordered_map<ShaderType, ::dawn::ShaderModule, CastHash<ShaderType>>
       module_for_type_;
 };

--- a/src/dawn/pipeline_info.h
+++ b/src/dawn/pipeline_info.h
@@ -57,8 +57,6 @@ struct RenderPipelineInfo {
   uint32_t fb_num_rows = 0;
   // The number of data bytes in the framebuffer host-side buffer.
   uint32_t fb_size = 0;
-  // The framebuffer format.
-  ::amber::Format fb_format;
 
   // TODO(dneto): Record index data
   // TODO(dneto): Record buffer data

--- a/src/dawn/pipeline_info.h
+++ b/src/dawn/pipeline_info.h
@@ -66,8 +66,8 @@ struct RenderPipelineInfo {
 
 struct ComputePipelineInfo {
   ComputePipelineInfo() {}
-  explicit ComputePipelineInfo(::amber::Pipeline* the_pipeline,
-                               ::dawn::ShaderModule comp)
+  ComputePipelineInfo(::amber::Pipeline* the_pipeline,
+                      ::dawn::ShaderModule comp)
       : pipeline(the_pipeline), compute_shader(comp) {}
 
   ::amber::Pipeline* pipeline = nullptr;

--- a/src/dawn/pipeline_info.h
+++ b/src/dawn/pipeline_info.h
@@ -16,6 +16,7 @@
 #define SRC_DAWN_PIPELINE_INFO_H_
 
 #include <cstdint>
+#include <memory>
 #include <utility>
 
 #include "amber/result.h"
@@ -28,8 +29,12 @@ namespace dawn {
 
 struct RenderPipelineInfo {
   RenderPipelineInfo() {}
-  RenderPipelineInfo(::dawn::ShaderModule vert, ::dawn::ShaderModule frag)
-      : vertex_shader(vert), fragment_shader(frag) {}
+  RenderPipelineInfo(::amber::Pipeline* the_pipeline,
+                     ::dawn::ShaderModule vert,
+                     ::dawn::ShaderModule frag)
+      : pipeline(the_pipeline), vertex_shader(vert), fragment_shader(frag) {}
+
+  ::amber::Pipeline* pipeline = nullptr;
 
   ::dawn::ShaderModule vertex_shader;
   ::dawn::ShaderModule fragment_shader;
@@ -52,7 +57,6 @@ struct RenderPipelineInfo {
   uint32_t fb_num_rows = 0;
   // The number of data bytes in the framebuffer host-side buffer.
   uint32_t fb_size = 0;
-  const void* fb_data = nullptr;
   // The framebuffer format.
   ::amber::Format fb_format;
 
@@ -62,10 +66,18 @@ struct RenderPipelineInfo {
 
 struct ComputePipelineInfo {
   ComputePipelineInfo() {}
-  explicit ComputePipelineInfo(::dawn::ShaderModule comp)
-      : compute_shader(comp) {}
+  explicit ComputePipelineInfo(::amber::Pipeline* the_pipeline,
+                               ::dawn::ShaderModule comp)
+      : pipeline(the_pipeline), compute_shader(comp) {}
 
+  ::amber::Pipeline* pipeline = nullptr;
   ::dawn::ShaderModule compute_shader;
+};
+
+// Holds either a render or compute pipeline.
+struct Pipeline {
+  std::unique_ptr<RenderPipelineInfo> render_pipeline;
+  std::unique_ptr<ComputePipelineInfo> compute_pipeline;
 };
 
 }  // namespace dawn

--- a/src/dawn/pipeline_info_test.cc
+++ b/src/dawn/pipeline_info_test.cc
@@ -52,7 +52,6 @@ TEST_F(DawnRenderPipelineInfoTest, DefaultValuesForMembers) {
   EXPECT_EQ(0u, rpi.fb_row_stride);
   EXPECT_EQ(0u, rpi.fb_num_rows);
   EXPECT_EQ(0u, rpi.fb_size);
-  EXPECT_EQ(nullptr, rpi.fb_data);
 }
 
 }  // namespace


### PR DESCRIPTION
- Eliminate lots of state from the Dawn engine
  - The Dawn Queue
    - Create and destroy within a single Amber command execution instead.
  - The Dawn CommandBufferEncoder:
    - Create and destroy within a single Amber command execution instead.
- Map an Amber Pipeline object to a Dawn-engine Pipeline object
- Use the framebuffer width and height from the Amber pipeline object,
  instead of hardcoding it.
- The framebuffer buffer is only mapped during the execution of an Amber
  command, then immediately unmapped afterward.