### PR TITLE
Convert ProbeSSBO to use Format objects.

### DIFF
--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -1208,7 +1208,7 @@ Result Parser::ParseExpect() {
     auto probe = MakeUnique<ProbeSSBOCommand>(buffer);
     probe->SetLine(line);
     probe->SetComparator(ToComparator(token->AsString()));
-    probe->SetDatumType(buffer->AsDataBuffer()->GetDatumType());
+    probe->SetFormat(buffer->AsDataBuffer()->GetDatumType().AsFormat());
     probe->SetOffset(static_cast<uint32_t>(x));
 
     std::vector<Value> values;

--- a/src/amberscript/parser_expect_test.cc
+++ b/src/amberscript/parser_expect_test.cc
@@ -654,7 +654,7 @@ EXPECT orig_buf IDX 5 EQ 11)";
   auto* probe = cmd->AsProbeSSBO();
   EXPECT_EQ(ProbeSSBOCommand::Comparator::kEqual, probe->GetComparator());
   EXPECT_EQ(5U, probe->GetOffset());
-  EXPECT_TRUE(probe->GetDatumType().IsInt32());
+  EXPECT_TRUE(probe->GetFormat()->IsInt32());
   ASSERT_EQ(1U, probe->GetValues().size());
   EXPECT_EQ(11U, probe->GetValues()[0].AsInt32());
 }

--- a/src/command.h
+++ b/src/command.h
@@ -25,7 +25,6 @@
 #include "amber/value.h"
 #include "src/buffer.h"
 #include "src/command_data.h"
-#include "src/datum_type.h"
 #include "src/pipeline_data.h"
 
 namespace amber {
@@ -360,8 +359,8 @@ class ProbeSSBOCommand : public Probe {
   void SetOffset(uint32_t offset) { offset_ = offset; }
   uint32_t GetOffset() const { return offset_; }
 
-  void SetDatumType(const DatumType& type) { datum_type_ = type; }
-  const DatumType& GetDatumType() const { return datum_type_; }
+  void SetFormat(std::unique_ptr<Format> fmt) { format_ = std::move(fmt); }
+  Format* GetFormat() const { return format_.get(); }
 
   void SetValues(std::vector<Value>&& values) { values_ = std::move(values); }
   const std::vector<Value>& GetValues() const { return values_; }
@@ -371,7 +370,7 @@ class ProbeSSBOCommand : public Probe {
   uint32_t descriptor_set_id_ = 0;
   uint32_t binding_num_ = 0;
   uint32_t offset_ = 0;
-  DatumType datum_type_;
+  std::unique_ptr<Format> format_;
   std::vector<Value> values_;
 };
 

--- a/src/verifier.cc
+++ b/src/verifier.cc
@@ -25,6 +25,7 @@
 namespace amber {
 namespace {
 
+const uint8_t kBitsPerByte = 8;
 const double kEpsilon = 0.000001;
 const double kDefaultTexelTolerance = 0.002;
 
@@ -36,13 +37,13 @@ void CopyBitsOfMemoryToBuffer(uint8_t* dst,
                               uint8_t bits) {
   while (src_bit_offset > static_cast<uint8_t>(7)) {
     ++src;
-    src_bit_offset = static_cast<uint8_t>(src_bit_offset - 8);
+    src_bit_offset = static_cast<uint8_t>(src_bit_offset - kBitsPerByte);
   }
 
   // Number of bytes greater than or equal to |(src_bit_offset + bits) / 8|.
   const uint8_t size_in_bytes =
-      static_cast<uint8_t>((src_bit_offset + bits + 7) / 8);
-  assert(size_in_bytes <= static_cast<uint8_t>(8));
+      static_cast<uint8_t>((src_bit_offset + bits + 7) / kBitsPerByte);
+  assert(size_in_bytes <= static_cast<uint8_t>(kBitsPerByte));
 
   uint64_t data = 0;
   uint8_t* ptr = reinterpret_cast<uint8_t*>(&data);
@@ -54,7 +55,7 @@ void CopyBitsOfMemoryToBuffer(uint8_t* dst,
   if (bits != 64)
     data &= (1ULL << bits) - 1ULL;
 
-  std::memcpy(dst, &data, static_cast<size_t>((bits + 7) / 8));
+  std::memcpy(dst, &data, static_cast<size_t>((bits + 7) / kBitsPerByte));
 }
 
 // Convert float |value| whose size is 16 bits to 32 bits float
@@ -649,8 +650,8 @@ Result Verifier::ProbeSSBO(const ProbeSSBOCommand* command,
 
   auto* fmt = command->GetFormat();
   // TODO(dsinclair): This assumes that all components are the same number
-  // of bits which may not alway shold.
-  size_t bytes_per_elem = fmt->GetComponents()[0].num_bits / 8;
+  // of bits which may not always hold.
+  size_t bytes_per_elem = fmt->GetComponents()[0].num_bits / kBitsPerByte;
   size_t offset = static_cast<size_t>(command->GetOffset());
   if (values.size() * bytes_per_elem + offset > size_in_bytes) {
     return Result(

--- a/src/verifier.cc
+++ b/src/verifier.cc
@@ -647,8 +647,10 @@ Result Verifier::ProbeSSBO(const ProbeSSBOCommand* command,
                                 "while expected data is not");
   }
 
-  const auto& datum_type = command->GetDatumType();
-  size_t bytes_per_elem = datum_type.ElementSizeInBytes();
+  auto* fmt = command->GetFormat();
+  // TODO(dsinclair): This assumes that all components are the same number
+  // of bits which may not alway shold.
+  size_t bytes_per_elem = fmt->GetComponents()[0].num_bits / 8;
   size_t offset = static_cast<size_t>(command->GetOffset());
   if (values.size() * bytes_per_elem + offset > size_in_bytes) {
     return Result(
@@ -663,25 +665,25 @@ Result Verifier::ProbeSSBO(const ProbeSSBOCommand* command,
   }
 
   const uint8_t* ptr = static_cast<const uint8_t*>(cpu_memory) + offset;
-  if (datum_type.IsInt8())
+  if (fmt->IsInt8())
     return CheckValue<int8_t>(command, ptr, values);
-  if (datum_type.IsUint8())
+  if (fmt->IsUint8())
     return CheckValue<uint8_t>(command, ptr, values);
-  if (datum_type.IsInt16())
+  if (fmt->IsInt16())
     return CheckValue<int16_t>(command, ptr, values);
-  if (datum_type.IsUint16())
+  if (fmt->IsUint16())
     return CheckValue<uint16_t>(command, ptr, values);
-  if (datum_type.IsInt32())
+  if (fmt->IsInt32())
     return CheckValue<int32_t>(command, ptr, values);
-  if (datum_type.IsUint32())
+  if (fmt->IsUint32())
     return CheckValue<uint32_t>(command, ptr, values);
-  if (datum_type.IsInt64())
+  if (fmt->IsInt64())
     return CheckValue<int64_t>(command, ptr, values);
-  if (datum_type.IsUint64())
+  if (fmt->IsUint64())
     return CheckValue<uint64_t>(command, ptr, values);
-  if (datum_type.IsFloat())
+  if (fmt->IsFloat())
     return CheckValue<float>(command, ptr, values);
-  if (datum_type.IsDouble())
+  if (fmt->IsDouble())
     return CheckValue<double>(command, ptr, values);
 
   return Result("Line " + std::to_string(command->GetLine()) +

--- a/src/verifier_test.cc
+++ b/src/verifier_test.cc
@@ -22,7 +22,7 @@
 #include "amber/value.h"
 #include "gtest/gtest.h"
 #include "src/command.h"
-#include "src/datum_type.h"
+#include "src/format_parser.h"
 #include "src/make_unique.h"
 #include "src/pipeline.h"
 
@@ -699,10 +699,8 @@ TEST_F(VerifierTest, ProbeSSBOUint8Single) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kUint8);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R8_UINT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -724,10 +722,8 @@ TEST_F(VerifierTest, ProbeSSBOUint8Multiple) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kUint8);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R8_UINT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -750,10 +746,8 @@ TEST_F(VerifierTest, ProbeSSBOUint8Many) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kUint8);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R8_UINT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -781,10 +775,8 @@ TEST_F(VerifierTest, ProbeSSBOUint32Single) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kUint32);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R32_UINT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -806,10 +798,8 @@ TEST_F(VerifierTest, ProbeSSBOUint32Multiple) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kUint32);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R32_UINT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -833,10 +823,8 @@ TEST_F(VerifierTest, ProbeSSBOUint32Many) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kUint32);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R32_UINT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -864,10 +852,8 @@ TEST_F(VerifierTest, ProbeSSBOFloatSingle) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kFloat);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R32_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -889,10 +875,8 @@ TEST_F(VerifierTest, ProbeSSBOFloatMultiple) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kFloat);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R32_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -916,10 +900,8 @@ TEST_F(VerifierTest, ProbeSSBOFloatMany) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kFloat);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R32_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -947,10 +929,8 @@ TEST_F(VerifierTest, ProbeSSBODoubleSingle) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -972,10 +952,8 @@ TEST_F(VerifierTest, ProbeSSBODoubleMultiple) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -999,10 +977,8 @@ TEST_F(VerifierTest, ProbeSSBODoubleMany) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -1030,10 +1006,8 @@ TEST_F(VerifierTest, ProbeSSBOEqualFail) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -1059,10 +1033,8 @@ TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithAbsoluteTolerance) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kFuzzyEqual);
 
   std::vector<Probe::Tolerance> tolerances;
@@ -1095,10 +1067,8 @@ TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithAbsoluteToleranceFail) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kFuzzyEqual);
 
   std::vector<Probe::Tolerance> tolerances;
@@ -1128,10 +1098,8 @@ TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithRelativeTolerance) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kFuzzyEqual);
 
   std::vector<Probe::Tolerance> tolerances;
@@ -1164,10 +1132,8 @@ TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithRelativeToleranceFail) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kFuzzyEqual);
 
   std::vector<Probe::Tolerance> tolerances;
@@ -1197,10 +1163,8 @@ TEST_F(VerifierTest, ProbeSSBONotEqual) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kNotEqual);
 
   std::vector<Value> values;
@@ -1224,10 +1188,8 @@ TEST_F(VerifierTest, ProbeSSBONotEqualFail) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kNotEqual);
 
   std::vector<Value> values;
@@ -1253,10 +1215,8 @@ TEST_F(VerifierTest, ProbeSSBOLess) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kLess);
 
   std::vector<Value> values;
@@ -1280,10 +1240,8 @@ TEST_F(VerifierTest, ProbeSSBOLessFail) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kLess);
 
   std::vector<Value> values;
@@ -1309,10 +1267,8 @@ TEST_F(VerifierTest, ProbeSSBOLessOrEqual) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kLessOrEqual);
 
   std::vector<Value> values;
@@ -1336,10 +1292,8 @@ TEST_F(VerifierTest, ProbeSSBOLessOrEqualFail) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kLessOrEqual);
 
   std::vector<Value> values;
@@ -1365,10 +1319,8 @@ TEST_F(VerifierTest, ProbeSSBOGreater) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kGreater);
 
   std::vector<Value> values;
@@ -1392,10 +1344,8 @@ TEST_F(VerifierTest, ProbeSSBOGreaterFail) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kGreater);
 
   std::vector<Value> values;
@@ -1421,10 +1371,8 @@ TEST_F(VerifierTest, ProbeSSBOGreaterOrEqual) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kGreaterOrEqual);
 
   std::vector<Value> values;
@@ -1448,10 +1396,8 @@ TEST_F(VerifierTest, ProbeSSBOGreaterOrEqualFail) {
 
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
-  DatumType datum_type;
-  datum_type.SetType(DataType::kDouble);
-  probe_ssbo.SetDatumType(datum_type);
-
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kGreaterOrEqual);
 
   std::vector<Value> values;

--- a/src/vkscript/command_parser.cc
+++ b/src/vkscript/command_parser.cc
@@ -2045,7 +2045,7 @@ Result CommandParser::ProcessProbeSSBO() {
   auto cmd = MakeUnique<ProbeSSBOCommand>(buffer);
   cmd->SetLine(cur_line);
   cmd->SetTolerances(current_tolerances_);
-  cmd->SetDatumType(tp.GetType());
+  cmd->SetFormat(tp.GetType().AsFormat());
   cmd->SetDescriptorSet(set);
   cmd->SetBinding(binding);
 
@@ -2068,8 +2068,7 @@ Result CommandParser::ProcessProbeSSBO() {
   cmd->SetComparator(comp);
 
   std::vector<Value> values;
-  auto fmt = cmd->GetDatumType().AsFormat();
-  r = ParseValues("probe ssbo", fmt.get(), &values, false);
+  r = ParseValues("probe ssbo", cmd->GetFormat(), &values, false);
   if (!r.IsSuccess())
     return r;
 

--- a/src/vkscript/command_parser_test.cc
+++ b/src/vkscript/command_parser_test.cc
@@ -3922,10 +3922,10 @@ probe ssbo vec3 3:6 2 >= 2.3 4.2 1.2)";
   EXPECT_EQ(ProbeSSBOCommand::Comparator::kGreaterOrEqual,
             cmd->GetComparator());
 
-  const auto& type = cmd->GetDatumType();
-  EXPECT_TRUE(type.IsFloat());
-  EXPECT_EQ(1U, type.ColumnCount());
-  EXPECT_EQ(3U, type.RowCount());
+  auto* fmt = cmd->GetFormat();
+  EXPECT_TRUE(fmt->IsFloat());
+  EXPECT_EQ(1U, fmt->ColumnCount());
+  EXPECT_EQ(3U, fmt->RowCount());
 
   const auto& values = cmd->GetValues();
   std::vector<float> results = {2.3f, 4.2f, 1.2f};
@@ -3957,10 +3957,10 @@ probe ssbo vec3 6 2 >= 2.3 4.2 1.2)";
   EXPECT_EQ(ProbeSSBOCommand::Comparator::kGreaterOrEqual,
             cmd->GetComparator());
 
-  const auto& type = cmd->GetDatumType();
-  EXPECT_TRUE(type.IsFloat());
-  EXPECT_EQ(1U, type.ColumnCount());
-  EXPECT_EQ(3U, type.RowCount());
+  auto* fmt = cmd->GetFormat();
+  EXPECT_TRUE(fmt->IsFloat());
+  EXPECT_EQ(1U, fmt->ColumnCount());
+  EXPECT_EQ(3U, fmt->RowCount());
 
   const auto& values = cmd->GetValues();
   std::vector<float> results = {2.3f, 4.2f, 1.2f};
@@ -3992,10 +3992,10 @@ probe ssbo vec3 6 2 >= 2.3 4.2 1.2)";
   EXPECT_EQ(ProbeSSBOCommand::Comparator::kGreaterOrEqual,
             cmd->GetComparator());
 
-  const auto& type = cmd->GetDatumType();
-  EXPECT_TRUE(type.IsFloat());
-  EXPECT_EQ(1U, type.ColumnCount());
-  EXPECT_EQ(3U, type.RowCount());
+  auto* fmt = cmd->GetFormat();
+  EXPECT_TRUE(fmt->IsFloat());
+  EXPECT_EQ(1U, fmt->ColumnCount());
+  EXPECT_EQ(3U, fmt->RowCount());
 
   const auto& values = cmd->GetValues();
   std::vector<float> results = {2.3f, 4.2f, 1.2f};
@@ -4026,10 +4026,10 @@ probe ssbo i16vec3 6 2 <= 2 4 1)";
   EXPECT_EQ(2U, cmd->GetOffset());
   EXPECT_EQ(ProbeSSBOCommand::Comparator::kLessOrEqual, cmd->GetComparator());
 
-  const auto& type = cmd->GetDatumType();
-  EXPECT_TRUE(type.IsInt16());
-  EXPECT_EQ(1U, type.ColumnCount());
-  EXPECT_EQ(3U, type.RowCount());
+  auto* fmt = cmd->GetFormat();
+  EXPECT_TRUE(fmt->IsInt16());
+  EXPECT_EQ(1U, fmt->ColumnCount());
+  EXPECT_EQ(3U, fmt->RowCount());
 
   const auto& values = cmd->GetValues();
   std::vector<int16_t> results = {2, 4, 1};
@@ -4060,10 +4060,10 @@ probe ssbo i16vec3 6 2 == 2 4 1 3 6 8)";
   EXPECT_EQ(2U, cmd->GetOffset());
   EXPECT_EQ(ProbeSSBOCommand::Comparator::kEqual, cmd->GetComparator());
 
-  const auto& type = cmd->GetDatumType();
-  EXPECT_TRUE(type.IsInt16());
-  EXPECT_EQ(1U, type.ColumnCount());
-  EXPECT_EQ(3U, type.RowCount());
+  auto* fmt = cmd->GetFormat();
+  EXPECT_TRUE(fmt->IsInt16());
+  EXPECT_EQ(1U, fmt->ColumnCount());
+  EXPECT_EQ(3U, fmt->RowCount());
 
   const auto& values = cmd->GetValues();
   std::vector<int16_t> results = {2, 4, 1, 3, 6, 8};

--- a/src/vulkan/buffer_descriptor.h
+++ b/src/vulkan/buffer_descriptor.h
@@ -22,11 +22,13 @@
 #include "amber/value.h"
 #include "amber/vulkan_header.h"
 #include "src/buffer.h"
-#include "src/datum_type.h"
 #include "src/engine.h"
 #include "src/vulkan/transfer_buffer.h"
 
 namespace amber {
+
+class Format;
+
 namespace vulkan {
 
 class CommandBuffer;

--- a/src/vulkan/resource.h
+++ b/src/vulkan/resource.h
@@ -21,9 +21,11 @@
 #include "amber/result.h"
 #include "amber/value.h"
 #include "amber/vulkan_header.h"
-#include "src/datum_type.h"
 
 namespace amber {
+
+class Format;
+
 namespace vulkan {
 
 class CommandBuffer;


### PR DESCRIPTION
This CL moves the ProbeSSBO command to use a format object instead of a
Datum type.