### PR TITLE
Set the element count so we'll know the max size of a ssbo

### DIFF
--- a/src/vkscript/command_parser.cc
+++ b/src/vkscript/command_parser.cc
@@ -615,7 +615,21 @@ Result CommandParser::ProcessSSBO() {
     if (!r.IsSuccess())
       return r;
 
-    buf->SetDataWithOffset(values, cmd->GetOffset());
+    // Multiply by the input needed because the value count will use the needed
+    // input as the multiplier
+    uint32_t value_count =
+        ((cmd->GetOffset() / buf->GetFormat()->SizeInBytes()) *
+         buf->GetFormat()->InputNeededPerElement()) +
+        static_cast<uint32_t>(values.size());
+    // The buffer should only be resized to become bigger. This means that if a
+    // command was run to set the buffer size we'll honour that size until a
+    // request happens to make the buffer bigger.
+    if (value_count > buf->ValueCount())
+      buf->SetValueCount(value_count);
+
+    // Even if the value count doesn't change, the buffer is still resized
+    // because this maybe the first time data is set into the buffer.
+    buf->ResizeTo(buf->GetSizeInBytes());
 
     cmd->SetValues(std::move(values));
 

--- a/src/vkscript/command_parser.cc
+++ b/src/vkscript/command_parser.cc
@@ -615,9 +615,7 @@ Result CommandParser::ProcessSSBO() {
     if (!r.IsSuccess())
       return r;
 
-    // Resize the buffer so we'll know the max size
-    if (buf->ElementCount() < values.size())
-      buf->SetElementCount(static_cast<uint32_t>(values.size()));
+    buf->SetDataWithOffset(values, cmd->GetOffset());
 
     cmd->SetValues(std::move(values));
 

--- a/src/vkscript/command_parser.cc
+++ b/src/vkscript/command_parser.cc
@@ -617,7 +617,7 @@ Result CommandParser::ProcessSSBO() {
 
     // Resize the buffer so we'll know the max size
     if (buf->ElementCount() < values.size())
-      buf->SetElementCount(values.size());
+      buf->SetElementCount(static_cast<uint32_t>(values.size()));
 
     cmd->SetValues(std::move(values));
 

--- a/src/vkscript/command_parser.cc
+++ b/src/vkscript/command_parser.cc
@@ -615,6 +615,10 @@ Result CommandParser::ProcessSSBO() {
     if (!r.IsSuccess())
       return r;
 
+    // Resize the buffer so we'll know the max size
+    if (buf->ElementCount() < values.size())
+      buf->SetElementCount(values.size());
+
     cmd->SetValues(std::move(values));
 
   } else {


### PR DESCRIPTION
This change sets the max element count of an ssbo. The is needed since Dawn backend needs to know the buffer size while creating it and passing to the pipeline layout. 
issue: #21 