### PR TITLE
[amberscript] Extend DRAW_ARRAYS parsing.

### DIFF
--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -991,6 +991,9 @@ Result Parser::ParseRun() {
     if (!pipeline->IsGraphics())
       return Result("RUN command requires graphics pipeline");
 
+    if (pipeline->GetVertexBuffers().empty())
+      return Result("RUN DRAW_ARRAY requires attached vertex buffer");
+
     token = tokenizer_->NextToken();
     if (!token->IsString() || token->AsString() != "AS")
       return Result("missing AS for RUN command");
@@ -1006,35 +1009,55 @@ Result Parser::ParseRun() {
       return Result("invalid topology for RUN command: " + token->AsString());
 
     token = tokenizer_->NextToken();
-    if (!token->IsString() || token->AsString() != "START_IDX")
-      return Result("missing START_IDX for RUN command");
+    uint32_t start_idx = 0;
+    uint32_t count = 0;
+    if (!token->IsEOS() && !token->IsEOL()) {
+      if (!token->IsString() || token->AsString() != "START_IDX")
+        return Result("missing START_IDX for RUN command");
 
-    token = tokenizer_->NextToken();
-    if (!token->IsInteger()) {
-      return Result("invalid START_IDX value for RUN command: " +
-                    token->ToOriginalString());
+      token = tokenizer_->NextToken();
+      if (!token->IsInteger()) {
+        return Result("invalid START_IDX value for RUN command: " +
+                      token->ToOriginalString());
+      }
+      if (token->AsInt32() < 0)
+        return Result("START_IDX value must be >= 0 for RUN command");
+      start_idx = token->AsUint32();
+
+      token = tokenizer_->NextToken();
+
+      if (!token->IsEOS() && !token->IsEOL()) {
+        if (!token->IsString() || token->AsString() != "COUNT")
+          return Result("missing COUNT for RUN command");
+
+        token = tokenizer_->NextToken();
+        if (!token->IsInteger()) {
+          return Result("invalid COUNT value for RUN command: " +
+                        token->ToOriginalString());
+        }
+        if (token->AsInt32() <= 0)
+          return Result("COUNT value must be > 0 for RUN command");
+
+        count = token->AsUint32();
+      }
     }
-    if (token->AsInt32() < 0)
-      return Result("START_IDX value must be >= 0 for RUN command");
-    uint32_t start_idx = token->AsUint32();
-
-    token = tokenizer_->NextToken();
-    if (!token->IsString() || token->AsString() != "COUNT")
-      return Result("missing COUNT for RUN command");
-
-    token = tokenizer_->NextToken();
-    if (!token->IsInteger()) {
-      return Result("invalid COUNT value for RUN command: " +
-                    token->ToOriginalString());
+    // If we get here then we never set count, as if count was set it must
+    // be > 0.
+    if (count == 0) {
+      count =
+          pipeline->GetVertexBuffers()[0].buffer->ElementCount() - start_idx;
     }
-    if (token->AsInt32() <= 0)
-      return Result("COUNT value must be > 0 for RUN command");
+
+    if (start_idx + count >
+        pipeline->GetVertexBuffers()[0].buffer->ElementCount()) {
+      return Result("START_IDX plus COUNT exceeds vertex buffer data size");
+    }
 
     auto cmd = MakeUnique<DrawArraysCommand>(pipeline, PipelineData{});
     cmd->SetLine(line);
     cmd->SetTopology(topo);
     cmd->SetFirstVertexIndex(start_idx);
-    cmd->SetVertexCount(token->AsUint32());
+    cmd->SetVertexCount(count);
 
     command_list_.push_back(std::move(cmd));
     return ValidateEndOfStatement("RUN command");

--- a/src/amberscript/parser_run_test.cc
+++ b/src/amberscript/parser_run_test.cc
@@ -495,10 +495,16 @@ SHADER vertex my_shader PASSTHROUGH
 SHADER fragment my_fragment GLSL
 # GLSL Shader
 END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
 
 PIPELINE graphics my_pipeline
   ATTACH my_shader
   ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
 END
 
 RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1 COUNT 2)";
@@ -522,7 +528,87 @@ RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1 COUNT 2)";
   EXPECT_EQ(2U, cmd->GetVertexCount());
 }
 
-TEST_F(AmberScriptParserTest, RunDrawArraysMissingAS) {
+TEST_F(AmberScriptParserTest, RunDrawArraysCountOmitted) {
+  std::string in = R"(
+SHADER vertex my_shader PASSTHROUGH
+SHADER fragment my_fragment GLSL
+# GLSL Shader
+END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
+
+PIPELINE graphics my_pipeline
+  ATTACH my_shader
+  ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
+END
+
+RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto script = parser.GetScript();
+  const auto& commands = script->GetCommands();
+  ASSERT_EQ(1U, commands.size());
+
+  ASSERT_TRUE(commands[0]->IsDrawArrays());
+
+  auto* cmd = commands[0]->AsDrawArrays();
+  EXPECT_FALSE(cmd->IsIndexed());
+  EXPECT_FALSE(cmd->IsInstanced());
+  EXPECT_EQ(static_cast<uint32_t>(0U), cmd->GetInstanceCount());
+  EXPECT_EQ(Topology::kTriangleList, cmd->GetTopology());
+  EXPECT_EQ(1U, cmd->GetFirstVertexIndex());
+  // There are 3 elements in the vertex buffer, but we start at element 1.
+  EXPECT_EQ(2U, cmd->GetVertexCount());
+}
+
+TEST_F(AmberScriptParserTest, RunDrawArraysStartIdxAndCountOmitted) {
+  std::string in = R"(
+SHADER vertex my_shader PASSTHROUGH
+SHADER fragment my_fragment GLSL
+# GLSL Shader
+END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
+
+PIPELINE graphics my_pipeline
+  ATTACH my_shader
+  ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
+END
+
+RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto script = parser.GetScript();
+  const auto& commands = script->GetCommands();
+  ASSERT_EQ(1U, commands.size());
+
+  ASSERT_TRUE(commands[0]->IsDrawArrays());
+
+  auto* cmd = commands[0]->AsDrawArrays();
+  EXPECT_FALSE(cmd->IsIndexed());
+  EXPECT_FALSE(cmd->IsInstanced());
+  EXPECT_EQ(static_cast<uint32_t>(0U), cmd->GetInstanceCount());
+  EXPECT_EQ(Topology::kTriangleList, cmd->GetTopology());
+  EXPECT_EQ(static_cast<uint32_t>(0U), cmd->GetFirstVertexIndex());
+  // There are 3 elements in the vertex buffer.
+  EXPECT_EQ(3U, cmd->GetVertexCount());
+}
+
+TEST_F(AmberScriptParserTest, RunDrawArraysMissingVertexBuffer) {
   std::string in = R"(
 SHADER vertex my_shader PASSTHROUGH
 SHADER fragment my_fragment GLSL
@@ -539,7 +625,33 @@ RUN my_pipeline DRAW_ARRAY TRIANGLE_LIST START_IDX 1 COUNT 2)";
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("12: missing AS for RUN command", r.Error());
+  EXPECT_EQ("12: RUN DRAW_ARRAY requires attached vertex buffer", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, RunDrawArraysMissingAS) {
+  std::string in = R"(
+SHADER vertex my_shader PASSTHROUGH
+SHADER fragment my_fragment GLSL
+# GLSL Shader
+END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
+
+PIPELINE graphics my_pipeline
+  ATTACH my_shader
+  ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
+END
+
+RUN my_pipeline DRAW_ARRAY TRIANGLE_LIST START_IDX 1 COUNT 2)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("18: missing AS for RUN command", r.Error());
 }
 
 TEST_F(AmberScriptParserTest, RunDrawArraysMissingTopology) {
@@ -548,10 +660,16 @@ SHADER vertex my_shader PASSTHROUGH
 SHADER fragment my_fragment GLSL
 # GLSL Shader
 END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
 
 PIPELINE graphics my_pipeline
   ATTACH my_shader
   ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
 END
 
 RUN my_pipeline DRAW_ARRAY AS START_IDX 1 COUNT 2)";
@@ -559,7 +677,7 @@ RUN my_pipeline DRAW_ARRAY AS START_IDX 1 COUNT 2)";
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("12: invalid topology for RUN command: START_IDX", r.Error());
+  EXPECT_EQ("18: invalid topology for RUN command: START_IDX", r.Error());
 }
 
 TEST_F(AmberScriptParserTest, RunDrawArraysInvalidTopologyFormat) {
@@ -568,10 +686,16 @@ SHADER vertex my_shader PASSTHROUGH
 SHADER fragment my_fragment GLSL
 # GLSL Shader
 END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
 
 PIPELINE graphics my_pipeline
   ATTACH my_shader
   ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
 END
 
 RUN my_pipeline DRAW_ARRAY AS 1234 START_IDX 1 COUNT 2)";
@@ -579,7 +703,7 @@ RUN my_pipeline DRAW_ARRAY AS 1234 START_IDX 1 COUNT 2)";
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("12: invalid topology for RUN command: 1234", r.Error());
+  EXPECT_EQ("18: invalid topology for RUN command: 1234", r.Error());
 }
 
 TEST_F(AmberScriptParserTest, RunDrawArraysInvalidTopology) {
@@ -588,10 +712,16 @@ SHADER vertex my_shader PASSTHROUGH
 SHADER fragment my_fragment GLSL
 # GLSL Shader
 END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
 
 PIPELINE graphics my_pipeline
   ATTACH my_shader
   ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
 END
 
 RUN my_pipeline DRAW_ARRAY AS INVALID_TOPOLOGY START_IDX 1 COUNT 2)";
@@ -599,7 +729,7 @@ RUN my_pipeline DRAW_ARRAY AS INVALID_TOPOLOGY START_IDX 1 COUNT 2)";
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("12: invalid topology for RUN command: INVALID_TOPOLOGY",
+  EXPECT_EQ("18: invalid topology for RUN command: INVALID_TOPOLOGY",
             r.Error());
 }
 
@@ -609,10 +739,16 @@ SHADER vertex my_shader PASSTHROUGH
 SHADER fragment my_fragment GLSL
 # GLSL Shader
 END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
 
 PIPELINE graphics my_pipeline
   ATTACH my_shader
   ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
 END
 
 RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST 1 COUNT 2)";
@@ -620,7 +756,7 @@ RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST 1 COUNT 2)";
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("12: missing START_IDX for RUN command", r.Error());
+  EXPECT_EQ("18: missing START_IDX for RUN command", r.Error());
 }
 
 TEST_F(AmberScriptParserTest, RunDrawArraysMissingStartIdxValue) {
@@ -629,10 +765,16 @@ SHADER vertex my_shader PASSTHROUGH
 SHADER fragment my_fragment GLSL
 # GLSL Shader
 END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
 
 PIPELINE graphics my_pipeline
   ATTACH my_shader
   ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
 END
 
 RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX COUNT 2)";
@@ -640,7 +782,7 @@ RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX COUNT 2)";
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("12: invalid START_IDX value for RUN command: COUNT", r.Error());
+  EXPECT_EQ("18: invalid START_IDX value for RUN command: COUNT", r.Error());
 }
 
 TEST_F(AmberScriptParserTest, RunDrawArraysInvalidStartIdxValueFormat) {
@@ -649,10 +791,16 @@ SHADER vertex my_shader PASSTHROUGH
 SHADER fragment my_fragment GLSL
 # GLSL Shader
 END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
 
 PIPELINE graphics my_pipeline
   ATTACH my_shader
   ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
 END
 
 RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX INVALID COUNT 2)";
@@ -660,7 +808,7 @@ RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX INVALID COUNT 2)";
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("12: invalid START_IDX value for RUN command: INVALID", r.Error());
+  EXPECT_EQ("18: invalid START_IDX value for RUN command: INVALID", r.Error());
 }
 
 TEST_F(AmberScriptParserTest, RunDrawArraysInvalidStartIdxValue) {
@@ -669,10 +817,16 @@ SHADER vertex my_shader PASSTHROUGH
 SHADER fragment my_fragment GLSL
 # GLSL Shader
 END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
 
 PIPELINE graphics my_pipeline
   ATTACH my_shader
   ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
 END
 
 RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1.3 COUNT 2)";
@@ -680,7 +834,7 @@ RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1.3 COUNT 2)";
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("12: invalid START_IDX value for RUN command: 1.3", r.Error());
+  EXPECT_EQ("18: invalid START_IDX value for RUN command: 1.3", r.Error());
 }
 
 TEST_F(AmberScriptParserTest, RunDrawArraysNegativeStartIdxValue) {
@@ -689,10 +843,16 @@ SHADER vertex my_shader PASSTHROUGH
 SHADER fragment my_fragment GLSL
 # GLSL Shader
 END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
 
 PIPELINE graphics my_pipeline
   ATTACH my_shader
   ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
 END
 
 RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX -1 COUNT 2)";
@@ -700,7 +860,7 @@ RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX -1 COUNT 2)";
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("12: START_IDX value must be >= 0 for RUN command", r.Error());
+  EXPECT_EQ("18: START_IDX value must be >= 0 for RUN command", r.Error());
 }
 
 TEST_F(AmberScriptParserTest, RunDrawArraysMissingCount) {
@@ -709,10 +869,16 @@ SHADER vertex my_shader PASSTHROUGH
 SHADER fragment my_fragment GLSL
 # GLSL Shader
 END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
 
 PIPELINE graphics my_pipeline
   ATTACH my_shader
   ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
 END
 
 RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1 2)";
@@ -720,7 +886,7 @@ RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1 2)";
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("12: missing COUNT for RUN command", r.Error());
+  EXPECT_EQ("18: missing COUNT for RUN command", r.Error());
 }
 
 TEST_F(AmberScriptParserTest, RunDrawArraysMissingCountValue) {
@@ -729,10 +895,16 @@ SHADER vertex my_shader PASSTHROUGH
 SHADER fragment my_fragment GLSL
 # GLSL Shader
 END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
 
 PIPELINE graphics my_pipeline
   ATTACH my_shader
   ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
 END
 
 RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1 COUNT)";
@@ -740,7 +912,61 @@ RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1 COUNT)";
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("12: invalid COUNT value for RUN command: ", r.Error());
+  EXPECT_EQ("18: invalid COUNT value for RUN command: ", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, RunDrawArraysStartIdxTooLarge) {
+  std::string in = R"(
+SHADER vertex my_shader PASSTHROUGH
+SHADER fragment my_fragment GLSL
+# GLSL Shader
+END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
+
+PIPELINE graphics my_pipeline
+  ATTACH my_shader
+  ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
+END
+
+RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 9 COUNT 1)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("18: START_IDX plus COUNT exceeds vertex buffer data size",
+            r.Error());
+}
+
+TEST_F(AmberScriptParserTest, RunDrawArraysCountTooLarge) {
+  std::string in = R"(
+SHADER vertex my_shader PASSTHROUGH
+SHADER fragment my_fragment GLSL
+# GLSL Shader
+END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
+
+PIPELINE graphics my_pipeline
+  ATTACH my_shader
+  ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
+END
+
+RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1 COUNT 9)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("18: START_IDX plus COUNT exceeds vertex buffer data size",
+            r.Error());
 }
 
 TEST_F(AmberScriptParserTest, RunDrawArraysInvalidCountValueFormat) {
@@ -749,10 +975,16 @@ SHADER vertex my_shader PASSTHROUGH
 SHADER fragment my_fragment GLSL
 # GLSL Shader
 END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
 
 PIPELINE graphics my_pipeline
   ATTACH my_shader
   ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
 END
 
 RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1 COUNT INVALID)";
@@ -760,7 +992,7 @@ RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1 COUNT INVALID)";
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("12: invalid COUNT value for RUN command: INVALID", r.Error());
+  EXPECT_EQ("18: invalid COUNT value for RUN command: INVALID", r.Error());
 }
 
 TEST_F(AmberScriptParserTest, RunDrawArraysInvalidCountValue) {
@@ -769,10 +1001,16 @@ SHADER vertex my_shader PASSTHROUGH
 SHADER fragment my_fragment GLSL
 # GLSL Shader
 END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
 
 PIPELINE graphics my_pipeline
   ATTACH my_shader
   ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
 END
 
 RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1 COUNT 2.4)";
@@ -780,7 +1018,7 @@ RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1 COUNT 2.4)";
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("12: invalid COUNT value for RUN command: 2.4", r.Error());
+  EXPECT_EQ("18: invalid COUNT value for RUN command: 2.4", r.Error());
 }
 
 TEST_F(AmberScriptParserTest, RunDrawArraysNegativeCountValue) {
@@ -789,10 +1027,16 @@ SHADER vertex my_shader PASSTHROUGH
 SHADER fragment my_fragment GLSL
 # GLSL Shader
 END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
 
 PIPELINE graphics my_pipeline
   ATTACH my_shader
   ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
 END
 
 RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1 COUNT -2)";
@@ -800,7 +1044,7 @@ RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1 COUNT -2)";
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("12: COUNT value must be > 0 for RUN command", r.Error());
+  EXPECT_EQ("18: COUNT value must be > 0 for RUN command", r.Error());
 }
 
 TEST_F(AmberScriptParserTest, RunDrawArraysZeroCountValue) {
@@ -809,10 +1053,16 @@ SHADER vertex my_shader PASSTHROUGH
 SHADER fragment my_fragment GLSL
 # GLSL Shader
 END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
 
 PIPELINE graphics my_pipeline
   ATTACH my_shader
   ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
 END
 
 RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1 COUNT 0)";
@@ -820,7 +1070,7 @@ RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 1 COUNT 0)";
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("12: COUNT value must be > 0 for RUN command", r.Error());
+  EXPECT_EQ("18: COUNT value must be > 0 for RUN command", r.Error());
 }
 
 }  // namespace amberscript


### PR DESCRIPTION
This CL extends the parsing of the DRAW_ARRAYS command to allow dropping
the COUNT and START_IDX parameters as per the spec.

Fixes #474, #475.