### PR TITLE
Add support for building SwiftShader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ third_party/lodepng
 third_party/shaderc
 third_party/spirv-tools
 third_party/spirv-headers
+third_party/swiftshader
 third_party/vulkan-headers
 third_party/vulkan-loader
 .vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ option(AMBER_SKIP_SHADERC
 option(AMBER_SKIP_SAMPLES
   "Skip building sample application" ${AMBER_SKIP_SAMPLES})
 option(AMBER_USE_LOCAL_VULKAN "Build with vulkan in third_party" OFF)
+option(AMBER_ENABLE_SWIFTSHADER
+  "Build using SwiftShader" ${AMBER_ENABLE_SWIFTSHADER})
+option(AMBER_USE_LOCAL_VULKAN "Build with vulkan in third_party" OFF)
 
 if (${AMBER_SKIP_SPIRV_TOOLS})
   set(AMBER_ENABLE_SPIRV_TOOLS FALSE)
@@ -66,6 +69,11 @@ else()
   set(AMBER_ENABLE_SAMPLES TRUE)
 endif()
 
+if (${AMBER_ENABLE_SWIFTSHADER})
+  # Swiftshader requires the loader to be built.
+  set(AMBER_USE_LOCAL_VULKAN TRUE)
+endif()
+
 if (${AMBER_USE_LOCAL_VULKAN})
   message(STATUS "Using python3")
   # vulkan-loaders requires python 3
@@ -76,6 +84,7 @@ message(STATUS "Amber enable SPIRV-Tools: ${AMBER_ENABLE_SPIRV_TOOLS}")
 message(STATUS "Amber enable Shaderc: ${AMBER_ENABLE_SHADERC}")
 message(STATUS "Amber enable tests: ${AMBER_ENABLE_TESTS}")
 message(STATUS "Amber enable samples: ${AMBER_ENABLE_SAMPLES}")
+message(STATUS "Amber enable SwiftShader: ${AMBER_ENABLE_SWIFTSHADER}")
 
 include_directories("${PROJECT_SOURCE_DIR}/include")
 include_directories("${PROJECT_SOURCE_DIR}")

--- a/DEPS
+++ b/DEPS
@@ -4,6 +4,7 @@ vars = {
   'google_git':  'https://github.com/google',
   'khronos_git': 'https://github.com/KhronosGroup',
   'lvandeve_git':  'https://github.com/lvandeve',
+  'swiftshader_git': 'https://swiftshader.googlesource.com',
 
   'cpplint_revision': '9f41862c0efa7681e2147910d39629c73a2b2702',
   'glslang_revision': 'f44b17ee135d5e153ce000e88b806b5377812b11',
@@ -12,6 +13,7 @@ vars = {
   'shaderc_revision': '53c776f776821bc037b31b8b3b79db2fa54b4ce7',
   'spirv_headers_revision': '03a081524afabdde274d885880c2fef213e46a59',
   'spirv_tools_revision': '07f80c4df1b0619ee484c38e79a7ad71f672ca14',
+  'swiftshader_revision': '67cf8a9266d0a2a39f5823d67ffa50698977302b',
   'vulkan_headers_revision': '8e2c4cd554b644592a6d904f2c8000ebbd4aa77f',
   'vulkan_loader_revision': '15fa85d92454f7823febeb68b56038d427e2a7a4',
 }
@@ -37,6 +39,9 @@ deps = {
 
   'third_party/spirv-tools': vars['khronos_git'] + '/SPIRV-Tools.git@' +
       vars['spirv_tools_revision'],
+
+  'third_party/swiftshader': vars['swiftshader_git'] + '/SwiftShader.git@' +
+      vars['swiftshader_revision'],
 
   'third_party/vulkan-headers': vars['khronos_git'] + '/Vulkan-Headers.git@' +
       vars['vulkan_headers_revision'],

--- a/DEPS
+++ b/DEPS
@@ -13,7 +13,7 @@ vars = {
   'shaderc_revision': '53c776f776821bc037b31b8b3b79db2fa54b4ce7',
   'spirv_headers_revision': '03a081524afabdde274d885880c2fef213e46a59',
   'spirv_tools_revision': '07f80c4df1b0619ee484c38e79a7ad71f672ca14',
-  'swiftshader_revision': '67cf8a9266d0a2a39f5823d67ffa50698977302b',
+  'swiftshader_revision': 'a453ba42f72d0e513ada6bb29409bcde5d298612',
   'vulkan_headers_revision': '8e2c4cd554b644592a6d904f2c8000ebbd4aa77f',
   'vulkan_loader_revision': '15fa85d92454f7823febeb68b56038d427e2a7a4',
 }

--- a/README.md
+++ b/README.md
@@ -193,3 +193,15 @@ Please see the [CONTRIBUTING](CONTRIBUTING.md) and
 [Talvos]: https://talvos.github.io/
 [Vulkan-Headers]: https://github.com/KhronosGroup/Vulkan-Headers
 [VkRunner]: https://github.com/igalia/vkrunner
+
+### Using SwiftShader as a backend
+
+```
+mkdir out/sw
+cd out/sw
+cmake -GNinja -DAMBER_ENABLE_SWIFTSHADER=TRUE ../..
+ninja
+export VK_ICD_FILENAMES=$PWD/Linux/vk_swiftshader_icd.json
+./amber -d -V    # Should see SwiftShader listed as device
+./amber -d ../../tests/cases/clear.vkscript
+```

--- a/src/vulkan/find_vulkan.cmake
+++ b/src/vulkan/find_vulkan.cmake
@@ -19,17 +19,19 @@ set(Vulkan_FOUND FALSE)
 set(VULKAN_CTS_HEADER FALSE)
 set(VULKAN_LIB "")
 
-if (${AMBER_USE_LOCAL_VULKAN})
-  set(Vulkan_FOUND TRUE)
-  set(VulkanHeaders_INCLUDE_DIR
-    ${PROJECT_SOURCE_DIR}/third_party/vulkan-headers/include
-    CACHE PATH "vk headers dir" FORCE)
-  set(VulkanRegistry_DIR
-    ${PROJECT_SOURCE_DIR}/third_party/vulkan-headers/registry
-    CACHE PATH "vk_registry_dir" FORCE)
-  include_directories(BEFORE "${VulkanHeaders_INCLUDE_DIR}")
-  set(VULKAN_LIB vulkan)
-  message(STATUS "Amber: using local vulkan")
+if (NOT ${Vulkan_FOUND})
+  if (${AMBER_USE_LOCAL_VULKAN})
+    set(Vulkan_FOUND TRUE)
+    set(VulkanHeaders_INCLUDE_DIR
+      ${PROJECT_SOURCE_DIR}/third_party/vulkan-headers/include
+      CACHE PATH "vk headers dir" FORCE)
+    set(VulkanRegistry_DIR
+      ${PROJECT_SOURCE_DIR}/third_party/vulkan-headers/registry
+      CACHE PATH "vk_registry_dir" FORCE)
+    include_directories(BEFORE "${VulkanHeaders_INCLUDE_DIR}")
+    set(VULKAN_LIB vulkan)
+    message(STATUS "Amber: using local vulkan")
+  endif()
 endif()
 
 if (NOT ${Vulkan_FOUND})

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -178,7 +178,10 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     -Wno-newline-eof
     -Wno-non-virtual-dtor
     -Wno-old-style-cast
+    -Wno-range-loop-analysis
     -Wno-redundant-parens
+    -Wno-reserved-id-macro
+    -Wno-return-std-move-in-c++11
     -Wno-shift-sign-overflow
     -Wno-sign-conversion
     -Wno-signed-enum-bitfield
@@ -186,8 +189,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     -Wno-shadow-field
     -Wno-shadow-field-in-constructor
     -Wno-shorten-64-to-32
-    -Wno-range-loop-analysis
-    -Wno-reserved-id-macro
+    -Wno-tautological-unsigned-zero-compare
     -Wno-undef
     -Wno-undefined-func-template
     -Wno-undefined-reinterpret-cast

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -146,6 +146,63 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set(VULKAN_LOADER_BUILD_FIXES
     -Wno-unknown-warning-option
   )
+
+  set(SWIFTSHADER_BUILD_FIXES
+    -Wno-cast-align
+    -Wno-cast-qual
+    -Wno-comma
+    -Wno-conditional-uninitialized
+    -Wno-conversion
+    -Wno-covered-switch-default
+    -Wno-deprecated
+    -Wno-disabled-macro-expansion
+    -Wno-documentation-unknown-command
+    -Wno-double-promotion
+    -Wno-error
+    -Wno-exit-time-destructors
+    -Wno-extra-semi
+    -Wno-float-equal
+    -Wno-format-nonliteral
+    -Wno-global-constructors
+    -Wno-gnu-anonymous-struct
+    -Wno-gnu-zero-variadic-macro-arguments
+    -Wno-header-hygiene
+    -Wno-implicit-fallthrough
+    -Wno-inconsistent-missing-destructor-override
+    -Wno-keyword-macro
+    -Wno-missing-field-initializers
+    -Wno-missing-noreturn
+    -Wno-missing-prototypes
+    -Wno-missing-variable-declarations
+    -Wno-nested-anon-types
+    -Wno-newline-eof
+    -Wno-non-virtual-dtor
+    -Wno-old-style-cast
+    -Wno-redundant-parens
+    -Wno-shift-sign-overflow
+    -Wno-sign-conversion
+    -Wno-signed-enum-bitfield
+    -Wno-shadow
+    -Wno-shadow-field
+    -Wno-shadow-field-in-constructor
+    -Wno-shorten-64-to-32
+    -Wno-range-loop-analysis
+    -Wno-reserved-id-macro
+    -Wno-undef
+    -Wno-undefined-func-template
+    -Wno-undefined-reinterpret-cast
+    -Wno-used-but-marked-unused
+    -Wno-unused-parameter
+    -Wno-unused-macros
+    -Wno-unused-member-function
+    -Wno-unused-template
+    -Wno-unreachable-code
+    -Wno-unreachable-code-break
+    -Wno-unreachable-code-return
+    -Wno-weak-template-vtables
+    -Wno-weak-vtables
+    -Wno-zero-as-null-pointer-constant
+  )
 endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
@@ -166,10 +223,16 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set(SPIRV_TOOLS_BUILD_FIXES "")
 
   set(SHADERC_BUILD_FIXES
-      -Wno-missing-field-initializers
-      -Wno-pedantic)
+    -Wno-missing-field-initializers
+    -Wno-pedantic)
 
   set(VULKAN_LOADER_BUILD_FIXES "")
+
+  set(SWIFTSHADER_BUILD_FIXES
+    -Wno-all
+    -Wno-error
+    -Wno-pedantic
+  )
 endif()
 
 if (MSVC)
@@ -250,6 +313,10 @@ if (MSVC)
   set(VULKAN_LOADER_BUILD_FIXES
     /W3
   )
+
+  set(SWIFTSHADER_BUILD_FIXES
+    /W3
+  )
 endif()
 
 if (${AMBER_ENABLE_TESTS})
@@ -318,3 +385,17 @@ if (${AMBER_USE_LOCAL_VULKAN})
   set(CMAKE_CXX_FLAGS ${CXX_BACK})
 endif()
 
+if (${AMBER_ENABLE_SWIFTSHADER})
+  set(CXX_BACK ${CMAKE_CXX_FLAGS})
+  SET(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "${SWIFTSHADER_BUILD_FIXES}")
+  STRING(REGEX REPLACE ";" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
+  set(BUILD_EGL FALSE CACHE BOOL FALSE)
+  set(BUILD_GLESv2 FALSE CACHE BOOL FALSE)
+  set(BUILD_GLES_CM FALSE CACHE BOOL FALSE)
+  set(BUILD_VULKAN TRUE CACHE BOOL TRUE)
+  set(BUILD_SAMPLES FALSE CACHE BOOL FALSE)
+  set(BUILD_TESTS FALSE CACHE BOOL FALSE)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/swiftshader)
+  set(CMAKE_CXX_FLAGS ${CXX_BACK})
+endif()


### PR DESCRIPTION
This CL adds swiftshader into Amber and allows amber to compile with swiftshader if AMBER_ENABLE_SWIFTSHADER is provided. If swiftshader is built, you can set your `VK_ICD_FILENAMES` to point to the generated icd (out/sw/Linux/vk_swiftshader_icd.json for instance) and swiftshader will be used to run the tests.