### PR TITLE
Add clspv kokoro bot config

### DIFF
--- a/kokoro/linux-gcc-release-clspv/build.sh
+++ b/kokoro/linux-gcc-release-clspv/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2019 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e  # fail on error
+set -x  # display commands
+
+SCRIPT_DIR=`dirname "$BASH_SOURCE"`
+source $SCRIPT_DIR/../scripts/linux/build.sh RELEASE gcc -DAMBER_USE_CLSPV=ON

--- a/kokoro/linux-gcc-release-clspv/continuous.cfg
+++ b/kokoro/linux-gcc-release-clspv/continuous.cfg
@@ -1,0 +1,15 @@
+# Copyright 2019 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "amber/kokoro/linux-gcc-release-clspv/build.sh"

--- a/kokoro/linux-gcc-release-clspv/presubmit.cfg
+++ b/kokoro/linux-gcc-release-clspv/presubmit.cfg
@@ -1,0 +1,15 @@
+# Copyright 2019 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "amber/kokoro/linux-gcc-release-clspv/build.sh"

--- a/kokoro/scripts/linux/build.sh
+++ b/kokoro/scripts/linux/build.sh
@@ -55,7 +55,7 @@ mkdir build && cd $SRC/build
 # Invoke the build.
 BUILD_SHA=${KOKORO_GITHUB_COMMIT:-$KOKORO_GITHUB_PULL_REQUEST_COMMIT}
 echo $(date): Starting build...
-cmake -GNinja -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CMAKE_C_CXX_COMPILER -DAMBER_USE_LOCAL_VULKAN=1 $EXTRA_ARGS ..
+cmake -GNinja -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CMAKE_C_CXX_COMPILER -DAMBER_USE_LOCAL_VULKAN=1 $EXTRA_CONFIG ..
 
 echo $(date): Build everything...
 ninja

--- a/kokoro/scripts/linux/build.sh
+++ b/kokoro/scripts/linux/build.sh
@@ -19,7 +19,10 @@ set -x  # show commands
 BUILD_ROOT=$PWD
 SRC=$PWD/github/amber
 CONFIG=$1
-COMPILER=$2
+shift
+COMPILER=$1
+shift
+EXTRA_CONFIG=$@
 
 BUILD_TYPE="Debug"
 
@@ -52,7 +55,7 @@ mkdir build && cd $SRC/build
 # Invoke the build.
 BUILD_SHA=${KOKORO_GITHUB_COMMIT:-$KOKORO_GITHUB_PULL_REQUEST_COMMIT}
 echo $(date): Starting build...
-cmake -GNinja -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CMAKE_C_CXX_COMPILER -DAMBER_USE_LOCAL_VULKAN=1 ..
+cmake -GNinja -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CMAKE_C_CXX_COMPILER -DAMBER_USE_LOCAL_VULKAN=1 $EXTRA_ARGS ..
 
 echo $(date): Build everything...
 ninja


### PR DESCRIPTION
Contributes to #430

* Modified linux build script to accept extra cmake config options
* Clspv config passes -DAMBER_USE_CLSPV

Note: this change is necessary before enabling Kokoro to run the bot.