### PR TITLE
Add push constant graphics tests.

### DIFF
--- a/samples/png.cc
+++ b/samples/png.cc
@@ -50,7 +50,11 @@ amber::Result ConvertToPNG(uint32_t width,
                            uint32_t height,
                            const std::vector<amber::Value>& values,
                            std::vector<uint8_t>* buffer) {
-  assert(values.size() == width * height);
+  if (values.size() != (width * height)) {
+    return amber::Result("Values size (" + std::to_string(values.size()) +
+                         ") != " + "width * height (" +
+                         std::to_string(width * height) + ")");
+  }
 
   std::vector<uint8_t> data;
 

--- a/samples/ppm.cc
+++ b/samples/ppm.cc
@@ -20,7 +20,6 @@
 #include "amber/value.h"
 
 namespace ppm {
-
 namespace {
 
 const uint32_t kMaximumColorValue = 255;
@@ -39,11 +38,15 @@ uint8_t byte2(uint32_t word) {
 
 }  // namespace
 
-void ConvertToPPM(uint32_t width,
-                  uint32_t height,
-                  const std::vector<amber::Value>& values,
-                  std::vector<uint8_t>* buffer) {
-  assert(values.size() == width * height);
+amber::Result ConvertToPPM(uint32_t width,
+                           uint32_t height,
+                           const std::vector<amber::Value>& values,
+                           std::vector<uint8_t>* buffer) {
+  if (values.size() != (width * height)) {
+    return amber::Result("Values size (" + std::to_string(values.size()) +
+                         ") != " + "width * height (" +
+                         std::to_string(width * height) + ")");
+  }
 
   // Write PPM header
   std::string image = "P6\n";
@@ -62,6 +65,8 @@ void ConvertToPPM(uint32_t width,
     buffer->push_back(byte0(pixel));  // B
     // PPM does not support alpha channel
   }
+
+  return {};
 }
 
 }  // namespace ppm

--- a/samples/ppm.h
+++ b/samples/ppm.h
@@ -20,16 +20,17 @@
 #include <vector>
 
 #include "amber/amber.h"
+#include "amber/result.h"
 
 namespace ppm {
 
 /// Converts the image of dimensions |width| and |height| and with pixels stored
 /// in row-major order in |values| with format B8G8R8A8 into PPM format,
 /// returning the PPM binary in |buffer|.
-void ConvertToPPM(uint32_t width,
-                  uint32_t height,
-                  const std::vector<amber::Value>& values,
-                  std::vector<uint8_t>* buffer);
+amber::Result ConvertToPPM(uint32_t width,
+                           uint32_t height,
+                           const std::vector<amber::Value>& values,
+                           std::vector<uint8_t>* buffer);
 
 }  // namespace ppm
 

--- a/tests/cases/graphics_push_constants.amber
+++ b/tests/cases/graphics_push_constants.amber
@@ -1,0 +1,59 @@
+#!amber
+# Copyright 2019 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHADER vertex vtex_shader GLSL
+#version 450
+
+layout(push_constant) uniform PushConstants {
+  vec2 in_val[4];
+} u_pushConstants;
+
+void main() {
+  gl_Position = vec4(u_pushConstants.in_val[gl_VertexIndex], 0.0, 1.0);
+}
+END
+
+SHADER fragment frag_shader GLSL
+#version 430
+layout(location = 0) out vec4 outColor;
+
+void main() {
+  outColor = vec4(0.5, 0.5, 0.5, 1.0);
+}
+END
+
+BUFFER push_constants DATA_TYPE vec2<float> DATA
+-1.0 -1.0
+ 1.0 -1.0
+-1.0  0.0
+ 1.0  0.0
+END
+
+BUFFER framebuffer FORMAT B8G8R8A8_UNORM
+
+PIPELINE graphics pipeline
+  ATTACH vtex_shader
+  ATTACH frag_shader
+
+  BIND BUFFER push_constants AS push_constant
+  BIND BUFFER framebuffer AS color LOCATION 0
+  FRAMEBUFFER_SIZE 250 250
+END
+
+CLEAR pipeline
+RUN pipeline DRAW_RECT POS 0 0 SIZE 250 250
+
+EXPECT framebuffer IDX 0   0 SIZE 250 125 EQ_RGBA 127 127 127 255
+EXPECT framebuffer IDX 0 125 SIZE 250 125 EQ_RGBA   0   0   0   0

--- a/tests/cases/graphics_push_constants.vkscript
+++ b/tests/cases/graphics_push_constants.vkscript
@@ -1,0 +1,40 @@
+# Copyright 2019 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[vertex shader]
+#version 450
+
+layout(push_constant) uniform PushConstants {
+  vec2 in_val[4];
+} u_pushConstants;
+
+void main() {
+  gl_Position = vec4(u_pushConstants.in_val[gl_VertexIndex], 0.0, 1.0);
+}
+
+[fragment shader]
+#version 430
+layout(location = 0) out vec4 outColor;
+void main() {
+    outColor = vec4(0.5, 0.5, 0.5, 1.0);
+}
+
+[test]
+
+uniform float 0 -1.0 -1.0 1.0 -1.0 -1.0 0.0 1.0 0.0
+clear
+draw rect -1 -1 2 2
+
+probe rect rgba (0,   0, 250, 125) (0.5 0.5 0.5 1.0)
+probe rect rgba (0, 125, 250, 125) (0.0 0.0 0.0 0.0)


### PR DESCRIPTION
Currently all the push constant tests are compute based. This CL adds a
graphics push constant test in both VkScript and AmberScript.

(Along the way, the error message for outputting an image buffer was
cleaned up to make it clearer what failed.)