### PR TITLE
Use simple include path

### DIFF
--- a/samples/Android.mk
+++ b/samples/Android.mk
@@ -25,7 +25,7 @@ LOCAL_SRC_FILES:= \
     ppm.cc \
     png.cc \
     timestamp.cc
-LOCAL_C_INCLUDES := $(LOCAL_PATH)/.. $(LOCAL_PATH)/../include
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/.. $(LOCAL_PATH)/../include $(LOCAL_PATH)/../third_party
 LOCAL_LDLIBS:=-landroid -lvulkan -llog
 LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti -Werror -Wno-unknown-pragmas -DAMBER_ENGINE_VULKAN=1
 LOCAL_STATIC_LIBRARIES:=amber lodepng

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 add_executable(amber ${AMBER_SOURCES})
 target_include_directories(amber PRIVATE "${CMAKE_BINARY_DIR}")
 target_include_directories(amber PRIVATE
-  "${PROJECT_SOURCE_DIR}/third_party/lodepng")
+  "${PROJECT_SOURCE_DIR}/third_party")
 set_target_properties(amber PROPERTIES OUTPUT_NAME "amber")
 target_link_libraries(amber libamber ${AMBER_EXTRA_LIBS})
 amber_default_compile_options(amber)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -45,6 +45,8 @@ endif()
 
 add_executable(amber ${AMBER_SOURCES})
 target_include_directories(amber PRIVATE "${CMAKE_BINARY_DIR}")
+target_include_directories(amber PRIVATE
+  "${PROJECT_SOURCE_DIR}/third_party/lodepng")
 set_target_properties(amber PROPERTIES OUTPUT_NAME "amber")
 target_link_libraries(amber libamber ${AMBER_EXTRA_LIBS})
 amber_default_compile_options(amber)

--- a/samples/png.cc
+++ b/samples/png.cc
@@ -21,7 +21,7 @@
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wweak-vtables"
-#include "third_party/lodepng/lodepng.h"
+#include "lodepng.h"
 #pragma clang diagnostic pop
 
 namespace png {

--- a/samples/png.cc
+++ b/samples/png.cc
@@ -21,7 +21,7 @@
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wweak-vtables"
-#include "lodepng.h"
+#include "lodepng/lodepng.h"
 #pragma clang diagnostic pop
 
 namespace png {


### PR DESCRIPTION
This is similar to #571. We do not want to use `third_party` as
a part of include path.