### PR TITLE
Add Buffer::GetFormat

### DIFF
--- a/src/amber.cc
+++ b/src/amber.cc
@@ -36,10 +36,8 @@ Result GetFrameBuffer(Buffer* buffer, std::vector<Value>* values) {
   values->clear();
 
   // TODO(jaebaek): Support other formats
-  if (buffer->AsFormatBuffer()->GetFormat().GetFormatType() !=
-      kDefaultFramebufferFormat) {
+  if (buffer->GetFormat()->GetFormatType() != kDefaultFramebufferFormat)
     return Result("GetFrameBuffer Unsupported buffer format");
-  }
 
   const uint8_t* cpu_memory = buffer->ValuePtr()->data();
   if (!cpu_memory)

--- a/src/amberscript/parser_bind_test.cc
+++ b/src/amberscript/parser_bind_test.cc
@@ -920,7 +920,7 @@ END
   EXPECT_EQ(2U, bufs[0].binding);
   EXPECT_EQ(static_cast<uint32_t>(0), bufs[0].location);
   EXPECT_EQ(FormatType::kR32G32B32A32_SFLOAT,
-            bufs[0].buffer->AsFormatBuffer()->GetFormat().GetFormatType());
+            bufs[0].buffer->GetFormat()->GetFormatType());
 }
 
 TEST_F(AmberScriptParserTest, BindBufferMissingBindingValue) {

--- a/src/amberscript/parser_buffer_test.cc
+++ b/src/amberscript/parser_buffer_test.cc
@@ -376,8 +376,8 @@ TEST_F(AmberScriptParserTest, BufferFormat) {
   auto* buffer = buffers[0]->AsFormatBuffer();
   EXPECT_EQ("my_buf", buffer->GetName());
 
-  auto& fmt = buffer->GetFormat();
-  auto& comps = fmt.GetComponents();
+  auto fmt = buffer->GetFormat();
+  auto& comps = fmt->GetComponents();
   ASSERT_EQ(4U, comps.size());
 
   EXPECT_EQ(FormatComponentType::kR, comps[0].type);

--- a/src/amberscript/parser_pipeline_test.cc
+++ b/src/amberscript/parser_pipeline_test.cc
@@ -198,8 +198,7 @@ END)";
 
   Buffer* buffer1 = buf1.buffer;
   ASSERT_TRUE(buffer1->IsFormatBuffer());
-  EXPECT_EQ(FormatType::kB8G8R8A8_UNORM,
-            buffer1->AsFormatBuffer()->GetFormat().GetFormatType());
+  EXPECT_EQ(FormatType::kB8G8R8A8_UNORM, buffer1->GetFormat()->GetFormatType());
   EXPECT_EQ(0, buf1.location);
   EXPECT_EQ(250 * 250, buffer1->GetSize());
   EXPECT_EQ(250 * 250 * sizeof(uint32_t), buffer1->GetSizeInBytes());
@@ -210,7 +209,7 @@ END)";
   ASSERT_EQ(buffer1, buf2.buffer);
   EXPECT_EQ(0, buf2.location);
   EXPECT_EQ(FormatType::kB8G8R8A8_UNORM,
-            buf2.buffer->AsFormatBuffer()->GetFormat().GetFormatType());
+            buf2.buffer->GetFormat()->GetFormatType());
   EXPECT_EQ(250 * 250, buf2.buffer->GetSize());
   EXPECT_EQ(250 * 250 * sizeof(uint32_t), buf2.buffer->GetSizeInBytes());
 }

--- a/src/datum_type.cc
+++ b/src/datum_type.cc
@@ -58,7 +58,7 @@ uint32_t DatumType::SizeInBytes() const {
   return bytes;
 }
 
-Format DatumType::AsFormat() const {
+std::unique_ptr<Format> DatumType::AsFormat() const {
   uint32_t bits_per_element = ElementSizeInBytes() * 8;
   static const char* prefixes = "RGBA";
   std::string name = "";
@@ -75,8 +75,7 @@ Format DatumType::AsFormat() const {
     name += "UINT";
 
   FormatParser fp;
-  auto fmt = fp.Parse(name);
-  return *(fmt.get());
+  return fp.Parse(name);
 }
 
 }  // namespace amber

--- a/src/datum_type.h
+++ b/src/datum_type.h
@@ -67,7 +67,7 @@ class DatumType {
   uint32_t ElementSizeInBytes() const;
   uint32_t SizeInBytes() const;
 
-  Format AsFormat() const;
+  std::unique_ptr<Format> AsFormat() const;
 
  private:
   DataType type_ = DataType::kUint8;

--- a/src/datum_type_test.cc
+++ b/src/datum_type_test.cc
@@ -34,7 +34,7 @@ TEST_P(DatumTypeTestFormat, ToFormat) {
   dt.SetRowCount(test_data.row_count);
 
   auto fmt = dt.AsFormat();
-  EXPECT_EQ(test_data.format_type, fmt.GetFormatType());
+  EXPECT_EQ(test_data.format_type, fmt->GetFormatType());
 }
 INSTANTIATE_TEST_CASE_P(
     DatumTypeTestFormat,

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -84,8 +84,8 @@ Result Executor::ExecuteCommand(Engine* engine, Command* cmd) {
     auto* buffer = cmd->AsProbe()->GetBuffer()->AsFormatBuffer();
     assert(buffer);
 
-    Format fmt = buffer->GetFormat();
-    return verifier_.Probe(cmd->AsProbe(), &fmt, buffer->GetTexelStride(),
+    Format* fmt = buffer->GetFormat();
+    return verifier_.Probe(cmd->AsProbe(), fmt, buffer->GetTexelStride(),
                            buffer->GetRowStride(), buffer->GetWidth(),
                            buffer->GetHeight(), buffer->ValuePtr()->data());
   }

--- a/src/vkscript/parser_test.cc
+++ b/src/vkscript/parser_test.cc
@@ -133,7 +133,7 @@ TEST_F(VkScriptParserTest, RequireBlockFramebuffer) {
   EXPECT_EQ(BufferType::kColor, buffers[0]->GetBufferType());
   EXPECT_TRUE(buffers[0]->IsFormatBuffer());
   EXPECT_EQ(FormatType::kR32G32B32A32_SFLOAT,
-            buffers[0]->AsFormatBuffer()->GetFormat().GetFormatType());
+            buffers[0]->GetFormat()->GetFormatType());
 }
 
 TEST_F(VkScriptParserTest, RequireBlockDepthStencil) {
@@ -149,7 +149,7 @@ TEST_F(VkScriptParserTest, RequireBlockDepthStencil) {
   EXPECT_EQ(BufferType::kDepth, buffers[1]->GetBufferType());
   EXPECT_TRUE(buffers[1]->IsFormatBuffer());
   EXPECT_EQ(FormatType::kD24_UNORM_S8_UINT,
-            buffers[1]->AsFormatBuffer()->GetFormat().GetFormatType());
+            buffers[1]->GetFormat()->GetFormatType());
 }
 
 TEST_F(VkScriptParserTest, RequireFbSize) {
@@ -232,12 +232,12 @@ inheritedQueries # line comment
   EXPECT_EQ(BufferType::kColor, buffers[0]->GetBufferType());
   EXPECT_TRUE(buffers[0]->IsFormatBuffer());
   EXPECT_EQ(FormatType::kR32G32B32A32_SFLOAT,
-            buffers[0]->AsFormatBuffer()->GetFormat().GetFormatType());
+            buffers[0]->GetFormat()->GetFormatType());
 
   EXPECT_EQ(BufferType::kDepth, buffers[1]->GetBufferType());
   EXPECT_TRUE(buffers[1]->IsFormatBuffer());
   EXPECT_EQ(FormatType::kD24_UNORM_S8_UINT,
-            buffers[1]->AsFormatBuffer()->GetFormat().GetFormatType());
+            buffers[1]->GetFormat()->GetFormatType());
 
   auto feats = script->GetRequiredFeatures();
   EXPECT_EQ("sparseResidency4Samples", feats[0]);
@@ -337,13 +337,13 @@ TEST_F(VkScriptParserTest, VertexDataHeaderFormatString) {
   ASSERT_EQ(BufferType::kVertex, buffers[1]->GetBufferType());
   EXPECT_EQ(static_cast<uint8_t>(0U), buffers[1]->GetLocation());
   EXPECT_EQ(FormatType::kR32G32_SFLOAT,
-            buffers[1]->AsFormatBuffer()->GetFormat().GetFormatType());
+            buffers[1]->GetFormat()->GetFormatType());
   EXPECT_EQ(static_cast<uint32_t>(0), buffers[1]->GetSize());
 
   ASSERT_EQ(BufferType::kVertex, buffers[2]->GetBufferType());
   EXPECT_EQ(1U, buffers[2]->GetLocation());
   EXPECT_EQ(FormatType::kA8B8G8R8_UNORM_PACK32,
-            buffers[2]->AsFormatBuffer()->GetFormat().GetFormatType());
+            buffers[2]->GetFormat()->GetFormatType());
   EXPECT_EQ(static_cast<uint32_t>(0), buffers[2]->GetSize());
 }
 
@@ -362,10 +362,9 @@ TEST_F(VkScriptParserTest, VertexDataHeaderGlslString) {
   EXPECT_EQ(static_cast<uint8_t>(0U), buffers[1]->GetLocation());
 
   EXPECT_EQ(FormatType::kR32G32_SFLOAT,
-            buffers[1]->AsFormatBuffer()->GetFormat().GetFormatType());
+            buffers[1]->GetFormat()->GetFormatType());
 
-  auto fmt = buffers[1]->AsFormatBuffer()->GetFormat();
-  auto& comps1 = fmt.GetComponents();
+  auto& comps1 = buffers[1]->GetFormat()->GetComponents();
   ASSERT_EQ(2U, comps1.size());
   EXPECT_EQ(FormatMode::kSFloat, comps1[0].mode);
   EXPECT_EQ(FormatMode::kSFloat, comps1[1].mode);
@@ -374,10 +373,8 @@ TEST_F(VkScriptParserTest, VertexDataHeaderGlslString) {
   ASSERT_EQ(BufferType::kVertex, buffers[2]->GetBufferType());
   EXPECT_EQ(1U, buffers[2]->GetLocation());
   EXPECT_EQ(FormatType::kR32G32B32_SINT,
-            buffers[2]->AsFormatBuffer()->GetFormat().GetFormatType());
-
-  auto fmt2 = buffers[2]->AsFormatBuffer()->GetFormat();
-  auto& comps2 = fmt2.GetComponents();
+            buffers[2]->GetFormat()->GetFormatType());
+  auto& comps2 = buffers[2]->GetFormat()->GetComponents();
   ASSERT_EQ(3U, comps2.size());
   EXPECT_EQ(FormatMode::kSInt, comps2[0].mode);
   EXPECT_EQ(FormatMode::kSInt, comps2[1].mode);

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -147,8 +147,8 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
   }
 
   for (const auto& colour_info : pipeline->GetColorAttachments()) {
-    auto& fmt = colour_info.buffer->AsFormatBuffer()->GetFormat();
-    if (!device_->IsFormatSupportedByPhysicalDevice(fmt, colour_info.buffer))
+    auto fmt = colour_info.buffer->GetFormat();
+    if (!device_->IsFormatSupportedByPhysicalDevice(*fmt, colour_info.buffer))
       return Result("Vulkan color attachment format is not supported");
   }
 
@@ -156,7 +156,7 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
   if (pipeline->GetDepthBuffer().buffer) {
     const auto& depth_info = pipeline->GetDepthBuffer();
 
-    depth_fmt = depth_info.buffer->AsFormatBuffer()->GetFormat();
+    depth_fmt = *depth_info.buffer->GetFormat();
     if (!device_->IsFormatSupportedByPhysicalDevice(depth_fmt,
                                                     depth_info.buffer)) {
       return Result("Vulkan depth attachment format is not supported");
@@ -191,12 +191,8 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
   info.vk_pipeline = std::move(vk_pipeline);
 
   for (const auto& vtex_info : pipeline->GetVertexBuffers()) {
-    auto fmt =
-        vtex_info.buffer->IsFormatBuffer()
-            ? vtex_info.buffer->AsFormatBuffer()->GetFormat()
-            : vtex_info.buffer->AsDataBuffer()->GetDatumType().AsFormat();
-
-    if (!device_->IsFormatSupportedByPhysicalDevice(fmt, vtex_info.buffer))
+    auto fmt = vtex_info.buffer->GetFormat();
+    if (!device_->IsFormatSupportedByPhysicalDevice(*fmt, vtex_info.buffer))
       return Result("Vulkan vertex buffer format is not supported");
     if (!info.vertex_buffer)
       info.vertex_buffer = MakeUnique<VertexBuffer>(device_.get());

--- a/src/vulkan/frame_buffer.cc
+++ b/src/vulkan/frame_buffer.cc
@@ -62,8 +62,8 @@ Result FrameBuffer::Initialize(VkRenderPass render_pass,
     attachments.resize(color_attachments_.size());
     for (auto* info : color_attachments_) {
       color_images_.push_back(MakeUnique<TransferImage>(
-          device_, info->buffer->AsFormatBuffer()->GetFormat(),
-          VK_IMAGE_ASPECT_COLOR_BIT, width_, height_, depth_));
+          device_, *info->buffer->GetFormat(), VK_IMAGE_ASPECT_COLOR_BIT,
+          width_, height_, depth_));
 
       Result r = color_images_.back()->Initialize(
           VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -412,7 +412,7 @@ Result GraphicsPipeline::CreateRenderPass() {
   for (const auto* info : color_buffers_) {
     attachment_desc.push_back(kDefaultAttachmentDesc);
     attachment_desc.back().format =
-        device_->GetVkFormat(info->buffer->AsFormatBuffer()->GetFormat());
+        device_->GetVkFormat(*info->buffer->GetFormat());
     attachment_desc.back().initialLayout =
         VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     attachment_desc.back().finalLayout =

--- a/src/vulkan/vertex_buffer.cc
+++ b/src/vulkan/vertex_buffer.cc
@@ -29,27 +29,16 @@ VertexBuffer::VertexBuffer(Device* device) : device_(device) {}
 VertexBuffer::~VertexBuffer() = default;
 
 void VertexBuffer::SetData(uint8_t location, Buffer* buffer) {
-  uint32_t size_in_bytes = 0;
-  VkFormat fmt;
-
-  if (buffer->IsFormatBuffer()) {
-    auto format = buffer->AsFormatBuffer()->GetFormat();
-    size_in_bytes = format.SizeInBytes();
-    fmt = device_->GetVkFormat(format);
-  } else {
-    auto format = buffer->AsDataBuffer()->GetDatumType().AsFormat();
-    size_in_bytes = format.SizeInBytes();
-    fmt = device_->GetVkFormat(format);
-  }
+  auto format = buffer->GetFormat();
 
   vertex_attr_desc_.emplace_back();
   // TODO(jaebaek): Support multiple binding
   vertex_attr_desc_.back().binding = 0;
   vertex_attr_desc_.back().location = location;
   vertex_attr_desc_.back().offset = stride_in_bytes_;
-  vertex_attr_desc_.back().format = fmt;
+  vertex_attr_desc_.back().format = device_->GetVkFormat(*format);
 
-  stride_in_bytes_ += size_in_bytes;
+  stride_in_bytes_ += format->SizeInBytes();
   data_.push_back(buffer);
 }
 
@@ -60,15 +49,7 @@ Result VertexBuffer::FillVertexBufferWithData(CommandBuffer* command) {
   for (uint32_t i = 0; i < GetVertexCount(); ++i) {
     uint8_t* ptr = ptr_in_stride_begin;
     for (uint32_t j = 0; j < data_.size(); ++j) {
-      size_t bytes = 0;
-      if (data_[j]->IsFormatBuffer()) {
-        auto& format = data_[j]->AsFormatBuffer()->GetFormat();
-        bytes = format.SizeInBytes();
-      } else {
-        auto format = data_[j]->AsDataBuffer()->GetDatumType().AsFormat();
-        bytes = format.SizeInBytes();
-      }
-
+      size_t bytes = data_[j]->GetFormat()->SizeInBytes();
       std::memcpy(ptr, data_[j]->GetValues<uint8_t>() + (i * bytes), bytes);
       ptr += bytes;
     }


### PR DESCRIPTION
This CL adds a GetFormat method directly to the Buffer class. The method
is overriden by the two sub-classes. The DataBuffer will cache the
generated format.