### PR TITLE
[amberscript] Add TOLERANCE parsing.

### DIFF
--- a/docs/amber_script.md
+++ b/docs/amber_script.md
@@ -387,7 +387,8 @@ EXPECT {buffer_name} IDX _x_ {comparator} _value_+
 # Checks that |buffer_name| at |x| has values within |tolerance| of |value|
 # The |tolerance| can be specified as 1-4 float values separated by spaces.
 # The tolerances may be given as a percentage by placing a '%' symbol after
-# the value.
+# the value. If less tolerance values are provided then are needed for a given
+# data component the default tolerance will be applied.
 EXPECT {buffer_name} IDX _x_ TOLERANCE _tolerance_{1,4} EQ _value_+
 
 # Checks that |buffer_name| at |x|, |y| for |width|x|height| pixels has the

--- a/docs/amber_script.md
+++ b/docs/amber_script.md
@@ -385,10 +385,10 @@ CLEAR {pipeline}
 EXPECT {buffer_name} IDX _x_ {comparator} _value_+
 
 # Checks that |buffer_name| at |x| has values within |tolerance| of |value|
-# when compared with the given |comparator|. The |tolerance| can be specified
-# as 1-4 float values separated by spaces.
-EXPECT {buffer_name} IDX _x_ TOLERANCE \
-    _tolerance_{1,4} {comparator} _value_+
+# The |tolerance| can be specified as 1-4 float values separated by spaces.
+# The tolerances may be given as a percentage by placing a '%' symbol after
+# the value.
+EXPECT {buffer_name} IDX _x_ TOLERANCE _tolerance_{1,4} EQ _value_+
 
 # Checks that |buffer_name| at |x|, |y| for |width|x|height| pixels has the
 # given |r|, |g|, |b| values. Each r, g, b value is an integer from 0-255.

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -1204,7 +1204,7 @@ Result Parser::ParseExpect() {
   }
 
   if (token->AsString() != "IDX")
-    return Result("Unknown comparator in EXPECT command");
+    return Result("missing IDX in EXPECT command");
 
   token = tokenizer_->NextToken();
   if (!token->IsInteger() || token->AsInt32() < 0)
@@ -1288,32 +1288,73 @@ Result Parser::ParseExpect() {
     }
 
     command_list_.push_back(std::move(probe));
-  } else if (token->IsString() && IsComparator(token->AsString())) {
-    if (has_y_val)
-      return Result("Y value not needed for non-color comparator");
+    return ValidateEndOfStatement("EXPECT command");
+  }
 
-    auto probe = MakeUnique<ProbeSSBOCommand>(buffer);
-    probe->SetLine(line);
-    probe->SetComparator(ToComparator(token->AsString()));
-    probe->SetFormat(MakeUnique<Format>(*buffer->GetFormat()));
-    probe->SetOffset(static_cast<uint32_t>(x));
+  auto probe = MakeUnique<ProbeSSBOCommand>(buffer);
+  probe->SetLine(line);
 
-    std::vector<Value> values;
-    Result r = ParseValues("EXPECT", buffer->GetFormat(), &values);
-    if (!r.IsSuccess())
-      return r;
+  if (token->IsString() && token->AsString() == "TOLERANCE") {
+    std::vector<Probe::Tolerance> tolerances;
 
-    if (values.empty())
-      return Result("missing comparison values for EXPECT command");
-    probe->SetValues(std::move(values));
-    command_list_.push_back(std::move(probe));
-    return {};
-  } else {
+    token = tokenizer_->NextToken();
+    while (!token->IsEOL() && !token->IsEOS()) {
+      if (!token->IsInteger() && !token->IsDouble())
+        break;
+
+      Result r = token->ConvertToDouble();
+      if (!r.IsSuccess())
+        return r;
+
+      double value = token->AsDouble();
+      token = tokenizer_->NextToken();
+      if (token->IsString() && token->AsString() == "%") {
+        tolerances.push_back(Probe::Tolerance{true, value});
+        token = tokenizer_->NextToken();
+      } else {
+        tolerances.push_back(Probe::Tolerance{false, value});
+      }
+    }
+    if (tolerances.empty())
+      return Result("TOLERANCE specified but no tolerances provided");
+    if (tolerances.size() > 4)
+      return Result("TOLERANCE has a maximum of 4 values");
+
+    probe->SetTolerances(std::move(tolerances));
+  }
+
+  if (!token->IsString() || !IsComparator(token->AsString())) {
     return Result("unexpected token in EXPECT command: " +
                   token->ToOriginalString());
   }
 
-  return ValidateEndOfStatement("EXPECT command");
+  if (has_y_val)
+    return Result("Y value not needed for non-color comparator");
+
+  auto cmp = ToComparator(token->AsString());
+  if (probe->HasTolerances()) {
+    if (cmp != ProbeSSBOCommand::Comparator::kEqual)
+      return Result("TOLERANCE only available with EQ probes");
+
+    cmp = ProbeSSBOCommand::Comparator::kFuzzyEqual;
+  }
+
+  probe->SetComparator(cmp);
+  probe->SetFormat(MakeUnique<Format>(*buffer->GetFormat()));
+  probe->SetOffset(static_cast<uint32_t>(x));
+
+  std::vector<Value> values;
+  Result r = ParseValues("EXPECT", buffer->GetFormat(), &values);
+  if (!r.IsSuccess())
+    return r;
+
+  if (values.empty())
+    return Result("missing comparison values for EXPECT command");
+
+  probe->SetValues(std::move(values));
+  command_list_.push_back(std::move(probe));
+
+  return {};
 }
 
 Result Parser::ParseCopy() {

--- a/src/amberscript/parser_expect_test.cc
+++ b/src/amberscript/parser_expect_test.cc
@@ -843,7 +843,7 @@ EXPECT orig_buf IDX 5 TOLERANCE 1 EQ 11)";
   auto& tolerances = probe->GetTolerances();
   ASSERT_EQ(1U, tolerances.size());
   EXPECT_FALSE(tolerances[0].is_percent);
-  EXPECT_FLOAT_EQ(1.f, tolerances[0].value);
+  EXPECT_FLOAT_EQ(1.0, tolerances[0].value);
 }
 
 TEST_F(AmberScriptParserTest, ExpectToleranceOneValuePercent) {
@@ -873,7 +873,7 @@ EXPECT orig_buf IDX 5 TOLERANCE 1% EQ 11)";
   auto& tolerances = probe->GetTolerances();
   ASSERT_EQ(1U, tolerances.size());
   EXPECT_TRUE(tolerances[0].is_percent);
-  EXPECT_FLOAT_EQ(1.f, tolerances[0].value);
+  EXPECT_FLOAT_EQ(1.0, tolerances[0].value);
 }
 
 TEST_F(AmberScriptParserTest, ExpectToleranceMultiValue) {
@@ -904,16 +904,16 @@ EXPECT orig_buf IDX 5 TOLERANCE 1% .2 3.7% 4 EQ 11)";
   ASSERT_EQ(4U, tolerances.size());
 
   EXPECT_TRUE(tolerances[0].is_percent);
-  EXPECT_FLOAT_EQ(1.f, tolerances[0].value);
+  EXPECT_FLOAT_EQ(1.0, tolerances[0].value);
 
   EXPECT_FALSE(tolerances[1].is_percent);
-  EXPECT_FLOAT_EQ(.2f, tolerances[1].value);
+  EXPECT_FLOAT_EQ(0.2, tolerances[1].value);
 
   EXPECT_TRUE(tolerances[2].is_percent);
-  EXPECT_FLOAT_EQ(3.7f, tolerances[2].value);
+  EXPECT_FLOAT_EQ(3.7, tolerances[2].value);
 
   EXPECT_FALSE(tolerances[3].is_percent);
-  EXPECT_FLOAT_EQ(4.f, tolerances[3].value);
+  EXPECT_FLOAT_EQ(4.0, tolerances[3].value);
 }
 
 TEST_F(AmberScriptParserTest, ExpectToleranceNoValues) {

--- a/src/amberscript/parser_expect_test.cc
+++ b/src/amberscript/parser_expect_test.cc
@@ -816,5 +816,138 @@ EXPECT buf_1 EQ_BUFFER buf_2
       r.Error());
 }
 
+TEST_F(AmberScriptParserTest, ExpectToleranceOneValue) {
+  std::string in = R"(
+BUFFER orig_buf DATA_TYPE int32 SIZE 100 FILL 11
+EXPECT orig_buf IDX 5 TOLERANCE 1 EQ 11)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto script = parser.GetScript();
+  const auto& commands = script->GetCommands();
+  ASSERT_EQ(1U, commands.size());
+
+  auto* cmd = commands[0].get();
+  ASSERT_TRUE(cmd->IsProbeSSBO());
+
+  auto* probe = cmd->AsProbeSSBO();
+  EXPECT_EQ(ProbeSSBOCommand::Comparator::kFuzzyEqual, probe->GetComparator());
+  EXPECT_EQ(5U, probe->GetOffset());
+  EXPECT_TRUE(probe->GetFormat()->IsInt32());
+  ASSERT_EQ(1U, probe->GetValues().size());
+  EXPECT_EQ(11U, probe->GetValues()[0].AsInt32());
+  EXPECT_TRUE(probe->HasTolerances());
+
+  auto& tolerances = probe->GetTolerances();
+  ASSERT_EQ(1U, tolerances.size());
+  EXPECT_FALSE(tolerances[0].is_percent);
+  EXPECT_FLOAT_EQ(1.f, tolerances[0].value);
+}
+
+TEST_F(AmberScriptParserTest, ExpectToleranceOneValuePercent) {
+  std::string in = R"(
+BUFFER orig_buf DATA_TYPE int32 SIZE 100 FILL 11
+EXPECT orig_buf IDX 5 TOLERANCE 1% EQ 11)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto script = parser.GetScript();
+  const auto& commands = script->GetCommands();
+  ASSERT_EQ(1U, commands.size());
+
+  auto* cmd = commands[0].get();
+  ASSERT_TRUE(cmd->IsProbeSSBO());
+
+  auto* probe = cmd->AsProbeSSBO();
+  EXPECT_EQ(ProbeSSBOCommand::Comparator::kFuzzyEqual, probe->GetComparator());
+  EXPECT_EQ(5U, probe->GetOffset());
+  EXPECT_TRUE(probe->GetFormat()->IsInt32());
+  ASSERT_EQ(1U, probe->GetValues().size());
+  EXPECT_EQ(11U, probe->GetValues()[0].AsInt32());
+  EXPECT_TRUE(probe->HasTolerances());
+
+  auto& tolerances = probe->GetTolerances();
+  ASSERT_EQ(1U, tolerances.size());
+  EXPECT_TRUE(tolerances[0].is_percent);
+  EXPECT_FLOAT_EQ(1.f, tolerances[0].value);
+}
+
+TEST_F(AmberScriptParserTest, ExpectToleranceMultiValue) {
+  std::string in = R"(
+BUFFER orig_buf DATA_TYPE int32 SIZE 100 FILL 11
+EXPECT orig_buf IDX 5 TOLERANCE 1% .2 3.7% 4 EQ 11)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto script = parser.GetScript();
+  const auto& commands = script->GetCommands();
+  ASSERT_EQ(1U, commands.size());
+
+  auto* cmd = commands[0].get();
+  ASSERT_TRUE(cmd->IsProbeSSBO());
+
+  auto* probe = cmd->AsProbeSSBO();
+  EXPECT_EQ(ProbeSSBOCommand::Comparator::kFuzzyEqual, probe->GetComparator());
+  EXPECT_EQ(5U, probe->GetOffset());
+  EXPECT_TRUE(probe->GetFormat()->IsInt32());
+  ASSERT_EQ(1U, probe->GetValues().size());
+  EXPECT_EQ(11U, probe->GetValues()[0].AsInt32());
+
+  EXPECT_TRUE(probe->HasTolerances());
+  auto& tolerances = probe->GetTolerances();
+  ASSERT_EQ(4U, tolerances.size());
+
+  EXPECT_TRUE(tolerances[0].is_percent);
+  EXPECT_FLOAT_EQ(1.f, tolerances[0].value);
+
+  EXPECT_FALSE(tolerances[1].is_percent);
+  EXPECT_FLOAT_EQ(.2f, tolerances[1].value);
+
+  EXPECT_TRUE(tolerances[2].is_percent);
+  EXPECT_FLOAT_EQ(3.7f, tolerances[2].value);
+
+  EXPECT_FALSE(tolerances[3].is_percent);
+  EXPECT_FLOAT_EQ(4.f, tolerances[3].value);
+}
+
+TEST_F(AmberScriptParserTest, ExpectToleranceNoValues) {
+  std::string in = R"(
+BUFFER orig_buf DATA_TYPE int32 SIZE 100 FILL 11
+EXPECT orig_buf IDX 5 TOLERANCE EQ 11)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("3: TOLERANCE specified but no tolerances provided", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, ExpectToleranceTooManyValues) {
+  std::string in = R"(
+BUFFER orig_buf DATA_TYPE int32 SIZE 100 FILL 11
+EXPECT orig_buf IDX 5 TOLERANCE 1 2 3 4 5 EQ 11)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("3: TOLERANCE has a maximum of 4 values", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, ExpectToleranceNonEqCompator) {
+  std::string in = R"(
+BUFFER orig_buf DATA_TYPE int32 SIZE 100 FILL 11
+EXPECT orig_buf IDX 5 TOLERANCE 1 2 3 4 NE 11)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("3: TOLERANCE only available with EQ probes", r.Error());
+}
+
 }  // namespace amberscript
 }  // namespace amber

--- a/src/amberscript/parser_expect_test.cc
+++ b/src/amberscript/parser_expect_test.cc
@@ -843,7 +843,7 @@ EXPECT orig_buf IDX 5 TOLERANCE 1 EQ 11)";
   auto& tolerances = probe->GetTolerances();
   ASSERT_EQ(1U, tolerances.size());
   EXPECT_FALSE(tolerances[0].is_percent);
-  EXPECT_FLOAT_EQ(1.0, tolerances[0].value);
+  EXPECT_FLOAT_EQ(1.f, static_cast<float>(tolerances[0].value));
 }
 
 TEST_F(AmberScriptParserTest, ExpectToleranceOneValuePercent) {
@@ -873,7 +873,7 @@ EXPECT orig_buf IDX 5 TOLERANCE 1% EQ 11)";
   auto& tolerances = probe->GetTolerances();
   ASSERT_EQ(1U, tolerances.size());
   EXPECT_TRUE(tolerances[0].is_percent);
-  EXPECT_FLOAT_EQ(1.0, tolerances[0].value);
+  EXPECT_FLOAT_EQ(1.f, static_cast<float>(tolerances[0].value));
 }
 
 TEST_F(AmberScriptParserTest, ExpectToleranceMultiValue) {
@@ -904,16 +904,16 @@ EXPECT orig_buf IDX 5 TOLERANCE 1% .2 3.7% 4 EQ 11)";
   ASSERT_EQ(4U, tolerances.size());
 
   EXPECT_TRUE(tolerances[0].is_percent);
-  EXPECT_FLOAT_EQ(1.0, tolerances[0].value);
+  EXPECT_FLOAT_EQ(1.f, static_cast<float>(tolerances[0].value));
 
   EXPECT_FALSE(tolerances[1].is_percent);
-  EXPECT_FLOAT_EQ(0.2, tolerances[1].value);
+  EXPECT_FLOAT_EQ(.2f, static_cast<float>(tolerances[1].value));
 
   EXPECT_TRUE(tolerances[2].is_percent);
-  EXPECT_FLOAT_EQ(3.7, tolerances[2].value);
+  EXPECT_FLOAT_EQ(3.7f, static_cast<float>(tolerances[2].value));
 
   EXPECT_FALSE(tolerances[3].is_percent);
-  EXPECT_FLOAT_EQ(4.0, tolerances[3].value);
+  EXPECT_FLOAT_EQ(4.f, static_cast<float>(tolerances[3].value));
 }
 
 TEST_F(AmberScriptParserTest, ExpectToleranceNoValues) {

--- a/tests/cases/compute_ssbo_with_tolerance.amber
+++ b/tests/cases/compute_ssbo_with_tolerance.amber
@@ -1,0 +1,75 @@
+#!amber
+# Copyright 2019 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHADER compute compute_shader GLSL
+#version 430
+
+layout(set = 0, binding = 0) buffer block0 {
+  float data_set0_binding0[3];
+};
+
+layout(set = 1, binding = 2) buffer block1 {
+  float data_set1_binding2[3];
+};
+
+layout(set = 2, binding = 1) buffer block2 {
+  float data_set2_binding1[3];
+};
+
+layout(set = 2, binding = 3) buffer block3 {
+  float data_set2_binding3[3];
+};
+
+void main() {
+  const uint index = gl_WorkGroupID.x;
+  data_set0_binding0[index] = data_set0_binding0[index] + 1.0f;
+  data_set1_binding2[index] = data_set2_binding1[index] -
+                              data_set1_binding2[index];
+  data_set2_binding1[index] = 10.0f * data_set2_binding3[index] +
+                              data_set2_binding1[index];
+  data_set2_binding3[index] = 30.0f * data_set2_binding3[index];
+}
+END
+
+BUFFER buf0 DATA_TYPE vec3<float> DATA  1.0  2.0  3.0 END
+BUFFER buf1 DATA_TYPE vec3<float> DATA  4.0  5.0  6.0 END
+BUFFER buf2 DATA_TYPE vec3<float> DATA 21.0 22.0 23.0 END
+BUFFER buf3 DATA_TYPE vec3<float> DATA  0.7  0.8  0.9 END
+
+PIPELINE compute pipeline
+  ATTACH compute_shader
+
+  BIND BUFFER buf0 AS storage DESCRIPTOR_SET 0 BINDING 0
+  BIND BUFFER buf1 AS storage DESCRIPTOR_SET 1 BINDING 2
+  BIND BUFFER buf2 AS storage DESCRIPTOR_SET 2 BINDING 1
+  BIND BUFFER buf3 AS storage DESCRIPTOR_SET 2 BINDING 3
+END
+
+RUN pipeline 3 1 1
+
+EXPECT buf0 IDX 0 EQ  2.0  3.0  4.0
+EXPECT buf1 IDX 0 EQ 17.0 17.0 17.0
+EXPECT buf2 IDX 0 EQ 28.0 30.0 32.0
+EXPECT buf3 IDX 0 EQ 21.0 24.0 27.0
+
+EXPECT buf0 IDX 0 TOLERANCE 1 EQ  2.99  3.99  4.99
+EXPECT buf1 IDX 0 TOLERANCE 1 EQ 17.99 17.99 17.99
+EXPECT buf2 IDX 0 TOLERANCE 1 EQ 28.99 30.99 32.99
+EXPECT buf3 IDX 0 TOLERANCE 1 EQ 21.99 24.99 27.99
+
+EXPECT buf0 IDX 0 TOLERANCE 1% EQ  2.0199  3.0199  4.0199
+EXPECT buf1 IDX 0 TOLERANCE 1% EQ 17.0199 17.0199 17.0199
+EXPECT buf2 IDX 0 TOLERANCE 1% EQ 28.0199 30.0199 32.0199
+EXPECT buf3 IDX 0 TOLERANCE 1% EQ 21.0199 24.0199 27.0199


### PR DESCRIPTION
This CL adds the TOLERANCE flag in to the EXPECT parsing. The TOLERANCE
requires an EQ buffer comparison (to match how VkScript works).

Fixes #418