### PR TITLE
Add flag to log execute calls.

### DIFF
--- a/include/amber/amber.h
+++ b/include/amber/amber.h
@@ -74,6 +74,8 @@ class Delegate {
   virtual bool LogGraphicsCallsTime() const = 0;
   /// Returns the current timestamp in nanoseconds
   virtual uint64_t GetTimestampNs() const = 0;
+  /// Tells whether to log each test as it's executed
+  virtual bool LogExecuteCalls() const = 0;
 };
 
 /// Stores configuration options for Amber.

--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -51,6 +51,7 @@ struct Options {
   bool show_version_info = false;
   bool log_graphics_calls = false;
   bool log_graphics_calls_time = false;
+  bool log_execute_calls = false;
   amber::EngineType engine = amber::kEngineTypeVulkan;
   std::string spv_env;
 };
@@ -72,6 +73,7 @@ const char kUsage[] = R"(Usage: amber [options] SCRIPT [SCRIPTS...]
   -V, --version             -- Output version information for Amber and libraries.
   --log-graphics-calls      -- Log graphics API calls (only for Vulkan so far).
   --log-graphics-calls-time -- Log timing of graphics API calls timing (Vulkan only).
+  --log-execute-calls       -- Log each execute call before run.
   -h                        -- This help text.
 )";
 
@@ -169,6 +171,8 @@ bool ParseArgs(const std::vector<std::string>& args, Options* opts) {
       opts->log_graphics_calls = true;
     } else if (arg == "--log-graphics-calls-time") {
       opts->log_graphics_calls_time = true;
+    } else if (arg == "--log-execute-calls") {
+      opts->log_execute_calls = true;
     } else if (arg.size() > 0 && arg[0] == '-') {
       std::cerr << "Unrecognized option " << arg << std::endl;
       return false;
@@ -217,8 +221,7 @@ std::string ReadFile(const std::string& input_file) {
 
 class SampleDelegate : public amber::Delegate {
  public:
-  SampleDelegate()
-      : log_graphics_calls_(false), log_graphics_calls_time_(false) {}
+  SampleDelegate() = default;
   ~SampleDelegate() override = default;
 
   void Log(const std::string& message) override {
@@ -226,15 +229,18 @@ class SampleDelegate : public amber::Delegate {
   }
 
   bool LogGraphicsCalls() const override { return log_graphics_calls_; }
-
   void SetLogGraphicsCalls(bool log_graphics_calls) {
     log_graphics_calls_ = log_graphics_calls;
+  }
+
+  bool LogExecuteCalls() const override { return log_execute_calls_; }
+  void SetLogExecuteCalls(bool log_execute_calls) {
+    log_execute_calls_ = log_execute_calls;
   }
 
   bool LogGraphicsCallsTime() const override {
     return log_graphics_calls_time_;
   }
-
   void SetLogGraphicsCallsTime(bool log_graphics_calls_time) {
     log_graphics_calls_time_ = log_graphics_calls_time;
     if (log_graphics_calls_time) {
@@ -248,8 +254,9 @@ class SampleDelegate : public amber::Delegate {
   }
 
  private:
-  bool log_graphics_calls_;
-  bool log_graphics_calls_time_;
+  bool log_graphics_calls_ = false;
+  bool log_graphics_calls_time_ = false;
+  bool log_execute_calls_ = false;
 };
 
 }  // namespace
@@ -314,12 +321,12 @@ int main(int argc, const char** argv) {
     return 0;
 
   SampleDelegate delegate;
-  if (options.log_graphics_calls) {
+  if (options.log_graphics_calls)
     delegate.SetLogGraphicsCalls(true);
-  }
-  if (options.log_graphics_calls_time) {
+  if (options.log_graphics_calls_time)
     delegate.SetLogGraphicsCallsTime(true);
-  }
+  if (options.log_execute_calls)
+    delegate.SetLogExecuteCalls(true);
 
   amber::Options amber_options;
   amber_options.engine = options.engine;

--- a/src/amber.cc
+++ b/src/amber.cc
@@ -169,7 +169,7 @@ amber::Result Amber::ExecuteWithShaderData(const amber::Recipe* recipe,
 
   Executor executor;
   Result executor_result = executor.Execute(
-      engine.get(), script, shader_data,
+      engine.get(), script, opts->delegate, shader_data,
       opts->pipeline_create_only ? ExecutionType::kPipelineCreateOnly
                                  : ExecutionType::kExecute);
   // Hold the executor result until the extractions are complete. This will let

--- a/src/command.h
+++ b/src/command.h
@@ -106,6 +106,8 @@ class Command {
   BufferCommand* AsBuffer();
   RepeatCommand* AsRepeat();
 
+  virtual std::string ToString() const = 0;
+
   /// Sets the input file line number this command is declared on.
   void SetLine(size_t line) { line_ = line; }
   /// Returns the input file line this command was declared on.
@@ -157,6 +159,8 @@ class DrawRectCommand : public PipelineCommand {
   void SetHeight(float h) { height_ = h; }
   float GetHeight() const { return height_; }
 
+  std::string ToString() const override { return "DrawRectCommand"; }
+
  private:
   PipelineData data_;
   bool is_ortho_ = false;
@@ -193,6 +197,8 @@ class DrawArraysCommand : public PipelineCommand {
   void SetInstanceCount(uint32_t count) { instance_count_ = count; }
   uint32_t GetInstanceCount() const { return instance_count_; }
 
+  std::string ToString() const override { return "DrawArraysCommand"; }
+
  private:
   PipelineData data_;
   bool is_indexed_ = false;
@@ -211,6 +217,8 @@ class CompareBufferCommand : public Command {
 
   Buffer* GetBuffer1() const { return buffer_1_; }
   Buffer* GetBuffer2() const { return buffer_2_; }
+
+  std::string ToString() const override { return "CompareBufferCommand"; }
 
  private:
   Buffer* buffer_1_;
@@ -232,6 +240,8 @@ class ComputeCommand : public PipelineCommand {
   void SetZ(uint32_t z) { z_ = z; }
   uint32_t GetZ() const { return z_; }
 
+  std::string ToString() const override { return "ComputeCommand"; }
+
  private:
   uint32_t x_ = 0;
   uint32_t y_ = 0;
@@ -246,6 +256,8 @@ class CopyCommand : public Command {
 
   Buffer* GetBufferFrom() const { return buffer_from_; }
   Buffer* GetBufferTo() const { return buffer_to_; }
+
+  std::string ToString() const override { return "CopyCommand"; }
 
  private:
   Buffer* buffer_from_;
@@ -322,6 +334,8 @@ class ProbeCommand : public Probe {
   void SetA(float a) { a_ = a; }
   float GetA() const { return a_; }
 
+  std::string ToString() const override { return "ProbeCommand"; }
+
  private:
   enum class ColorFormat {
     kRGB = 0,
@@ -378,6 +392,8 @@ class ProbeSSBOCommand : public Probe {
   void SetValues(std::vector<Value>&& values) { values_ = std::move(values); }
   const std::vector<Value>& GetValues() const { return values_; }
 
+  std::string ToString() const override { return "ProbeSSBOCommand"; }
+
  private:
   Comparator comparator_ = Comparator::kEqual;
   uint32_t descriptor_set_id_ = 0;
@@ -431,6 +447,8 @@ class BufferCommand : public PipelineCommand {
   void SetBuffer(Buffer* buffer) { buffer_ = buffer; }
   Buffer* GetBuffer() const { return buffer_; }
 
+  std::string ToString() const override { return "BufferCommand"; }
+
  private:
   Buffer* buffer_ = nullptr;
   BufferType buffer_type_;
@@ -447,6 +465,8 @@ class ClearCommand : public PipelineCommand {
  public:
   explicit ClearCommand(Pipeline* pipeline);
   ~ClearCommand() override;
+
+  std::string ToString() const override { return "ClearCommand"; }
 };
 
 /// Command to set the colour for the clear command.
@@ -468,6 +488,8 @@ class ClearColorCommand : public PipelineCommand {
   void SetA(float a) { a_ = a; }
   float GetA() const { return a_; }
 
+  std::string ToString() const override { return "ClearColorCommand"; }
+
  private:
   float r_ = 0.0;
   float g_ = 0.0;
@@ -484,6 +506,8 @@ class ClearDepthCommand : public PipelineCommand {
   void SetValue(float val) { value_ = val; }
   float GetValue() const { return value_; }
 
+  std::string ToString() const override { return "ClearDepthCommand"; }
+
  private:
   float value_ = 0.0;
 };
@@ -497,6 +521,8 @@ class ClearStencilCommand : public PipelineCommand {
   void SetValue(uint32_t val) { value_ = val; }
   uint32_t GetValue() const { return value_; }
 
+  std::string ToString() const override { return "ClearStencilCommand"; }
+
  private:
   uint32_t value_ = 0;
 };
@@ -509,6 +535,10 @@ class PatchParameterVerticesCommand : public PipelineCommand {
 
   void SetControlPointCount(uint32_t count) { control_point_count_ = count; }
   uint32_t GetControlPointCount() const { return control_point_count_; }
+
+  std::string ToString() const override {
+    return "PatchParameterVerticesCommand";
+  }
 
  private:
   uint32_t control_point_count_ = 0;
@@ -525,6 +555,8 @@ class EntryPointCommand : public PipelineCommand {
 
   void SetEntryPointName(const std::string& name) { entry_point_name_ = name; }
   std::string GetEntryPointName() const { return entry_point_name_; }
+
+  std::string ToString() const override { return "EntryPointCommand"; }
 
  private:
   ShaderType shader_type_ = kShaderTypeVertex;
@@ -546,6 +578,8 @@ class RepeatCommand : public Command {
   const std::vector<std::unique_ptr<Command>>& GetCommands() const {
     return commands_;
   }
+
+  std::string ToString() const override { return "RepeatCommand"; }
 
  private:
   uint32_t count_ = 0;

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -49,6 +49,7 @@ Result Executor::CompileShaders(const amber::Script* script,
 
 Result Executor::Execute(Engine* engine,
                          const amber::Script* script,
+                         Delegate* delegate,
                          const ShaderMap& shader_map,
                          ExecutionType executionType) {
   engine->SetEngineData(script->GetEngineData());
@@ -70,6 +71,9 @@ Result Executor::Execute(Engine* engine,
 
   // Process Commands
   for (const auto& cmd : script->GetCommands()) {
+    if (delegate && delegate->LogExecuteCalls())
+      delegate->Log(std::to_string(cmd->GetLine()) + ": " + cmd->ToString());
+
     Result r = ExecuteCommand(engine, cmd.get());
     if (!r.IsSuccess())
       return r;

--- a/src/executor.h
+++ b/src/executor.h
@@ -15,6 +15,7 @@
 #ifndef SRC_EXECUTOR_H_
 #define SRC_EXECUTOR_H_
 
+#include "amber/amber.h"
 #include "amber/result.h"
 #include "src/engine.h"
 #include "src/script.h"
@@ -36,6 +37,7 @@ class Executor {
   /// used as the shader binary.
   Result Execute(Engine* engine,
                  const Script* script,
+                 Delegate* delegate,
                  const ShaderMap& map,
                  ExecutionType executionType);
 

--- a/src/executor_test.cc
+++ b/src/executor_test.cc
@@ -226,7 +226,7 @@ logicOp)";
                                         script->GetRequiredDeviceExtensions());
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
 
@@ -256,7 +256,7 @@ VK_KHR_variable_pointers)";
                                         script->GetRequiredDeviceExtensions());
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
 
@@ -286,7 +286,7 @@ depthstencil D24_UNORM_S8_UINT)";
                                         script->GetRequiredDeviceExtensions());
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
 
@@ -313,7 +313,7 @@ fence_timeout 12345)";
                                         script->GetRequiredDeviceExtensions());
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
 
@@ -346,7 +346,7 @@ fence_timeout 12345)";
                                         script->GetRequiredDeviceExtensions());
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
 
@@ -375,7 +375,7 @@ clear)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   EXPECT_TRUE(ToStub(engine.get())->DidClearCommand());
@@ -394,7 +394,7 @@ clear)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("clear command failed", r.Error());
@@ -412,7 +412,7 @@ clear color 244 123 123 13)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidClearColorCommand());
@@ -440,7 +440,7 @@ clear color 123 123 123 123)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("clear color command failed", r.Error());
@@ -458,7 +458,7 @@ clear depth 24)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidClearDepthCommand());
@@ -477,7 +477,7 @@ clear depth 24)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("clear depth command failed", r.Error());
@@ -495,7 +495,7 @@ clear stencil 24)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidClearStencilCommand());
@@ -514,7 +514,7 @@ clear stencil 24)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("clear stencil command failed", r.Error());
@@ -532,7 +532,7 @@ draw rect 2 4 10 20)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidDrawRectCommand());
@@ -551,7 +551,7 @@ draw rect 2 4 10 20)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("draw rect command failed", r.Error());
@@ -569,7 +569,7 @@ draw arrays TRIANGLE_LIST 0 0)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidDrawArraysCommand());
@@ -588,7 +588,7 @@ draw arrays TRIANGLE_LIST 0 0)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("draw arrays command failed", r.Error());
@@ -606,7 +606,7 @@ compute 2 3 4)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidComputeCommand());
@@ -625,7 +625,7 @@ compute 2 3 4)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("compute command failed", r.Error());
@@ -643,7 +643,7 @@ vertex entrypoint main)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidEntryPointCommand());
@@ -662,7 +662,7 @@ vertex entrypoint main)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("entrypoint command failed", r.Error());
@@ -680,7 +680,7 @@ patch parameter vertices 10)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidPatchParameterVerticesCommand());
@@ -699,7 +699,7 @@ patch parameter vertices 10)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("patch command failed", r.Error());
@@ -717,7 +717,7 @@ probe rect rgba 2 3 40 40 0.2 0.4 0.4 0.3)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   // ASSERT_TRUE(ToStub(engine.get())->DidProbeCommand());
@@ -736,7 +736,7 @@ probe rect rgba 2 3 40 40 0.2 0.4 0.4 0.3)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("probe command failed", r.Error());
@@ -754,7 +754,7 @@ ssbo 0 24)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   ASSERT_TRUE(ToStub(engine.get())->DidBufferCommand());
@@ -773,7 +773,7 @@ ssbo 0 24)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("buffer command failed", r.Error());
@@ -791,7 +791,7 @@ probe ssbo vec3 0 2 <= 2 3 4)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_TRUE(r.IsSuccess());
   // ASSERT_TRUE(ToStub(engine.get())->DidProbeSSBOCommand());
@@ -810,7 +810,7 @@ probe ssbo vec3 0 2 <= 2 3 4)";
   auto script = parser.GetScript();
 
   Executor ex;
-  Result r = ex.Execute(engine.get(), script.get(), ShaderMap(),
+  Result r = ex.Execute(engine.get(), script.get(), nullptr, ShaderMap(),
                         ExecutionType::kExecute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("probe ssbo command failed", r.Error());


### PR DESCRIPTION
This CL adds a flag to the sample app and extends the Delgate to allow
logging command names before they're executed. This should allow easier
tracking down of the command which causes a segv during executing.