### PR TITLE
[amberscript] Add instance and device extensions

### DIFF
--- a/docs/amber_script.md
+++ b/docs/amber_script.md
@@ -25,8 +25,8 @@ which is the characters `0x` followed by hexadecimal digits.
 
 ### Requesting features
 
-If specific device featuers are required you can use the DEVICE_FEATURE command
-to enable them.
+If specific device features are required you can use the `DEVICE_FEATURE`
+command to enable them.
 
 ```groovy
 DEVICE_FEATURE vertexPipelineStoresAndAtomics
@@ -36,6 +36,13 @@ DEVICE_FEATURE VariablePointerFeatures.variablePointersStorageBuffer
 Currently each of the items in `VkPhysicalDeviceFeatures` are recognized along
 with `VariablePointerFeatures.variablePointers` and
 `VariablePointerFeatures.variablePointersStorageBuffer`.
+
+Extensions can be enabled with the `DEVICE_EXTENSION` and `INSTANCE_EXTENSION`
+commands.
+```groovy
+DEVICE_EXTENSION VK_KHR_get_physical_device_properties2
+INSTANCE_EXTENSION VK_KHR_storage_buffer_storage_class
+```
 
 ### Shaders
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,6 +85,7 @@ if (${AMBER_ENABLE_TESTS})
     amberscript/parser_copy_test.cc
     amberscript/parser_device_feature_test.cc
     amberscript/parser_expect_test.cc
+    amberscript/parser_extension_test.cc
     amberscript/parser_framebuffer_test.cc
     amberscript/parser_pipeline_test.cc
     amberscript/parser_repeat_test.cc

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -80,6 +80,10 @@ Result Parser::Parse(const std::string& data) {
       r = ParseDerivePipelineBlock();
     } else if (tok == "DEVICE_FEATURE") {
       r = ParseDeviceFeature();
+    } else if (tok == "DEVICE_EXTENSION") {
+      r = ParseDeviceExtension();
+    } else if (tok == "INSTANCE_EXTENSION") {
+      r = ParseInstanceExtension();
     } else if (tok == "PIPELINE") {
       r = ParsePipelineBlock();
     } else if (tok == "REPEAT") {
@@ -1484,6 +1488,34 @@ Result Parser::ParseDerivePipelineBlock() {
   pipeline->SetName(name);
 
   return ParsePipelineBody("DERIVE_PIPELINE", std::move(pipeline));
+}
+
+Result Parser::ParseDeviceExtension() {
+  auto token = tokenizer_->NextToken();
+  if (token->IsEOL() || token->IsEOS())
+    return Result("DEVICE_EXTENSION missing name");
+  if (!token->IsString()) {
+    return Result("DEVICE_EXTENSION invalid name: " +
+                  token->ToOriginalString());
+  }
+
+  script_->AddRequiredDeviceExtension(token->AsString());
+
+  return ValidateEndOfStatement("DEVICE_EXTENSION command");
+}
+
+Result Parser::ParseInstanceExtension() {
+  auto token = tokenizer_->NextToken();
+  if (token->IsEOL() || token->IsEOS())
+    return Result("INSTANCE_EXTENSION missing name");
+  if (!token->IsString()) {
+    return Result("INSTANCE_EXTENSION invalid name: " +
+                  token->ToOriginalString());
+  }
+
+  script_->AddRequiredInstanceExtension(token->AsString());
+
+  return ValidateEndOfStatement("INSTANCE_EXTENSION command");
 }
 
 }  // namespace amberscript

--- a/src/amberscript/parser.h
+++ b/src/amberscript/parser.h
@@ -68,6 +68,8 @@ class Parser : public amber::Parser {
   Result ParseExpect();
   Result ParseCopy();
   Result ParseDeviceFeature();
+  Result ParseDeviceExtension();
+  Result ParseInstanceExtension();
   Result ParseRepeat();
   bool IsRepeatable(const std::string& name) const;
   Result ParseRepeatableCommand(const std::string& name);

--- a/src/amberscript/parser_extension_test.cc
+++ b/src/amberscript/parser_extension_test.cc
@@ -1,0 +1,139 @@
+// Copyright 2019 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+#include "src/amberscript/parser.h"
+
+namespace amber {
+namespace amberscript {
+
+using AmberScriptParserTest = testing::Test;
+
+TEST_F(AmberScriptParserTest, ExtensionInstance) {
+  std::string in = "INSTANCE_EXTENSION VK_KHR_storage_buffer_storage_class";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto script = parser.GetScript();
+  auto ext = script->GetRequiredInstanceExtensions();
+  ASSERT_EQ(1U, ext.size());
+  EXPECT_EQ("VK_KHR_storage_buffer_storage_class", ext[0]);
+}
+
+TEST_F(AmberScriptParserTest, ExtensionInstanceMulti) {
+  std::string in = R"(
+INSTANCE_EXTENSION VK_KHR_storage_buffer_storage_class
+INSTANCE_EXTENSION VK_KHR_variable_pointers)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto script = parser.GetScript();
+  auto ext = script->GetRequiredInstanceExtensions();
+  ASSERT_EQ(2U, ext.size());
+  EXPECT_EQ("VK_KHR_storage_buffer_storage_class", ext[0]);
+  EXPECT_EQ("VK_KHR_variable_pointers", ext[1]);
+}
+
+TEST_F(AmberScriptParserTest, ExtensionInstanceMissingName) {
+  std::string in = "INSTANCE_EXTENSION";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+
+  EXPECT_EQ("1: INSTANCE_EXTENSION missing name", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, ExtensionInstanceInvalidName) {
+  std::string in = "INSTANCE_EXTENSION 1234";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+
+  EXPECT_EQ("1: INSTANCE_EXTENSION invalid name: 1234", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, ExtensionInstanceExtraParams) {
+  std::string in = "INSTANCE_EXTENSION VK_KHR_variable_pointers EXTRA";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+
+  EXPECT_EQ("1: extra parameters after INSTANCE_EXTENSION command", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, ExtensionDevice) {
+  std::string in = "DEVICE_EXTENSION VK_KHR_get_physical_device_properties2";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto script = parser.GetScript();
+  auto ext = script->GetRequiredDeviceExtensions();
+  ASSERT_EQ(1U, ext.size());
+  EXPECT_EQ("VK_KHR_get_physical_device_properties2", ext[0]);
+}
+
+TEST_F(AmberScriptParserTest, ExtensionDeviceMulti) {
+  std::string in = R"(
+DEVICE_EXTENSION VK_KHR_get_physical_device_properties2
+DEVICE_EXTENSION VK_KHR_external_memory)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto script = parser.GetScript();
+  auto ext = script->GetRequiredDeviceExtensions();
+  ASSERT_EQ(2U, ext.size());
+  EXPECT_EQ("VK_KHR_get_physical_device_properties2", ext[0]);
+  EXPECT_EQ("VK_KHR_external_memory", ext[1]);
+}
+
+TEST_F(AmberScriptParserTest, ExtensionDeviceMissingName) {
+  std::string in = "DEVICE_EXTENSION";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("1: DEVICE_EXTENSION missing name", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, ExtensionDeviceInvalidName) {
+  std::string in = "DEVICE_EXTENSION 1234";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("1: DEVICE_EXTENSION invalid name: 1234", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, ExtensionDeviceExtraParams) {
+  std::string in = "DEVICE_EXTENSION VK_KHR_external_memory EXTRA";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("1: extra parameters after DEVICE_EXTENSION command", r.Error());
+}
+
+}  // namespace amberscript
+}  // namespace amber

--- a/src/script.cc
+++ b/src/script.cc
@@ -41,9 +41,9 @@ std::vector<ShaderInfo> Script::GetShaderInfo() const {
 void Script::AddRequiredExtension(const std::string& ext) {
   // Make this smarter when we have more instance extensions to match.
   if (ext == "VK_KHR_get_physical_device_properties2")
-    engine_info_.required_instance_extensions.push_back(ext);
+    AddRequiredInstanceExtension(ext);
   else
-    engine_info_.required_device_extensions.push_back(ext);
+    AddRequiredDeviceExtension(ext);
 }
 
 bool Script::IsKnownFeature(const std::string& name) const {

--- a/src/script.h
+++ b/src/script.h
@@ -130,7 +130,19 @@ class Script : public RecipeImpl {
     engine_info_.required_features.push_back(feature);
   }
 
+  /// Adds |ext| to the list of device extensions that must be supported.
+  void AddRequiredDeviceExtension(const std::string& ext) {
+    engine_info_.required_device_extensions.push_back(ext);
+  }
+
+  /// Adds |ext| to the list of instance extensions that must be supported.
+  void AddRequiredInstanceExtension(const std::string& ext) {
+    engine_info_.required_instance_extensions.push_back(ext);
+  }
+
   /// Adds |ext| to the list of extensions that must be supported by the engine.
+  /// Note, this should only be used by the VkScript engine where there is no
+  /// differentiation between the types of extensions.
   void AddRequiredExtension(const std::string& ext);
 
   /// Retrieves the engine configuration data for this script.


### PR DESCRIPTION
This CL adds support for parsing instance and device extensions in
amberscript test files.

Fixes #346