### PR TITLE
[amberscript] Add INDEXED parsing

### DIFF
--- a/docs/amber_script.md
+++ b/docs/amber_script.md
@@ -300,19 +300,19 @@ RUN {pipeline_name} DRAW_ARRAY AS {topology} START_IDX _value_ \
 # data and  index data must be attached to the pipeline. The vertices will be
 # drawn using the given |topology|. A start index of 0 will be used and the
 # count will be determined by the size of the index data buffer.
-RUN {pipeline_name} DRAW_ARRAY INDEXED AS {topology}
+RUN {pipeline_name} DRAW_ARRAY AS {topology} INDEXED
 
 # Run the |pipeline_name| which must be a `graphics` pipeline. The vertex
 # data and  index data must be attached to the pipeline. The vertices will be
 # drawn using the given |topology|. A start index of |value| will be used and
 # the count will be determined by the size of the index data buffer.
-RUN {pipeline_name} DRAW_ARRAY INDEXED AS {topology} START_IDX _value_
+RUN {pipeline_name} DRAW_ARRAY AS {topology} INDEXED START_IDX _value_
 
 # Run the |pipeline_name| which must be a `graphics` pipeline. The vertex
 # data and  index data must be attached to the pipeline. The vertices will be
 # drawn using the given |topology|. A start index of |value| will be used and
 # the count of |count_value| items will be processed.
-RUN {pipeline_name} DRAW_ARRAY INDEXED AS {topology} \
+RUN {pipeline_name} DRAW_ARRAY AS {topology} INDEXED \
   START_IDX _value_ COUNT _count_value_
 ```
 

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -1020,6 +1020,9 @@ Result Parser::ParseRun() {
     token = tokenizer_->NextToken();
     bool indexed = false;
     if (token->IsString() && token->AsString() == "INDEXED") {
+      if (!pipeline->GetIndexBuffer())
+        return Result("RUN DRAW_ARRAYS INDEXED requires attached index buffer");
+
       indexed = true;
       token = tokenizer_->NextToken();
     }

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -1012,6 +1012,12 @@ Result Parser::ParseRun() {
       return Result("invalid topology for RUN command: " + token->AsString());
 
     token = tokenizer_->NextToken();
+    bool indexed = false;
+    if (token->IsString() && token->AsString() == "INDEXED") {
+      indexed = true;
+      token = tokenizer_->NextToken();
+    }
+
     uint32_t start_idx = 0;
     uint32_t count = 0;
     if (!token->IsEOS() && !token->IsEOL()) {
@@ -1061,6 +1067,9 @@ Result Parser::ParseRun() {
     cmd->SetTopology(topo);
     cmd->SetFirstVertexIndex(start_idx);
     cmd->SetVertexCount(count);
+
+    if (indexed)
+      cmd->EnableIndexed();
 
     command_list_.push_back(std::move(cmd));
     return ValidateEndOfStatement("RUN command");

--- a/src/amberscript/parser_run_test.cc
+++ b/src/amberscript/parser_run_test.cc
@@ -619,11 +619,17 @@ BUFFER vtex_buf DATA_TYPE vec3<float> DATA
 4 5 6
 7 8 9
 END
+BUFFER idx_buf DATA_TYPE vec3<float> DATA
+9 8 7
+6 5 4
+3 2 1
+END
 
 PIPELINE graphics my_pipeline
   ATTACH my_shader
   ATTACH my_fragment
   VERTEX_DATA vtex_buf LOCATION 0
+  INDEX_DATA idx_buf
 END
 
 RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST INDEXED)";
@@ -646,6 +652,34 @@ RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST INDEXED)";
   EXPECT_EQ(static_cast<uint32_t>(0U), cmd->GetFirstVertexIndex());
   // There are 3 elements in the vertex buffer.
   EXPECT_EQ(3U, cmd->GetVertexCount());
+}
+
+TEST_F(AmberScriptParserTest, RunDrawArraysIndexedMissingIndexData) {
+  std::string in = R"(
+SHADER vertex my_shader PASSTHROUGH
+SHADER fragment my_fragment GLSL
+# GLSL Shader
+END
+BUFFER vtex_buf DATA_TYPE vec3<float> DATA
+1 2 3
+4 5 6
+7 8 9
+END
+
+PIPELINE graphics my_pipeline
+  ATTACH my_shader
+  ATTACH my_fragment
+  VERTEX_DATA vtex_buf LOCATION 0
+END
+
+RUN my_pipeline DRAW_ARRAY AS TRIANGLE_LIST INDEXED)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+
+  EXPECT_EQ("18: RUN DRAW_ARRAYS INDEXED requires attached index buffer",
+            r.Error());
 }
 
 TEST_F(AmberScriptParserTest, RunDrawArraysMissingVertexBuffer) {


### PR DESCRIPTION
This CL adds parsing of the INDEXED parameter to DRAW_ARRAYS. This
amends the spec slightly to move the INDEXED after the topology. This
better matches with other DRAW_ARRAY commands.

Fixes #473