### PR TITLE
Only resize buffer if it will become bigger.

### DIFF
--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -122,7 +122,14 @@ Result Buffer::SetDataWithOffset(const std::vector<Value>& data,
   uint32_t value_count =
       ((offset / format_->SizeInBytes()) * format_->InputNeededPerElement()) +
       static_cast<uint32_t>(data.size());
-  SetValueCount(value_count);
+  // The buffer should only be resized to become bigger. This means that if a
+  // command was run to set the buffer size we'll honour that size until a
+  // request happens to make the buffer bigger.
+  if (value_count > ValueCount())
+    SetValueCount(value_count);
+
+  // Even if the value count doesn't change, the buffer is still resized because
+  // this maybe the first time data is set into the buffer.
   bytes_.resize(GetSizeInBytes());
 
   uint8_t* ptr = bytes_.data() + offset;

--- a/src/buffer_test.cc
+++ b/src/buffer_test.cc
@@ -54,7 +54,7 @@ TEST_F(BufferTest, SizeFromData) {
   EXPECT_EQ(5 * sizeof(float), b.GetSizeInBytes());
 }
 
-TEST_F(BufferTest, SizeFromDataOverrideSize) {
+TEST_F(BufferTest, SizeFromDataDoesNotOverrideSize) {
   std::vector<Value> values;
   values.resize(5);
 
@@ -64,9 +64,9 @@ TEST_F(BufferTest, SizeFromDataOverrideSize) {
   b.SetElementCount(20);
   b.SetData(std::move(values));
 
-  EXPECT_EQ(5, b.ElementCount());
-  EXPECT_EQ(5, b.ValueCount());
-  EXPECT_EQ(5 * sizeof(float), b.GetSizeInBytes());
+  EXPECT_EQ(20, b.ElementCount());
+  EXPECT_EQ(20, b.ValueCount());
+  EXPECT_EQ(20 * sizeof(float), b.GetSizeInBytes());
 }
 
 TEST_F(BufferTest, SizeMatrix) {

--- a/tests/cases/ssbo_subdata_size.vkscript
+++ b/tests/cases/ssbo_subdata_size.vkscript
@@ -1,0 +1,35 @@
+# Copyright 2019 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[compute shader]
+#version 450
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+layout(binding = 1) buffer data_buf {
+    int val0;
+    int val1;
+} data;
+
+void main() {
+    data.val0 = 100;
+    data.val1 = 200;
+}
+
+[test]
+ssbo 0:1 8
+ssbo 0:1 subdata int 0 0
+
+compute 1 1 1
+
+probe ssbo int 0:1 0 == 100 200


### PR DESCRIPTION
When setting data into the buffer we were resizing the buffer to fit the
values provided. This is incorrect as a buffer may have been sized
explicitly with a size command and we don't want to make it smaller.

This CL changes the code to only resize the buffer bigger and not
smaller.

Fixes #503