### PR TITLE
Remove old location code from buffer class.

### DIFF
--- a/src/buffer.h
+++ b/src/buffer.h
@@ -66,11 +66,6 @@ class Buffer {
   /// Sets the BufferType for this buffer.
   void SetBufferType(BufferType type) { buffer_type_ = type; }
 
-  /// Set the location binding value for the buffer.
-  void SetLocation(uint8_t loc) { location_ = loc; }
-  /// Get the location binding value for the buffer.
-  uint8_t GetLocation() const { return location_; }
-
   /// Sets the Format of the buffer to |format|.
   void SetFormat(std::unique_ptr<Format> format) {
     format_is_default_ = false;
@@ -189,7 +184,6 @@ class Buffer {
   uint32_t element_count_ = 0;
   uint32_t width_ = 0;
   uint32_t height_ = 0;
-  uint8_t location_ = 0;
   bool format_is_default_ = false;
   std::vector<uint8_t> bytes_;
   std::unique_ptr<Format> format_;

--- a/src/vkscript/parser.cc
+++ b/src/vkscript/parser.cc
@@ -421,7 +421,6 @@ Result Parser::ProcessVertexDataBlock(const SectionParser::Section& section) {
     auto* buf = buffer.get();
     buffer->SetName("Vertices" + std::to_string(i));
     buffer->SetFormat(std::move(headers[i].format));
-    buffer->SetLocation(headers[i].location);
     buffer->SetData(std::move(values[i]));
     script_->AddBuffer(std::move(buffer));
 

--- a/src/vkscript/parser_test.cc
+++ b/src/vkscript/parser_test.cc
@@ -340,14 +340,20 @@ TEST_F(VkScriptParserTest, VertexDataHeaderFormatString) {
   const auto& buffers = script->GetBuffers();
   ASSERT_EQ(3U, buffers.size());
 
+  ASSERT_EQ(1U, script->GetPipelines().size());
+  const auto* pipeline = script->GetPipelines()[0].get();
+
+  ASSERT_EQ(2U, pipeline->GetVertexBuffers().size());
+  const auto& pipeline_buffers = pipeline->GetVertexBuffers();
+
   ASSERT_EQ(BufferType::kVertex, buffers[1]->GetBufferType());
-  EXPECT_EQ(static_cast<uint8_t>(0U), buffers[1]->GetLocation());
+  EXPECT_EQ(static_cast<uint8_t>(0U), pipeline_buffers[0].location);
   EXPECT_EQ(FormatType::kR32G32_SFLOAT,
             buffers[1]->GetFormat()->GetFormatType());
   EXPECT_EQ(static_cast<uint32_t>(0), buffers[1]->ElementCount());
 
   ASSERT_EQ(BufferType::kVertex, buffers[2]->GetBufferType());
-  EXPECT_EQ(1U, buffers[2]->GetLocation());
+  EXPECT_EQ(1U, pipeline_buffers[1].location);
   EXPECT_EQ(FormatType::kA8B8G8R8_UNORM_PACK32,
             buffers[2]->GetFormat()->GetFormatType());
   EXPECT_EQ(static_cast<uint32_t>(0), buffers[2]->ElementCount());
@@ -365,8 +371,14 @@ TEST_F(VkScriptParserTest, VertexDataHeaderGlslString) {
   const auto& buffers = script->GetBuffers();
   ASSERT_EQ(3U, buffers.size());
 
+  ASSERT_EQ(1U, script->GetPipelines().size());
+  const auto* pipeline = script->GetPipelines()[0].get();
+
+  ASSERT_EQ(2U, pipeline->GetVertexBuffers().size());
+  const auto& pipeline_buffers = pipeline->GetVertexBuffers();
+
   ASSERT_EQ(BufferType::kVertex, buffers[1]->GetBufferType());
-  EXPECT_EQ(static_cast<uint8_t>(0U), buffers[1]->GetLocation());
+  EXPECT_EQ(static_cast<uint8_t>(0U), pipeline_buffers[0].location);
 
   EXPECT_EQ(FormatType::kR32G32_SFLOAT,
             buffers[1]->GetFormat()->GetFormatType());
@@ -378,7 +390,7 @@ TEST_F(VkScriptParserTest, VertexDataHeaderGlslString) {
   EXPECT_EQ(static_cast<uint32_t>(0), buffers[1]->ElementCount());
 
   ASSERT_EQ(BufferType::kVertex, buffers[2]->GetBufferType());
-  EXPECT_EQ(1U, buffers[2]->GetLocation());
+  EXPECT_EQ(1U, pipeline_buffers[1].location);
   EXPECT_EQ(FormatType::kR32G32B32_SINT,
             buffers[2]->GetFormat()->GetFormatType());
   auto& comps2 = buffers[2]->GetFormat()->GetComponents();


### PR DESCRIPTION
This Cl removes the {Get|Set}Location code from the buffer class as it
is no longer needed. The data should be retrieved from the pipeline. Two
tests were updated to pull the data from the right location.