### PR TITLE
[vkscript] Skip adding uniform buffer to list of pipeline buffers

### DIFF
--- a/src/vkscript/command_parser.cc
+++ b/src/vkscript/command_parser.cc
@@ -709,7 +709,8 @@ Result CommandParser::ProcessUniform() {
       b->SetName("AutoBuf-" + std::to_string(script_->GetBuffers().size()));
       buffer = b.get();
       script_->AddBuffer(std::move(b));
-      pipeline_->AddBuffer(buffer, set, binding);
+      if (!cmd->IsPushConstant())
+        pipeline_->AddBuffer(buffer, set, binding);
     }
     cmd->SetBuffer(buffer);
   }


### PR DESCRIPTION
The uniform buffer is purely a backing store and should not be added
into the list of buffers for the given pipeline.