### PR TITLE
Fix format sizes due to layout.

### DIFF
--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -781,7 +781,7 @@ Result Parser::ParseBufferInitializerFill(Buffer* buffer,
   bool is_double_data = fmt->IsFloat() || fmt->IsDouble();
 
   // Inflate the size because our items are multi-dimensional.
-  size_in_items = size_in_items * fmt->RowCount() * fmt->ColumnCount();
+  size_in_items = size_in_items * fmt->InputNeededPerElement();
 
   std::vector<Value> values;
   values.resize(size_in_items);
@@ -858,7 +858,6 @@ Result Parser::ParseBufferInitializerData(Buffer* buffer) {
       break;
     if (!token->IsInteger() && !token->IsDouble() && !token->IsHex())
       return Result("invalid BUFFER data value: " + token->ToOriginalString());
-
     if (!is_double_type && token->IsDouble())
       return Result("invalid BUFFER data value: " + token->ToOriginalString());
 

--- a/src/amberscript/parser_buffer_test.cc
+++ b/src/amberscript/parser_buffer_test.cc
@@ -334,41 +334,6 @@ END
   }
 }
 
-TEST_F(AmberScriptParserTest, BufferDataStd140Resized) {
-  std::string in = R"(
-BUFFER my_index_buffer DATA_TYPE vec3<int32> DATA
-2 3 3
-4 5 5
-6 7 7
-8 9 9
-END
-)";
-
-  Parser parser;
-  Result r = parser.Parse(in);
-  ASSERT_TRUE(r.IsSuccess()) << r.Error();
-
-  auto script = parser.GetScript();
-  const auto& buffers = script->GetBuffers();
-  ASSERT_EQ(1U, buffers.size());
-
-  ASSERT_TRUE(buffers[0] != nullptr);
-
-  auto* buffer = buffers[0].get();
-  EXPECT_EQ("my_index_buffer", buffer->GetName());
-  EXPECT_TRUE(buffer->GetFormat()->IsInt32());
-  EXPECT_EQ(4U, buffer->ElementCount());
-  EXPECT_EQ(12U, buffer->ValueCount());
-  EXPECT_EQ(16U * sizeof(int32_t), buffer->GetSizeInBytes());
-
-  std::vector<int32_t> results0 = {2, 3, 3, 0, 4, 5, 5, 0,
-                                   6, 7, 7, 0, 8, 9, 9, 0};
-  const auto* data0 = buffer->GetValues<int32_t>();
-  for (size_t i = 0; i < results0.size(); ++i) {
-    EXPECT_EQ(results0[i], data0[i]);
-  }
-}
-
 TEST_F(AmberScriptParserTest, BufferDataHex) {
   std::string in = R"(
 BUFFER my_index_buffer DATA_TYPE uint32 DATA

--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -172,8 +172,10 @@ Result Buffer::SetData(const std::vector<Value>& data) {
       }
       ++i;
     }
-    // Need to add an extra element if this is std140 and there are 3 elements.
-    if (format_->IsStd140() && format_->RowCount() == 3)
+    // For formats which we've padded to the the layout, make sure we skip over
+    // the space in the buffer.
+    size_t pad = format_->ValuesPerRow() - format_->GetComponents().size();
+    for (size_t i = 0; i < pad; ++i)
       ptr += (format_->GetComponents()[0].num_bits / 8);
   }
   return {};

--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -175,7 +175,7 @@ Result Buffer::SetData(const std::vector<Value>& data) {
     // For formats which we've padded to the the layout, make sure we skip over
     // the space in the buffer.
     size_t pad = format_->ValuesPerRow() - format_->GetComponents().size();
-    for (size_t i = 0; i < pad; ++i)
+    for (size_t j = 0; j < pad; ++j)
       ptr += (format_->GetComponents()[0].num_bits / 8);
   }
   return {};

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -110,10 +110,15 @@ class Buffer {
       element_count_ = 0;
       return;
     }
-    if (format_->GetPackSize() > 0)
+    if (format_->GetPackSize() > 0) {
       element_count_ = count;
-    else
-      element_count_ = count / format_->ValuesPerElement();
+    } else {
+      // This divides by the needed input values, not the values per element.
+      // The assumption being the values coming in are read from the input,
+      // where components are specified. The needed values maybe less then the
+      // values per element.
+      element_count_ = count / format_->InputNeededPerElement();
+    }
   }
   /// Returns the number of values in the buffer.
   uint32_t ValueCount() const {

--- a/src/buffer_test.cc
+++ b/src/buffer_test.cc
@@ -83,4 +83,18 @@ TEST_F(BufferTest, SizeMatrix) {
   EXPECT_EQ(60 * sizeof(int16_t), b.GetSizeInBytes());
 }
 
+TEST_F(BufferTest, SizeMatrixPadded) {
+  FormatParser fp;
+  auto fmt = fp.Parse("R32G32B32_SINT");
+  fmt->SetColumnCount(3);
+
+  Buffer b(BufferType::kColor);
+  b.SetFormat(std::move(fmt));
+  b.SetValueCount(9);
+
+  EXPECT_EQ(1U, b.ElementCount());
+  EXPECT_EQ(12U, b.ValueCount());
+  EXPECT_EQ(12U * sizeof(int32_t), b.GetSizeInBytes());
+}
+
 }  // namespace amber

--- a/src/command.h
+++ b/src/command.h
@@ -424,7 +424,7 @@ class BufferCommand : public PipelineCommand {
     values_ = std::move(values);
     auto fmt = buffer_->GetFormat();
     size_ = static_cast<uint32_t>(values_.size() * fmt->SizeInBytes()) /
-            fmt->ValuesPerElement();
+            fmt->InputNeededPerElement();
   }
   const std::vector<Value>& GetValues() const { return values_; }
 

--- a/src/datum_type.cc
+++ b/src/datum_type.cc
@@ -82,8 +82,6 @@ std::unique_ptr<Format> DatumType::AsFormat() const {
     fmt->SetFormatType(FormatType::kUnknown);
     fmt->SetColumnCount(column_count_);
   }
-  // Always pretend to be std140 as that's what datum type does.
-  fmt->SetIsStd140();
 
   return fmt;
 }

--- a/src/format.cc
+++ b/src/format.cc
@@ -29,11 +29,18 @@ uint32_t Format::SizeInBytesPerRow() const {
   for (const auto& comp : components_)
     bits += comp.num_bits;
 
-  if (is_std140_ && components_.size() == 3)
+  uint32_t inflate = 0;
+  // Std140 always has 4 elements. std430 expands 3 elements to 4.
+  if (is_std140_)
+    inflate = 4 - components_.size();
+  else if (components_.size() == 3)
+    inflate = 1;
+
+  for (uint32_t i = 0; i < inflate; ++i)
     bits += components_[0].num_bits;
 
   uint32_t bytes_per_element = bits / 8;
-  // Odd number of bits, inflate or byte count to accommodate
+  // Odd number of bits, inflate byte count to accommodate
   if ((bits % 8) != 0)
     bytes_per_element += 1;
 

--- a/src/format.cc
+++ b/src/format.cc
@@ -32,7 +32,7 @@ uint32_t Format::SizeInBytesPerRow() const {
   uint32_t inflate = 0;
   // Std140 always has 4 elements. std430 expands 3 elements to 4.
   if (is_std140_)
-    inflate = 4 - components_.size();
+    inflate = 4U - static_cast<uint32_t>(components_.size());
   else if (components_.size() == 3)
     inflate = 1;
 

--- a/src/format.h
+++ b/src/format.h
@@ -142,9 +142,7 @@ class Format {
   /// Returns the number of input values required for an item of this format.
   /// This differs from ValuesPerElement because it doesn't take padding into
   /// account.
-  uint32_t InputNeededPerElement() const {
-    return RowCount() * column_count_;
-  }
+  uint32_t InputNeededPerElement() const { return RowCount() * column_count_; }
 
   /// Returns the number of values for a given row.
   uint32_t ValuesPerRow() const {
@@ -154,9 +152,7 @@ class Format {
   }
 
   /// Returns the number of values for each instance of this format.
-  uint32_t ValuesPerElement() const {
-    return ValuesPerRow() * column_count_;
-  }
+  uint32_t ValuesPerElement() const { return ValuesPerRow() * column_count_; }
 
   uint32_t RowCount() const {
     return static_cast<uint32_t>(components_.size());

--- a/src/verifier.cc
+++ b/src/verifier.cc
@@ -650,7 +650,7 @@ Result Verifier::ProbeSSBO(const ProbeSSBOCommand* command,
   }
 
   auto* fmt = command->GetFormat();
-  size_t elem_count = values.size() / fmt->ValuesPerElement();
+  size_t elem_count = values.size() / fmt->InputNeededPerElement();
   size_t offset = static_cast<size_t>(command->GetOffset());
   size_t size_in_bytes = buffer_element_count * fmt->SizeInBytes();
   if ((elem_count * fmt->SizeInBytes()) + offset > size_in_bytes) {

--- a/src/vkscript/parser_test.cc
+++ b/src/vkscript/parser_test.cc
@@ -428,7 +428,7 @@ TEST_F(VkScriptParserTest, VertexDataRows) {
 
   ASSERT_EQ(BufferType::kVertex, buffers[1]->GetBufferType());
 
-  std::vector<float> seg_0 = {-1.f, -1.f, 0.25f, 0.25f, -1.f, 0.25f};
+  std::vector<float> seg_0 = {-1.f, -1.f, 0.25f, 0, 0.25f, -1.f, 0.25f, 0};
   const auto* values_0 = buffers[1]->GetValues<float>();
   ASSERT_EQ(seg_0.size(), buffers[1]->ValueCount());
   for (size_t i = 0; i < seg_0.size(); ++i) {
@@ -437,7 +437,7 @@ TEST_F(VkScriptParserTest, VertexDataRows) {
 
   ASSERT_EQ(BufferType::kVertex, buffers[2]->GetBufferType());
 
-  std::vector<uint8_t> seg_1 = {255, 128, 1, 255, 128, 255};
+  std::vector<uint8_t> seg_1 = {255, 128, 1, 0, 255, 128, 255, 0};
   const auto* values_1 = buffers[2]->GetValues<uint8_t>();
   ASSERT_EQ(seg_1.size(), buffers[2]->ValueCount());
   for (size_t i = 0; i < seg_1.size(); ++i) {


### PR DESCRIPTION
The STD140 and 430 layouts were not handled properly by the format code.
This CL extends the code to add the correct format padding for the
layouts and updates the buffer code to attempt to read the expected
number of values and handle the padding as needed.