### PR TITLE
[vkscript] Set default format into buffers.

### DIFF
--- a/docs/vk_script.md
+++ b/docs/vk_script.md
@@ -232,7 +232,7 @@ use the same `type` or the script will be rejected as invalid.
  * `ssbo _binding_ _size_`
 
 Sets the number of elements in the SSBO at `binding` to `size`. The buffer will
-be created with a default format of `int`. This default format will be
+be created with a default format of `char`. This default format will be
 overridden by a call to `ssbo subdata` or `probe ssbo`.
 
 

--- a/docs/vk_script.md
+++ b/docs/vk_script.md
@@ -231,9 +231,9 @@ use the same `type` or the script will be rejected as invalid.
 ### SSBO size
  * `ssbo _binding_ _size_`
 
-Sets the number of elements in the SSBO at `binding` to `size`. Note, Amber
-requires a buffer to have a format. So, a `subdata` or `probe ssbo` call must
-be made with this buffer in order to set the buffer format.
+Sets the number of elements in the SSBO at `binding` to `size`. The buffer will
+be created with a default format of `int`. This default format will be
+overridden by a call to `ssbo subdata` or `probe ssbo`.
 
 
 ### SSBO subdata

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -73,10 +73,14 @@ class Buffer {
 
   /// Sets the Format of the buffer to |format|.
   void SetFormat(std::unique_ptr<Format> format) {
+    format_is_default_ = false;
     format_ = std::move(format);
   }
   /// Returns the Format describing the buffer data.
   Format* GetFormat() const { return format_.get(); }
+
+  void SetFormatIsDefault(bool val) { format_is_default_ = val; }
+  bool FormatIsDefault() const { return format_is_default_; }
 
   /// Sets the buffer |name|.
   void SetName(const std::string& name) { name_ = name; }
@@ -186,6 +190,7 @@ class Buffer {
   uint32_t width_ = 0;
   uint32_t height_ = 0;
   uint8_t location_ = 0;
+  bool format_is_default_ = false;
   std::vector<uint8_t> bytes_;
   std::unique_ptr<Format> format_;
 };

--- a/src/vkscript/command_parser.cc
+++ b/src/vkscript/command_parser.cc
@@ -756,8 +756,7 @@ Result CommandParser::ProcessUniform() {
                   std::to_string(token->AsInt32()));
   }
 
-  auto buf_size =
-      static_cast<int32_t>(buf->GetFormat()->SizeInBytes());
+  auto buf_size = static_cast<int32_t>(buf->GetFormat()->SizeInBytes());
   if (token->AsInt32() % buf_size != 0)
     return Result("offset for uniform must be multiple of data size");
 

--- a/tests/cases/scratch_ssbo.vkscript
+++ b/tests/cases/scratch_ssbo.vkscript
@@ -13,18 +13,31 @@
 # limitations under the License.
 
 [compute shader]
-#version 430
+#version 450
 
-layout(set = 0, binding = 1) buffer block0 {
-  int data[2];
-};
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+layout(binding = 0) buffer data_buf0 {
+  int val0;
+  int val1;
+} data0;
+
+layout(binding = 1) buffer data_buf1 {
+    int val0;
+    int val1;
+} data1;
 
 void main() {
-  data[0] = 0;
-  data[1] = 1;
+    data0.val0 = 100;
+    data0.val1 = 200;
+
+    data1.val0 = data0.val0;
+    data1.val1 = data0.val1;
 }
 
 [test]
-ssbo 0:0 2
+ssbo 0:0 8
+ssbo 0:1 subdata int 0 0 0
 
 compute 1 1 1
+
+probe ssbo int 0:1 0 == 100 200


### PR DESCRIPTION
When the SSBO size command is used there is currently no format set into
a buffer. This CL sets a default format of `R8_SINT`. A flag is also set
that the format is defaulted and allows it to be overridden.

This permits the usage of scratch buffers, but allows the buffer to be
transferred to/from the device as we can set the buffer size to the
number of provided elements.

Fixes #513
Issue #501