### PR TITLE
[VkScript] Add pipeline validation.

### DIFF
--- a/src/executor_test.cc
+++ b/src/executor_test.cc
@@ -218,6 +218,7 @@ robustBufferAccess
 logicOp)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto script = parser.GetScript();
@@ -248,6 +249,7 @@ VK_KHR_storage_buffer_storage_class
 VK_KHR_variable_pointers)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto script = parser.GetScript();
@@ -278,6 +280,7 @@ framebuffer R32G32B32A32_SFLOAT
 depthstencil D24_UNORM_S8_UINT)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto script = parser.GetScript();
@@ -305,6 +308,7 @@ TEST_F(VkScriptExecutorTest, ExecutesRequiredFenceTimeout) {
 fence_timeout 12345)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto script = parser.GetScript();
@@ -338,6 +342,7 @@ depthstencil D24_UNORM_S8_UINT
 fence_timeout 12345)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto script = parser.GetScript();
@@ -369,6 +374,7 @@ TEST_F(VkScriptExecutorTest, ClearCommand) {
 clear)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -387,6 +393,7 @@ TEST_F(VkScriptExecutorTest, ClearCommandFailure) {
 clear)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -406,6 +413,7 @@ TEST_F(VkScriptExecutorTest, ClearColorCommand) {
 clear color 244 123 123 13)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -433,6 +441,7 @@ TEST_F(VkScriptExecutorTest, ClearColorCommandFailure) {
 clear color 123 123 123 123)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -452,6 +461,7 @@ TEST_F(VkScriptExecutorTest, ClearDepthCommand) {
 clear depth 24)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -470,6 +480,7 @@ TEST_F(VkScriptExecutorTest, ClearDepthCommandFailure) {
 clear depth 24)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -489,6 +500,7 @@ TEST_F(VkScriptExecutorTest, ClearStencilCommand) {
 clear stencil 24)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -507,6 +519,7 @@ TEST_F(VkScriptExecutorTest, ClearStencilCommandFailure) {
 clear stencil 24)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -526,6 +539,7 @@ TEST_F(VkScriptExecutorTest, DrawRectCommand) {
 draw rect 2 4 10 20)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -544,6 +558,7 @@ TEST_F(VkScriptExecutorTest, DrawRectCommandFailure) {
 draw rect 2 4 10 20)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -563,6 +578,7 @@ TEST_F(VkScriptExecutorTest, DrawArraysCommand) {
 draw arrays TRIANGLE_LIST 0 0)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -581,6 +597,7 @@ TEST_F(VkScriptExecutorTest, DrawArraysCommandFailure) {
 draw arrays TRIANGLE_LIST 0 0)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -600,6 +617,7 @@ TEST_F(VkScriptExecutorTest, ComputeCommand) {
 compute 2 3 4)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -618,6 +636,7 @@ TEST_F(VkScriptExecutorTest, ComputeCommandFailure) {
 compute 2 3 4)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -637,6 +656,7 @@ TEST_F(VkScriptExecutorTest, EntryPointCommand) {
 vertex entrypoint main)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -655,6 +675,7 @@ TEST_F(VkScriptExecutorTest, EntryPointCommandFailure) {
 vertex entrypoint main)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -674,6 +695,7 @@ TEST_F(VkScriptExecutorTest, PatchParameterVerticesCommand) {
 patch parameter vertices 10)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -692,6 +714,7 @@ TEST_F(VkScriptExecutorTest, PatchParameterVerticesCommandFailure) {
 patch parameter vertices 10)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -748,6 +771,7 @@ TEST_F(VkScriptExecutorTest, BufferCommand) {
 ssbo 0 24)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();
@@ -766,6 +790,7 @@ TEST_F(VkScriptExecutorTest, BufferCommandFailure) {
 ssbo 0 24)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   ASSERT_TRUE(parser.Parse(input).IsSuccess());
 
   auto engine = MakeEngine();

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -155,6 +155,13 @@ Result Pipeline::Validate() const {
   if (depth_buffer_.buffer && depth_buffer_.buffer->ElementCount() != fb_size)
     return Result("shared depth buffer must have same size over all PIPELINES");
 
+  for (auto& buf : GetBuffers()) {
+    if (buf.buffer->GetFormat() == nullptr) {
+      return Result("buffer (" + std::to_string(buf.descriptor_set) + ":" +
+                    std::to_string(buf.binding) + ") requires a format");
+    }
+  }
+
   if (pipeline_type_ == PipelineType::kGraphics)
     return ValidateGraphics();
   return ValidateCompute();

--- a/src/pipeline_test.cc
+++ b/src/pipeline_test.cc
@@ -302,6 +302,18 @@ TEST_F(PipelineTest, ComputePipelineWithoutShader) {
   EXPECT_EQ("compute pipeline requires a compute shader", r.Error());
 }
 
+TEST_F(PipelineTest, PipelineBufferWithoutFormat) {
+  Pipeline p(PipelineType::kCompute);
+
+  auto buf = MakeUnique<Buffer>(BufferType::kStorage);
+  buf->SetName("MyBuffer");
+  p.AddBuffer(buf.get(), 0, 0);
+
+  Result r = p.Validate();
+  EXPECT_FALSE(r.IsSuccess()) << r.Error();
+  EXPECT_EQ("buffer (0:0) requires a format", r.Error());
+}
+
 TEST_F(PipelineTest, SetEntryPointForMissingShader) {
   Shader c(kShaderTypeCompute);
   c.SetName("my_shader");

--- a/src/vkscript/parser.cc
+++ b/src/vkscript/parser.cc
@@ -62,7 +62,7 @@ Result Parser::Parse(const std::string& input) {
 
   if (!skip_validation_for_test_) {
     for (const auto& pipeline : script_->GetPipelines()) {
-      Result r = pipeline->Validate();
+      r = pipeline->Validate();
       if (!r.IsSuccess())
         return r;
     }

--- a/src/vkscript/parser.cc
+++ b/src/vkscript/parser.cc
@@ -60,6 +60,14 @@ Result Parser::Parse(const std::string& input) {
       return r;
   }
 
+  if (!skip_validation_for_test_) {
+    for (const auto& pipeline : script_->GetPipelines()) {
+      Result r = pipeline->Validate();
+      if (!r.IsSuccess())
+        return r;
+    }
+  }
+
   return {};
 }
 

--- a/src/vkscript/parser.h
+++ b/src/vkscript/parser.h
@@ -37,7 +37,11 @@ class Parser : public amber::Parser {
   // amber::Parser
   Result Parse(const std::string& data) override;
 
+  void SkipValidationForTest() { skip_validation_for_test_ = true; }
+
  private:
+  bool skip_validation_for_test_ = false;
+
   std::string make_error(const Tokenizer& tokenizer, const std::string& err);
   Result GenerateDefaultPipeline(const SectionParser& section_parser);
   Result ProcessSection(const SectionParser::Section& section);

--- a/src/vkscript/parser_test.cc
+++ b/src/vkscript/parser_test.cc
@@ -89,6 +89,7 @@ TEST_F(VkScriptParserTest, RequireBlockNoArgumentFeatures) {
     std::string in = std::string("[require]\n") + feature.name + "\n";
 
     Parser parser;
+    parser.SkipValidationForTest();
     Result r = parser.Parse(in);
     ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
@@ -106,6 +107,7 @@ VK_KHR_variable_pointers
 VK_KHR_get_physical_device_properties2)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   Result r = parser.Parse(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
@@ -124,6 +126,7 @@ TEST_F(VkScriptParserTest, RequireBlockFramebuffer) {
   std::string block = "[require]\nframebuffer R32G32B32A32_SFLOAT";
 
   Parser parser;
+  parser.SkipValidationForTest();
   Result r = parser.Parse(block);
   ASSERT_TRUE(r.IsSuccess());
 
@@ -139,6 +142,7 @@ TEST_F(VkScriptParserTest, RequireBlockDepthStencil) {
   std::string block = "[require]\ndepthstencil D24_UNORM_S8_UINT";
 
   Parser parser;
+  parser.SkipValidationForTest();
   Result r = parser.Parse(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
@@ -154,6 +158,7 @@ TEST_F(VkScriptParserTest, RequireFbSize) {
   std::string block = "[require]\nfbsize 300 400";
 
   Parser parser;
+  parser.SkipValidationForTest();
   Result r = parser.Parse(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
@@ -221,6 +226,7 @@ inheritedQueries # line comment
 )";
 
   Parser parser;
+  parser.SkipValidationForTest();
   Result r = parser.Parse(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
@@ -244,6 +250,7 @@ TEST_F(VkScriptParserTest, IndicesBlock) {
   std::string block = "[indices]\n1 2 3";
 
   Parser parser;
+  parser.SkipValidationForTest();
   Result r = parser.Parse(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
@@ -274,6 +281,7 @@ TEST_F(VkScriptParserTest, IndicesBlockMultipleLines) {
 )";
 
   Parser parser;
+  parser.SkipValidationForTest();
   Result r = parser.Parse(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
@@ -312,6 +320,7 @@ TEST_F(VkScriptParserTest, VertexDataEmpty) {
   std::string block = "[vertex data]\n#comment\n";
 
   Parser parser;
+  parser.SkipValidationForTest();
   Result r = parser.Parse(block);
   ASSERT_TRUE(r.IsSuccess());
 
@@ -323,6 +332,7 @@ TEST_F(VkScriptParserTest, VertexDataHeaderFormatString) {
   std::string block = "[vertex data]\n0/R32G32_SFLOAT 1/A8B8G8R8_UNORM_PACK32";
 
   Parser parser;
+  parser.SkipValidationForTest();
   Result r = parser.Parse(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
@@ -347,6 +357,7 @@ TEST_F(VkScriptParserTest, VertexDataHeaderGlslString) {
   std::string block = "[vertex data]\n0/float/vec2 1/int/vec3";
 
   Parser parser;
+  parser.SkipValidationForTest();
   Result r = parser.Parse(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
@@ -386,6 +397,7 @@ clear stencil 2
 clear)";
 
   Parser parser;
+  parser.SkipValidationForTest();
   Result r = parser.Parse(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
@@ -419,6 +431,7 @@ TEST_F(VkScriptParserTest, VertexDataRows) {
 )";
 
   Parser parser;
+  parser.SkipValidationForTest();
   Result r = parser.Parse(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
@@ -479,6 +492,7 @@ TEST_F(VkScriptParserTest, VertexDataRowsWithHex) {
 )";
 
   Parser parser;
+  parser.SkipValidationForTest();
   Result r = parser.Parse(block);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 

--- a/tests/cases/buffer_without_format.expect_fail.vkscript
+++ b/tests/cases/buffer_without_format.expect_fail.vkscript
@@ -1,0 +1,30 @@
+# Copyright 2019 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[compute shader]
+#version 430
+
+layout(set = 0, binding = 1) buffer block0 {
+  int data[2];
+};
+
+void main() {
+  data[0] = 0;
+  data[1] = 1;
+}
+
+[test]
+ssbo 0:0 2
+
+compute 1 1 1


### PR DESCRIPTION
This Cl adds the AmberScript pipeline validation into the VkScript
parser. The validation is extended to validate that all buffers have a
format provided.

Fixes #501.