### PR TITLE
Convert BufferCommand to use Format.

### DIFF
--- a/src/command.h
+++ b/src/command.h
@@ -407,13 +407,13 @@ class BufferCommand : public PipelineCommand {
   void SetSize(uint32_t size) { size_ = size; }
   uint32_t GetSize() const { return size_; }
 
-  void SetDatumType(const DatumType& type) { datum_type_ = type; }
-  const DatumType& GetDatumType() const { return datum_type_; }
+  void SetFormat(std::unique_ptr<Format> fmt) { format_ = std::move(fmt); }
+  Format* GetFormat() const { return format_.get(); }
 
   void SetValues(std::vector<Value>&& values) {
     values_ = std::move(values);
-    size_ = static_cast<uint32_t>(values_.size() * datum_type_.SizeInBytes()) /
-            datum_type_.ColumnCount() / datum_type_.RowCount();
+    size_ = static_cast<uint32_t>(values_.size() * format_->SizeInBytes()) /
+            format_->ColumnCount() / format_->RowCount();
   }
   const std::vector<Value>& GetValues() const { return values_; }
 
@@ -428,7 +428,7 @@ class BufferCommand : public PipelineCommand {
   uint32_t binding_num_ = 0;
   uint32_t size_ = 0;
   uint32_t offset_ = 0;
-  DatumType datum_type_;
+  std::unique_ptr<Format> format_;
   std::vector<Value> values_;
 };
 

--- a/src/datum_type.cc
+++ b/src/datum_type.cc
@@ -82,6 +82,8 @@ std::unique_ptr<Format> DatumType::AsFormat() const {
     fmt->SetFormatType(FormatType::kUnknown);
     fmt->SetColumnCount(column_count_);
   }
+  // Always pretend to be std140 as that's what datum type does.
+  fmt->SetIsStd140();
 
   return fmt;
 }

--- a/src/format.cc
+++ b/src/format.cc
@@ -27,7 +27,11 @@ uint32_t Format::SizeInBytes() const {
   for (const auto& comp : components_)
     bits += comp.num_bits;
 
-  return (bits / 8) * column_count_;
+  if (is_std140_ && components_.size() == 3)
+    bits += components_[0].num_bits;
+
+  uint32_t bytes_per_element = bits / 8;
+  return bytes_per_element * column_count_;
 }
 
 bool Format::AreAllComponents(FormatMode mode, uint32_t bits) const {

--- a/src/format.h
+++ b/src/format.h
@@ -44,6 +44,9 @@ class Format {
   void SetFormatType(FormatType type) { type_ = type; }
   FormatType GetFormatType() const { return type_; }
 
+  void SetIsStd140() { is_std140_ = true; }
+  bool IsStd140() const { return is_std140_; }
+
   /// Set the number of bytes this format is packed into, if provided.
   void SetPackSize(uint8_t size_in_bytes) {
     pack_size_in_bytes_ = size_in_bytes;
@@ -86,6 +89,7 @@ class Format {
   bool AreAllComponents(FormatMode mode, uint32_t bits) const;
 
   FormatType type_ = FormatType::kUnknown;
+  bool is_std140_ = false;
   uint8_t pack_size_in_bytes_ = 0;
   uint32_t column_count_ = 1;
   std::vector<Component> components_;

--- a/src/vkscript/command_parser.h
+++ b/src/vkscript/command_parser.h
@@ -89,7 +89,7 @@ class CommandParser {
   Result TokenToDouble(Token* token, double* val) const;
   Result ParseBoolean(const std::string& str, bool* result);
   Result ParseValues(const std::string& name,
-                     const DatumType& type,
+                     Format* fmt,
                      std::vector<Value>* values,
                      bool use_std430_layout);
 

--- a/src/vkscript/command_parser_test.cc
+++ b/src/vkscript/command_parser_test.cc
@@ -3094,10 +3094,10 @@ TEST_F(CommandParserTest, SSBOSubdataWithFloat) {
   EXPECT_EQ(16U, cmd->GetSize());
   ASSERT_TRUE(cmd->IsSubdata());
 
-  const auto& type = cmd->GetDatumType();
-  EXPECT_TRUE(type.IsFloat());
-  EXPECT_EQ(1U, type.ColumnCount());
-  EXPECT_EQ(3U, type.RowCount());
+  auto* fmt = cmd->GetFormat();
+  EXPECT_TRUE(fmt->IsFloat());
+  EXPECT_EQ(1U, fmt->ColumnCount());
+  EXPECT_EQ(3U, fmt->RowCount());
 
   const auto& values = cmd->GetValues();
   std::vector<float> results = {2.3f, 4.2f, 1.2f};
@@ -3139,10 +3139,10 @@ TEST_F(CommandParserTest, SSBOSubdataWithDescriptorSet) {
   EXPECT_EQ(16U, cmd->GetOffset());
   EXPECT_EQ(16U, cmd->GetSize());
 
-  const auto& type = cmd->GetDatumType();
-  EXPECT_TRUE(type.IsFloat());
-  EXPECT_EQ(1U, type.ColumnCount());
-  EXPECT_EQ(3U, type.RowCount());
+  auto* fmt = cmd->GetFormat();
+  EXPECT_TRUE(fmt->IsFloat());
+  EXPECT_EQ(1U, fmt->ColumnCount());
+  EXPECT_EQ(3U, fmt->RowCount());
 
   const auto& values = cmd->GetValues();
   std::vector<float> results = {2.3f, 4.2f, 1.2f};
@@ -3173,10 +3173,10 @@ TEST_F(CommandParserTest, SSBOSubdataWithInts) {
   EXPECT_EQ(8U, cmd->GetOffset());
   EXPECT_EQ(8U, cmd->GetSize());
 
-  const auto& type = cmd->GetDatumType();
-  EXPECT_TRUE(type.IsInt16());
-  EXPECT_EQ(1U, type.ColumnCount());
-  EXPECT_EQ(3U, type.RowCount());
+  auto* fmt = cmd->GetFormat();
+  EXPECT_TRUE(fmt->IsInt16());
+  EXPECT_EQ(1U, fmt->ColumnCount());
+  EXPECT_EQ(3U, fmt->RowCount());
 
   const auto& values = cmd->GetValues();
   std::vector<int16_t> results = {2, 4, 1};
@@ -3207,10 +3207,10 @@ TEST_F(CommandParserTest, SSBOSubdataWithMultipleVectors) {
   EXPECT_EQ(8U, cmd->GetOffset());
   EXPECT_EQ(16U, cmd->GetSize());
 
-  const auto& type = cmd->GetDatumType();
-  EXPECT_TRUE(type.IsInt16());
-  EXPECT_EQ(1U, type.ColumnCount());
-  EXPECT_EQ(3U, type.RowCount());
+  auto* fmt = cmd->GetFormat();
+  EXPECT_TRUE(fmt->IsInt16());
+  EXPECT_EQ(1U, fmt->ColumnCount());
+  EXPECT_EQ(3U, fmt->RowCount());
 
   const auto& values = cmd->GetValues();
   std::vector<int16_t> results = {2, 4, 1, 3, 6, 8};
@@ -3340,10 +3340,10 @@ TEST_F(CommandParserTest, Uniform) {
   EXPECT_EQ(32U, cmd->GetOffset());
   EXPECT_EQ(16U, cmd->GetSize());
 
-  const auto& type = cmd->GetDatumType();
-  EXPECT_TRUE(type.IsFloat());
-  EXPECT_EQ(1U, type.ColumnCount());
-  EXPECT_EQ(3U, type.RowCount());
+  auto* fmt = cmd->GetFormat();
+  EXPECT_TRUE(fmt->IsFloat());
+  EXPECT_EQ(1U, fmt->ColumnCount());
+  EXPECT_EQ(3U, fmt->RowCount());
 
   const auto& values = cmd->GetValues();
   std::vector<float> results = {2.1f, 3.2f, 4.3f};
@@ -3382,10 +3382,10 @@ TEST_F(CommandParserTest, UniformWithContinuation) {
   EXPECT_EQ(16U, cmd->GetOffset());
   EXPECT_EQ(32U, cmd->GetSize());
 
-  const auto& type = cmd->GetDatumType();
-  EXPECT_TRUE(type.IsFloat());
-  EXPECT_EQ(1U, type.ColumnCount());
-  EXPECT_EQ(3U, type.RowCount());
+  auto* fmt = cmd->GetFormat();
+  EXPECT_TRUE(fmt->IsFloat());
+  EXPECT_EQ(1U, fmt->ColumnCount());
+  EXPECT_EQ(3U, fmt->RowCount());
 
   const auto& values = cmd->GetValues();
   std::vector<float> results = {2.1f, 3.2f, 4.3f, 5.4f, 6.7f, 8.9f};
@@ -3460,10 +3460,10 @@ TEST_F(CommandParserTest, UniformUBO) {
   EXPECT_EQ(static_cast<uint32_t>(0), cmd->GetOffset());
   EXPECT_EQ(16U, cmd->GetSize());
 
-  const auto& type = cmd->GetDatumType();
-  EXPECT_TRUE(type.IsFloat());
-  EXPECT_EQ(1U, type.ColumnCount());
-  EXPECT_EQ(3U, type.RowCount());
+  auto* fmt = cmd->GetFormat();
+  EXPECT_TRUE(fmt->IsFloat());
+  EXPECT_EQ(1U, fmt->ColumnCount());
+  EXPECT_EQ(3U, fmt->RowCount());
 
   const auto& values = cmd->GetValues();
   std::vector<float> results = {2.1f, 3.2f, 4.3f};
@@ -3504,10 +3504,10 @@ TEST_F(CommandParserTest, UniformUBOWithDescriptorSet) {
   EXPECT_EQ(16U, cmd->GetOffset());
   EXPECT_EQ(16U, cmd->GetSize());
 
-  const auto& type = cmd->GetDatumType();
-  EXPECT_TRUE(type.IsFloat());
-  EXPECT_EQ(1U, type.ColumnCount());
-  EXPECT_EQ(3U, type.RowCount());
+  auto* fmt = cmd->GetFormat();
+  EXPECT_TRUE(fmt->IsFloat());
+  EXPECT_EQ(1U, fmt->ColumnCount());
+  EXPECT_EQ(3U, fmt->RowCount());
 
   const auto& values = cmd->GetValues();
   std::vector<float> results = {2.1f, 3.2f, 4.3f};

--- a/src/vulkan/buffer_descriptor.cc
+++ b/src/vulkan/buffer_descriptor.cc
@@ -146,7 +146,7 @@ void BufferDescriptor::UpdateDescriptorSetIfNeeded(
   is_descriptor_set_update_needed_ = false;
 }
 
-Result BufferDescriptor::AddToBuffer(DataType type,
+Result BufferDescriptor::AddToBuffer(Format* fmt,
                                      uint32_t offset,
                                      uint32_t size_in_bytes,
                                      const std::vector<Value>& values) {
@@ -158,7 +158,7 @@ Result BufferDescriptor::AddToBuffer(DataType type,
     amber_buffer_->SetSize(offset + size_in_bytes);
   }
 
-  BufferInput in{offset, size_in_bytes, type, values};
+  BufferInput in{offset, size_in_bytes, fmt, values};
   in.UpdateBufferWithValues(amber_buffer_->ValuePtr()->data());
 
   return {};

--- a/src/vulkan/buffer_descriptor.h
+++ b/src/vulkan/buffer_descriptor.h
@@ -66,7 +66,7 @@ class BufferDescriptor {
   Result MoveResourceToBufferOutput();
   void UpdateDescriptorSetIfNeeded(VkDescriptorSet descriptor_set);
 
-  Result AddToBuffer(DataType type,
+  Result AddToBuffer(Format* fmt,
                      uint32_t offset,
                      uint32_t size_in_bytes,
                      const std::vector<Value>& values);

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -222,7 +222,7 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
     cmd->SetDescriptorSet(buf_info.descriptor_set);
     cmd->SetBinding(buf_info.binding);
     cmd->SetBuffer(buf_info.buffer);
-    cmd->SetDatumType(buf_info.buffer->AsDataBuffer()->GetDatumType());
+    cmd->SetFormat(buf_info.buffer->AsDataBuffer()->GetDatumType().AsFormat());
 
     r = info.vk_pipeline->AddDescriptor(cmd.get());
     if (!r.IsSuccess())

--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -300,9 +300,8 @@ Result Pipeline::AddDescriptor(const BufferCommand* cmd) {
 
   if (!cmd->GetValues().empty()) {
     auto* buf_desc = static_cast<BufferDescriptor*>(desc);
-    Result r =
-        buf_desc->AddToBuffer(cmd->GetDatumType().GetType(), cmd->GetOffset(),
-                              cmd->GetSize(), cmd->GetValues());
+    Result r = buf_desc->AddToBuffer(cmd->GetFormat(), cmd->GetOffset(),
+                                     cmd->GetSize(), cmd->GetValues());
     if (!r.IsSuccess())
       return r;
   }

--- a/src/vulkan/push_constant.cc
+++ b/src/vulkan/push_constant.cc
@@ -107,7 +107,7 @@ Result PushConstant::AddBufferData(const BufferCommand* command) {
         "PushConstant::AddBufferData BufferCommand type is not push constant");
 
   push_constant_data_.emplace_back();
-  push_constant_data_.back().type = command->GetDatumType().GetType();
+  push_constant_data_.back().format = command->GetFormat();
   push_constant_data_.back().offset = command->GetOffset();
   push_constant_data_.back().size_in_bytes = command->GetSize();
   push_constant_data_.back().values = command->GetValues();

--- a/src/vulkan/resource.cc
+++ b/src/vulkan/resource.cc
@@ -60,38 +60,26 @@ void SetValuesForBuffer(void* buffer, const std::vector<Value>& values) {
 
 void BufferInput::UpdateBufferWithValues(void* buffer) const {
   uint8_t* ptr = static_cast<uint8_t*>(buffer) + offset;
-  switch (type) {
-    case DataType::kInt8:
-      SetValuesForBuffer<int8_t>(ptr, values);
-      break;
-    case DataType::kUint8:
-      SetValuesForBuffer<uint8_t>(ptr, values);
-      break;
-    case DataType::kInt16:
-      SetValuesForBuffer<int16_t>(ptr, values);
-      break;
-    case DataType::kUint16:
-      SetValuesForBuffer<uint16_t>(ptr, values);
-      break;
-    case DataType::kInt32:
-      SetValuesForBuffer<int32_t>(ptr, values);
-      break;
-    case DataType::kUint32:
-      SetValuesForBuffer<uint32_t>(ptr, values);
-      break;
-    case DataType::kInt64:
-      SetValuesForBuffer<int64_t>(ptr, values);
-      break;
-    case DataType::kUint64:
-      SetValuesForBuffer<uint64_t>(ptr, values);
-      break;
-    case DataType::kFloat:
-      SetValuesForBuffer<float>(ptr, values);
-      break;
-    case DataType::kDouble:
-      SetValuesForBuffer<double>(ptr, values);
-      break;
-  }
+  if (format->IsInt8())
+    SetValuesForBuffer<int8_t>(ptr, values);
+  else if (format->IsUint8())
+    SetValuesForBuffer<uint8_t>(ptr, values);
+  else if (format->IsInt16())
+    SetValuesForBuffer<int16_t>(ptr, values);
+  else if (format->IsUint16())
+    SetValuesForBuffer<uint16_t>(ptr, values);
+  else if (format->IsInt32())
+    SetValuesForBuffer<int32_t>(ptr, values);
+  else if (format->IsUint32())
+    SetValuesForBuffer<uint32_t>(ptr, values);
+  else if (format->IsInt64())
+    SetValuesForBuffer<int64_t>(ptr, values);
+  else if (format->IsUint64())
+    SetValuesForBuffer<uint64_t>(ptr, values);
+  else if (format->IsFloat())
+    SetValuesForBuffer<float>(ptr, values);
+  else if (format->IsDouble())
+    SetValuesForBuffer<double>(ptr, values);
 }
 
 Resource::Resource(Device* device, uint32_t size_in_bytes)

--- a/src/vulkan/resource.h
+++ b/src/vulkan/resource.h
@@ -37,8 +37,8 @@ struct BufferInput {
 
   uint32_t offset;
   uint32_t size_in_bytes;
-  DataType type;              // Type of |values|.
-  std::vector<Value> values;  // Data whose type is |type|.
+  Format* format;
+  std::vector<Value> values;
 };
 
 // Class for Vulkan resources. Its children are Vulkan Buffer, Vulkan Image,


### PR DESCRIPTION
This Cl moves the buffer command to use a Format object instead of a
Datum object.