### PR TITLE
Add compute tests for AmberScript.

### DIFF
--- a/tests/cases/compute_accumulated_ubo_definition.amber
+++ b/tests/cases/compute_accumulated_ubo_definition.amber
@@ -1,0 +1,72 @@
+#!amber
+# Copyright 2019 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHADER compute compute_shader GLSL
+#version 430
+
+layout(set = 0, binding = 0) uniform block0 {
+  float data_set0_binding0[3];
+};
+
+layout(set = 1, binding = 2) uniform block1 {
+  float data_set1_binding2[3];
+};
+
+layout(set = 2, binding = 1) buffer block2 {
+  float data_set2_binding1[3];
+};
+
+layout(set = 2, binding = 3) buffer block3 {
+  float data_set2_binding3[3];
+};
+
+void main() {
+  const uint index = gl_WorkGroupID.x;
+  data_set2_binding1[index] = 10.0f * data_set0_binding0[index] +
+                              data_set1_binding2[index];
+  data_set2_binding3[index] += data_set1_binding2[index];
+}
+END
+
+# GLSLang gerates STD140 layout. Need to pad to 16 bytes per item.
+BUFFER buf0 DATA_TYPE float DATA
+1 0 0 0
+2 0 0 0
+3 0 0 0
+END
+
+# GLSLang gerates STD140 layout. Need to pad to 16 bytes per item.
+BUFFER buf1 DATA_TYPE float DATA
+4 0 0 0
+5 0 0 0
+6 0 0 0
+END
+
+BUFFER buf2 DATA_TYPE vec3<float> DATA 21.0 22.0 23.0 END
+BUFFER buf3 DATA_TYPE vec3<float> DATA  0.7  0.8  0.9 END
+
+PIPELINE compute pipeline
+  ATTACH compute_shader
+
+  BIND BUFFER buf0 AS uniform DESCRIPTOR_SET 0 BINDING 0
+  BIND BUFFER buf1 AS uniform DESCRIPTOR_SET 1 BINDING 2
+  BIND BUFFER buf2 AS storage DESCRIPTOR_SET 2 BINDING 1
+  BIND BUFFER buf3 AS storage DESCRIPTOR_SET 2 BINDING 3
+END
+
+RUN pipeline 3 1 1
+
+EXPECT buf2 IDX 0 EQ 14.0 25.0 36.0
+EXPECT buf3 IDX 0 EQ  4.7  5.8  6.9

--- a/tests/cases/compute_mat2x2.amber
+++ b/tests/cases/compute_mat2x2.amber
@@ -1,0 +1,67 @@
+#!amber
+# Copyright 2019 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHADER compute compute_shader GLSL
+#version 430
+
+layout(set = 0, binding = 0) buffer block0 {
+  mat2 identical_mat_0;
+};
+
+layout(set = 0, binding = 1) uniform block1 {
+  mat2 identical_mat_1;
+};
+
+layout(set = 0, binding = 2) buffer block3 {
+  vec2 test0;
+  vec2 test1;
+};
+
+void main() {
+  test0 = identical_mat_0 * test0;
+  test1 = identical_mat_1 * test1;
+}
+END
+
+# This is bound as an SSBO, so matrix stride is 8
+BUFFER buf0 DATA_TYPE mat2x2<float> DATA
+1.0 0.0
+0.0 1.0
+END
+
+# This is bound as a UBO so matrix stride is 16 due to GLSLang setting
+# STD140 layout.
+BUFFER buf1 DATA_TYPE mat2x2<float> DATA
+1.0 0.0 0.0 0.0
+0.0 1.0 0.0 0.0
+END
+
+BUFFER buf2 DATA_TYPE vec2<float> DATA
+3.7 9.4
+4.5 6.1
+END
+
+PIPELINE compute pipeline
+  ATTACH compute_shader
+
+  BIND BUFFER buf0 AS storage DESCRIPTOR_SET 0 BINDING 0
+  BIND BUFFER buf1 AS uniform DESCRIPTOR_SET 0 BINDING 1
+  BIND BUFFER buf2 AS storage DESCRIPTOR_SET 0 BINDING 2
+END
+
+RUN pipeline 1 1 1
+
+EXPECT buf2 IDX 0 EQ 3.7 9.4
+EXPECT buf2 IDX 8 EQ 4.5 6.1


### PR DESCRIPTION
This CL adds two more AmberScript conversions of VkScript tests for
compute.