### PR TITLE
[amberscript] Add ability to set engine data

### DIFF
--- a/docs/amber_script.md
+++ b/docs/amber_script.md
@@ -25,7 +25,7 @@ which is the characters `0x` followed by hexadecimal digits.
 
 ### Requesting features
 
-If specific device featuers are required you can use the DEVICE_FEATURE command
+If specific device features are required you can use the DEVICE\_FEATURE command
 to enable them.
 
 ```groovy
@@ -36,6 +36,19 @@ DEVICE_FEATURE VariablePointerFeatures.variablePointersStorageBuffer
 Currently each of the items in `VkPhysicalDeviceFeatures` are recognized along
 with `VariablePointerFeatures.variablePointers` and
 `VariablePointerFeatures.variablePointersStorageBuffer`.
+
+### Setting Engine Configuration
+
+In some instances there is extra data we want to provide to an engine for
+configuration purposes. The `SET ENGINE_DATA` command allows that for the given
+set of data types.
+
+#### Engine Data Variables
+  * `fence_timeout_ms`  - value must be a single uint32 in milliseconds.
+
+```groovy
+SET ENGINE_DATA {engine data variable} {value}*
+```
 
 ### Shaders
 
@@ -63,7 +76,7 @@ types, but in that case must only provide a single shader type in the module.
  * `GLSL`  (with glslang)
  * `HLSL`  (with dxc or glslang if dxc disabled)  -- future
  * `SPIRV-ASM` (with spirv-as)
- * `SPIRV-HEX` (decoded straight to spv)
+ * `SPIRV-HEX` (decoded straight to SPIR-V)
  * `OPENCL-C` (with clspv)  --- potentially?  -- future
 
 ```groovy

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,6 +89,7 @@ if (${AMBER_ENABLE_TESTS})
     amberscript/parser_pipeline_test.cc
     amberscript/parser_repeat_test.cc
     amberscript/parser_run_test.cc
+    amberscript/parser_set_test.cc
     amberscript/parser_shader_opt_test.cc
     amberscript/parser_shader_test.cc
     amberscript/parser_test.cc

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -84,6 +84,8 @@ Result Parser::Parse(const std::string& data) {
       r = ParsePipelineBlock();
     } else if (tok == "REPEAT") {
       r = ParseRepeat();
+    } else if (tok == "SET") {
+      r = ParseSet();
     } else if (tok == "SHADER") {
       r = ParseShaderBlock();
     } else {
@@ -1474,6 +1476,32 @@ Result Parser::ParseDerivePipelineBlock() {
   pipeline->SetName(name);
 
   return ParsePipelineBody("DERIVE_PIPELINE", std::move(pipeline));
+}
+
+Result Parser::ParseSet() {
+  auto token = tokenizer_->NextToken();
+  if (!token->IsString() || token->AsString() != "ENGINE_DATA")
+    return Result("SET missing ENGINE_DATA");
+
+  token = tokenizer_->NextToken();
+  if (token->IsEOS() || token->IsEOL())
+    return Result("SET missing variable to be set");
+
+  if (!token->IsString())
+    return Result("SET invalid variable to set: " + token->ToOriginalString());
+
+  if (token->AsString() != "fence_timeout_ms")
+    return Result("SET unknown variable provided: " + token->AsString());
+
+  token = tokenizer_->NextToken();
+  if (token->IsEOS() || token->IsEOL())
+    return Result("SET missing value for fence_timeout_ms");
+  if (!token->IsInteger())
+    return Result("SET invalid value for fence_timeout_ms, must be uint32");
+
+  script_->GetEngineData().fence_timeout_ms = token->AsUint32();
+
+  return ValidateEndOfStatement("SET command");
 }
 
 }  // namespace amberscript

--- a/src/amberscript/parser.h
+++ b/src/amberscript/parser.h
@@ -69,6 +69,7 @@ class Parser : public amber::Parser {
   Result ParseCopy();
   Result ParseDeviceFeature();
   Result ParseRepeat();
+  Result ParseSet();
   bool IsRepeatable(const std::string& name) const;
   Result ParseRepeatableCommand(const std::string& name);
   Result ParseDerivePipelineBlock();

--- a/src/amberscript/parser_set_test.cc
+++ b/src/amberscript/parser_set_test.cc
@@ -1,0 +1,101 @@
+// Copyright 2019 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or parseried.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+#include "src/amberscript/parser.h"
+
+namespace amber {
+namespace amberscript {
+
+using AmberScriptParserTest = testing::Test;
+
+TEST_F(AmberScriptParserTest, Set) {
+  std::string in = "SET ENGINE_DATA fence_timeout_ms 125";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto script = parser.GetScript();
+  auto& data = script->GetEngineData();
+
+  EXPECT_EQ(125U, data.fence_timeout_ms);
+}
+
+TEST_F(AmberScriptParserTest, SetMissingEngineData) {
+  std::string in = "SET fence_timeout_ms 125";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("1: SET missing ENGINE_DATA", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, SetMissingVariable) {
+  std::string in = "SET ENGINE_DATA";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("1: SET missing variable to be set", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, SetInvalidVariable) {
+  std::string in = "SET ENGINE_DATA 1234";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("1: SET invalid variable to set: 1234", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, SetWithUnknownVariable) {
+  std::string in = "SET ENGINE_DATA unknown";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("1: SET unknown variable provided: unknown", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, SetFenceTimeoutMissingValue) {
+  std::string in = "SET ENGINE_DATA fence_timeout_ms";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("1: SET missing value for fence_timeout_ms", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, SetFenceTimeInvalidValue) {
+  std::string in = "SET ENGINE_DATA fence_timeout_ms INVALID";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("1: SET invalid value for fence_timeout_ms, must be uint32",
+            r.Error());
+}
+
+TEST_F(AmberScriptParserTest, SetFenceTimeoutExtraParams) {
+  std::string in = "SET ENGINE_DATA fence_timeout_ms 100 EXTRA";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("1: extra parameters after SET command", r.Error());
+}
+
+}  // namespace amberscript
+}  // namespace amber


### PR DESCRIPTION
This CL adds a `SET ENGINE_DATA` command into amberscript. Currently the
only allowed value is `fence_timeout_ms`.

Fixes #489.