### PR TITLE
Set entry point names during pipeline creation

### DIFF
--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -52,7 +52,7 @@ class Pipeline {
     const Shader* GetShader() const { return shader_; }
 
     void SetEntryPoint(const std::string& ep) { entry_point_ = ep; }
-    std::string GetEntryPoint() const { return entry_point_; }
+    const std::string& GetEntryPoint() const { return entry_point_; }
 
     void SetShaderType(ShaderType type) { shader_type_ = type; }
     ShaderType GetShaderType() const { return shader_type_; }

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -198,7 +198,7 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
     r = ToVkShaderStage(shader_info.GetShaderType(), &stage);
     if (!r.IsSuccess())
       return r;
-    const auto& name = shader_info.GetEntryPointName();
+    const auto& name = shader_info.GetEntryPoint();
     if (!name.empty()) {
       info.vk_pipeline->SetEntryPointName(stage, name);
     }

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -192,6 +192,18 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
 
   info.vk_pipeline = std::move(vk_pipeline);
 
+  // Set the entry point names for the pipeline.
+  for (const auto& shader_info : pipeline->GetShaders()) {
+    VkShaderStageFlagBits stage = VK_SHADER_STAGE_FLAG_BITS_MAX_ENUM;
+    r = ToVkShaderStage(shader_info.GetShaderType(), &stage);
+    if (!r.IsSuccess())
+      return r;
+    const auto& name = shader_info.GetEntryPointName();
+    if (!name.empty()) {
+      info.vk_pipeline->SetEntryPointName(stage, name);
+    }
+  }
+
   for (const auto& vtex_info : pipeline->GetVertexBuffers()) {
     auto fmt = vtex_info.buffer->GetFormat();
     if (!device_->IsFormatSupportedByPhysicalDevice(*fmt, vtex_info.buffer))

--- a/tests/cases/non_default_entry_point.amber
+++ b/tests/cases/non_default_entry_point.amber
@@ -1,0 +1,62 @@
+#!amber
+
+SHADER compute my_shader SPIRV-ASM
+               OpCapability Shader
+               OpExtension "SPV_KHR_storage_buffer_storage_class"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %18 "foo"
+               OpSource OpenCL_C 120
+               OpDecorate %11 SpecId 0
+               OpDecorate %12 SpecId 1
+               OpDecorate %13 SpecId 2
+               OpDecorate %_runtimearr_uint ArrayStride 4
+               OpMemberDecorate %_struct_3 0 Offset 0
+               OpDecorate %_struct_3 Block
+               OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+               OpDecorate %16 DescriptorSet 0
+               OpDecorate %16 Binding 0
+               OpDecorate %17 DescriptorSet 0
+               OpDecorate %17 Binding 1
+       %uint = OpTypeInt 32 0
+%_runtimearr_uint = OpTypeRuntimeArray %uint
+  %_struct_3 = OpTypeStruct %_runtimearr_uint
+%_ptr_StorageBuffer__struct_3 = OpTypePointer StorageBuffer %_struct_3
+       %void = OpTypeVoid
+          %6 = OpTypeFunction %void
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+     %v3uint = OpTypeVector %uint 3
+%_ptr_Private_v3uint = OpTypePointer Private %v3uint
+     %uint_0 = OpConstant %uint 0
+         %11 = OpSpecConstant %uint 1
+         %12 = OpSpecConstant %uint 1
+         %13 = OpSpecConstant %uint 1
+%gl_WorkGroupSize = OpSpecConstantComposite %v3uint %11 %12 %13
+         %15 = OpVariable %_ptr_Private_v3uint Private %gl_WorkGroupSize
+         %16 = OpVariable %_ptr_StorageBuffer__struct_3 StorageBuffer
+         %17 = OpVariable %_ptr_StorageBuffer__struct_3 StorageBuffer
+         %18 = OpFunction %void None %6
+         %19 = OpLabel
+         %20 = OpAccessChain %_ptr_StorageBuffer_uint %16 %uint_0 %uint_0
+         %21 = OpAccessChain %_ptr_StorageBuffer_uint %17 %uint_0 %uint_0
+         %22 = OpLoad %uint %20
+               OpStore %21 %22
+               OpReturn
+               OpFunctionEnd
+
+END
+
+BUFFER in_buf DATA_TYPE uint32 DATA
+ 9
+END
+BUFFER out_buf DATA_TYPE uint32 SIZE 1 FILL 0
+
+PIPELINE compute my_pipeline
+  ATTACH my_shader ENTRY_POINT foo
+  BIND BUFFER in_buf AS storage DESCRIPTOR_SET 0 BINDING 0
+  BIND BUFFER out_buf AS storage DESCRIPTOR_SET 0 BINDING 1
+END
+
+RUN my_pipeline 1 1 1
+
+EXPECT out_buf EQ_BUFFER in_buf
+

--- a/tests/cases/non_default_entry_point.amber
+++ b/tests/cases/non_default_entry_point.amber
@@ -1,4 +1,17 @@
 #!amber
+# Copyright 2019 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 SHADER compute my_shader SPIRV-ASM
                OpCapability Shader


### PR DESCRIPTION
Previously pipeline names were only set if there was an entry point command executed. This doesn't match up with how AmberScript specifies entry point names.

Now, if the entry point name was specified in the attach command, it will get set at pipeline creation.