### PR TITLE
Add AMBER_ENABLE_SHARED_CRT option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,14 @@ option(AMBER_USE_LOCAL_VULKAN "Build with vulkan in third_party" OFF)
 option(AMBER_ENABLE_SWIFTSHADER
   "Build using SwiftShader" ${AMBER_ENABLE_SWIFTSHADER})
 option(AMBER_USE_LOCAL_VULKAN "Build with vulkan in third_party" OFF)
+if(WIN32)
+  # On Windows, CMake by default compiles with the shared CRT.
+  # Default it to the static CRT.
+  option(AMBER_ENABLE_SHARED_CRT
+         "Amber: Use the shared CRT with MSVC instead of the static CRT"
+	 ${AMBER_ENABLE_SHARED_CRT})
+endif(WIN32)
+
 
 if (${AMBER_SKIP_SPIRV_TOOLS})
   set(AMBER_ENABLE_SPIRV_TOOLS FALSE)
@@ -161,28 +169,44 @@ function(amber_default_compile_options TARGET)
     )
 
     # We don't want to have to copy the C Runtime DLL everywhere the executable
-    # goes.  So compile code to assume the CRT is statically linked, i.e. use
-    # /MT* options.  For debug builds use /MTd, and for release builds use /MT.
-    if(CMAKE_BUILD_TYPE MATCHES "Debug")
-      target_compile_options(${TARGET} PRIVATE /MTd)
-      message(STATUS "Setting /MTd")
-    elseif(CMAKE_BUILD_TYPE MATCHES "RelWithDebInfo")
-      target_compile_options(${TARGET} PRIVATE /MT)
-      message(STATUS "Setting /MT")
+    # goes.  So by default compile code to assume the CRT is statically linked,
+    # i.e. use /MT* options.  For debug builds use /MTd, and for release builds
+    # use /MT.  If AMBER_ENABLE_SHARED_CRT is ON, then use the shared C runtime.
+    if(NOT ${AMBER_ENABLE_SHARED_CRT})
+      if(CMAKE_BUILD_TYPE MATCHES "Debug")
+	target_compile_options(${TARGET} PRIVATE /MTd)
+	message(STATUS "Amber: Setting /MTd")
+      elseif(CMAKE_BUILD_TYPE MATCHES "RelWithDebInfo")
+	target_compile_options(${TARGET} PRIVATE /MT)
+	message(STATUS "Amber: Setting /MT")
+      else()
+	target_compile_options(${TARGET} PRIVATE /MT)
+	message(STATUS "Amber: Setting /MT")
+      endif()
     else()
-      target_compile_options(${TARGET} PRIVATE /MT)
-      message(STATUS "Setting /MT")
+      if(CMAKE_BUILD_TYPE MATCHES "Debug")
+	target_compile_options(${TARGET} PRIVATE /MDd)
+	message(STATUS "Amber: Setting /MDd")
+      elseif(CMAKE_BUILD_TYPE MATCHES "RelWithDebInfo")
+	target_compile_options(${TARGET} PRIVATE /MD)
+	message(STATUS "Amber: Setting /MD")
+      else()
+	target_compile_options(${TARGET} PRIVATE /MD)
+	message(STATUS "Amber: Setting /MD")
+      endif()
     endif()
   endif()
 
-  # For MinGW cross compile, statically link to the C++ runtime.
-  # But it still depends on MSVCRT.dll.
-  if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
-    if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
-      set_target_properties(${TARGET} PROPERTIES LINK_FLAGS
-        -static
-        -static-libgcc
-        -static-libstdc++)
+  if (NOT ${AMBER_ENABLE_SHARED_CRT})
+    # For MinGW cross compile, statically link to the C++ runtime.
+    # But it still depends on MSVCRT.dll.
+    if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+      if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+	set_target_properties(${TARGET} PROPERTIES LINK_FLAGS
+	  -static
+	  -static-libgcc
+	  -static-libstdc++)
+      endif()
     endif()
   endif()
 endfunction()

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ cmake -GNinja ../..
 ninja
 ```
 
+Alternatives:
+
+* On Windows, Amber normally statically links against the C runtime library.
+  To override this and link against a shared C runtime, CMake option
+  `-DAMBER_ENABLE_SHARED_CRT`.
+  This will cause Amber to be built with `/MD` for release builds or `/MDd` for
+  debug builds.
+
 ### Android
 
 * Android build needs Android SDK 28, Android NDK 16, Java 8. If you prefer

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 if (${AMBER_ENABLE_TESTS})
+  if (${AMBER_ENABLE_SHARED_CRT})
+    set(gtest_force_shared_crt ON)
+  endif()
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/googletest EXCLUDE_FROM_ALL)
 endif()
 


### PR DESCRIPTION
On Windows, using this will cause Amber to build with /MD or MDd.
Normally Amber builds with /MT or MTd.