### PR TITLE
Allow setting name of framebuffer to extract.

### DIFF
--- a/include/amber/amber.h
+++ b/include/amber/amber.h
@@ -51,6 +51,8 @@ struct BufferInfo {
 
   BufferInfo& operator=(const BufferInfo&);
 
+  /// Determines if this is an image buffer.
+  bool is_image_buffer;
   /// Holds the buffer name
   std::string buffer_name;
   /// Holds the buffer width

--- a/src/amber.cc
+++ b/src/amber.cc
@@ -72,7 +72,7 @@ Options::Options()
 
 Options::~Options() = default;
 
-BufferInfo::BufferInfo() : width(0), height(0) {}
+BufferInfo::BufferInfo() : is_image_buffer(false), width(0), height(0) {}
 
 BufferInfo::BufferInfo(const BufferInfo&) = default;
 
@@ -189,7 +189,7 @@ amber::Result Amber::ExecuteWithShaderData(const amber::Recipe* recipe,
   // extractor fails before running the pipeline that will trigger the dumps
   // to almost always fail.
   for (BufferInfo& buffer_info : opts->extractions) {
-    if (buffer_info.buffer_name == Pipeline::kGeneratedColorBuffer) {
+    if (buffer_info.is_image_buffer) {
       auto* buffer = script->GetBuffer(buffer_info.buffer_name);
       if (!buffer)
         break;


### PR DESCRIPTION
Currently the framebuffer must be named 'framebuffer' for the image
extraction to work correctly. This CL adds a -I option to the sample app
and changes the BufferInfo structure to record if it is an image that is
being extracted.

Fixes #505