### PR TITLE
[vulkan] Fixup colour attachment setup for render pass.

### DIFF
--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -422,11 +422,10 @@ Result GraphicsPipeline::CreateRenderPass() {
     ref.attachment = static_cast<uint32_t>(attachment_desc.size() - 1);
     ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_refer.push_back(ref);
-
-    subpass_desc.colorAttachmentCount =
-        static_cast<uint32_t>(color_refer.size());
-    subpass_desc.pColorAttachments = color_refer.data();
   }
+  subpass_desc.colorAttachmentCount =
+        static_cast<uint32_t>(color_refer.size());
+  subpass_desc.pColorAttachments = color_refer.data();
 
   if (depth_stencil_format_.IsFormatKnown()) {
     attachment_desc.push_back(kDefaultAttachmentDesc);
@@ -503,26 +502,31 @@ GraphicsPipeline::GetVkPipelineDepthStencilInfo(
   return depthstencil_info;
 }
 
-VkPipelineColorBlendAttachmentState
+std::vector<VkPipelineColorBlendAttachmentState>
 GraphicsPipeline::GetVkPipelineColorBlendAttachmentState(
     const PipelineData* pipeline_data) {
-  VkPipelineColorBlendAttachmentState colorblend_attachment =
-      VkPipelineColorBlendAttachmentState();
-  colorblend_attachment.blendEnable = pipeline_data->GetEnableBlend();
-  colorblend_attachment.srcColorBlendFactor =
-      ToVkBlendFactor(pipeline_data->GetSrcColorBlendFactor());
-  colorblend_attachment.dstColorBlendFactor =
-      ToVkBlendFactor(pipeline_data->GetDstColorBlendFactor());
-  colorblend_attachment.colorBlendOp =
-      ToVkBlendOp(pipeline_data->GetColorBlendOp());
-  colorblend_attachment.srcAlphaBlendFactor =
-      ToVkBlendFactor(pipeline_data->GetSrcAlphaBlendFactor());
-  colorblend_attachment.dstAlphaBlendFactor =
-      ToVkBlendFactor(pipeline_data->GetDstAlphaBlendFactor());
-  colorblend_attachment.alphaBlendOp =
-      ToVkBlendOp(pipeline_data->GetAlphaBlendOp());
-  colorblend_attachment.colorWriteMask = pipeline_data->GetColorWriteMask();
-  return colorblend_attachment;
+  std::vector<VkPipelineColorBlendAttachmentState> states;
+
+  for (size_t i = 0; i < color_buffers_.size(); ++i) {
+    VkPipelineColorBlendAttachmentState colorblend_attachment =
+        VkPipelineColorBlendAttachmentState();
+    colorblend_attachment.blendEnable = pipeline_data->GetEnableBlend();
+    colorblend_attachment.srcColorBlendFactor =
+        ToVkBlendFactor(pipeline_data->GetSrcColorBlendFactor());
+    colorblend_attachment.dstColorBlendFactor =
+        ToVkBlendFactor(pipeline_data->GetDstColorBlendFactor());
+    colorblend_attachment.colorBlendOp =
+        ToVkBlendOp(pipeline_data->GetColorBlendOp());
+    colorblend_attachment.srcAlphaBlendFactor =
+        ToVkBlendFactor(pipeline_data->GetSrcAlphaBlendFactor());
+    colorblend_attachment.dstAlphaBlendFactor =
+        ToVkBlendFactor(pipeline_data->GetDstAlphaBlendFactor());
+    colorblend_attachment.alphaBlendOp =
+        ToVkBlendOp(pipeline_data->GetAlphaBlendOp());
+    colorblend_attachment.colorWriteMask = pipeline_data->GetColorWriteMask();
+    states.push_back(colorblend_attachment);
+  }
+  return states;
 }
 
 Result GraphicsPipeline::CreateVkGraphicsPipeline(
@@ -653,16 +657,16 @@ Result GraphicsPipeline::CreateVkGraphicsPipeline(
 
   VkPipelineColorBlendStateCreateInfo colorblend_info =
       VkPipelineColorBlendStateCreateInfo();
-  VkPipelineColorBlendAttachmentState colorblend_attachment;
 
-  colorblend_attachment = GetVkPipelineColorBlendAttachmentState(pipeline_data);
+  auto colorblend_attachment = GetVkPipelineColorBlendAttachmentState(pipeline_data);
 
   colorblend_info.sType =
       VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
   colorblend_info.logicOpEnable = pipeline_data->GetEnableLogicOp();
   colorblend_info.logicOp = ToVkLogicOp(pipeline_data->GetLogicOp());
-  colorblend_info.attachmentCount = 1;
-  colorblend_info.pAttachments = &colorblend_attachment;
+  colorblend_info.attachmentCount =
+      static_cast<uint32_t>(colorblend_attachment.size());
+  colorblend_info.pAttachments = colorblend_attachment.data();
   pipeline_info.pColorBlendState = &colorblend_info;
 
   pipeline_info.layout = pipeline_layout;

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -423,8 +423,7 @@ Result GraphicsPipeline::CreateRenderPass() {
     ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_refer.push_back(ref);
   }
-  subpass_desc.colorAttachmentCount =
-        static_cast<uint32_t>(color_refer.size());
+  subpass_desc.colorAttachmentCount = static_cast<uint32_t>(color_refer.size());
   subpass_desc.pColorAttachments = color_refer.data();
 
   if (depth_stencil_format_.IsFormatKnown()) {

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -658,7 +658,8 @@ Result GraphicsPipeline::CreateVkGraphicsPipeline(
   VkPipelineColorBlendStateCreateInfo colorblend_info =
       VkPipelineColorBlendStateCreateInfo();
 
-  auto colorblend_attachment = GetVkPipelineColorBlendAttachmentState(pipeline_data);
+  auto colorblend_attachment =
+      GetVkPipelineColorBlendAttachmentState(pipeline_data);
 
   colorblend_info.sType =
       VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -83,7 +83,7 @@ class GraphicsPipeline : public Pipeline {
   VkPipelineDepthStencilStateCreateInfo GetVkPipelineDepthStencilInfo(
       const PipelineData* pipeline_data);
   std::vector<VkPipelineColorBlendAttachmentState>
-      GetVkPipelineColorBlendAttachmentState(const PipelineData* pipeline_data);
+  GetVkPipelineColorBlendAttachmentState(const PipelineData* pipeline_data);
 
   VkRenderPass render_pass_ = VK_NULL_HANDLE;
   std::unique_ptr<FrameBuffer> frame_;

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -82,8 +82,8 @@ class GraphicsPipeline : public Pipeline {
 
   VkPipelineDepthStencilStateCreateInfo GetVkPipelineDepthStencilInfo(
       const PipelineData* pipeline_data);
-  VkPipelineColorBlendAttachmentState GetVkPipelineColorBlendAttachmentState(
-      const PipelineData* pipeline_data);
+  std::vector<VkPipelineColorBlendAttachmentState>
+      GetVkPipelineColorBlendAttachmentState(const PipelineData* pipeline_data);
 
   VkRenderPass render_pass_ = VK_NULL_HANDLE;
   std::unique_ptr<FrameBuffer> frame_;


### PR DESCRIPTION
This CL fixes the render pass creation code when using multiple colour
attachments.

Fixes #543