### PR TITLE
Use simple include paths

### DIFF
--- a/src/dxc_helper.cc
+++ b/src/dxc_helper.cc
@@ -27,12 +27,12 @@
 
 // clang-format off
 // The order here matters, so don't reformat.
-#include "third_party/dxc/include/dxc/Support/WinAdapter.h"
-#include "third_party/dxc/include/dxc/Support/WinIncludes.h"
-#include "third_party/dxc/include/dxc/Support/Global.h"
-#include "third_party/dxc/include/dxc/Support/HLSLOptions.h"
-#include "third_party/dxc/include/dxc/Support/dxcapi.use.h"
-#include "third_party/dxc/include/dxc/dxcapi.h"
+#include "dxc/Support/WinAdapter.h"
+#include "dxc/Support/WinIncludes.h"
+#include "dxc/Support/Global.h"
+#include "dxc/Support/HLSLOptions.h"
+#include "dxc/Support/dxcapi.use.h"
+#include "dxc/dxcapi.h"
 // clang-format on
 
 #if AMBER_PLATFORM_WINDOWS

--- a/src/shader_compiler.cc
+++ b/src/shader_compiler.cc
@@ -30,7 +30,7 @@
 #pragma clang diagnostic ignored "-Wold-style-cast"
 #pragma clang diagnostic ignored "-Wshadow-uncaptured-local"
 #pragma clang diagnostic ignored "-Wweak-vtables"
-#include "third_party/shaderc/libshaderc/include/shaderc/shaderc.hpp"
+#include "shaderc/shaderc.hpp"
 #pragma clang diagnostic pop
 #endif  // AMBER_ENABLE_SHADERC
 


### PR DESCRIPTION
This change allows DXC to be picked up from any location, which may
not be in third_party/dxc/include/. A different build system or
environment may place it in a different directory. If amber is part
of another project that already has a copy of DXC, we would not
want two of them.