### PR TITLE
Add support for "NaN" as a double value

### DIFF
--- a/src/tokenizer.cc
+++ b/src/tokenizer.cc
@@ -99,10 +99,17 @@ std::unique_ptr<Token> Tokenizer::NextToken() {
       data_.substr(current_position_, end_pos - current_position_);
   current_position_ = end_pos;
 
+  // Check for "NaN" explicitly.
+  bool is_nan = (tok_str.size() == 3 &&
+                 std::tolower(tok_str[0]) == 'n' &&
+                 std::tolower(tok_str[1]) == 'a' &&
+                 std::tolower(tok_str[2]) == 'n');
+
   // Starts with an alpha is a string.
-  if (!std::isdigit(tok_str[0]) &&
-      !(tok_str[0] == '-' && std::isdigit(tok_str[1])) &&
-      !(tok_str[0] == '.' && std::isdigit(tok_str[1]))) {
+  if (!is_nan &&
+      !std::isdigit(tok_str[0]) &&
+      !(tok_str[0] == '-' && tok_str.size() >= 2 && std::isdigit(tok_str[1])) &&
+      !(tok_str[0] == '.' && tok_str.size() >= 2 && std::isdigit(tok_str[1]))) {
     // If we've got a continuation, skip over the end of line and get the next
     // token.
     if (tok_str == "\\") {
@@ -126,17 +133,21 @@ std::unique_ptr<Token> Tokenizer::NextToken() {
   }
 
   // Handle hex strings
-  if (tok_str.size() > 2 && tok_str[0] == '0' && tok_str[1] == 'x') {
+  if (!is_nan && tok_str.size() > 2 && tok_str[0] == '0' && tok_str[1] == 'x') {
     auto tok = MakeUnique<Token>(TokenType::kHex);
     tok->SetStringValue(tok_str);
     return tok;
   }
 
   bool is_double = false;
-  for (const char ch : tok_str) {
-    if (ch == '.') {
-      is_double = true;
-      break;
+  if (is_nan) {
+    is_double = true;
+  } else {
+    for (const char ch : tok_str) {
+      if (ch == '.') {
+        is_double = true;
+        break;
+      }
     }
   }
 

--- a/src/tokenizer.cc
+++ b/src/tokenizer.cc
@@ -100,14 +100,12 @@ std::unique_ptr<Token> Tokenizer::NextToken() {
   current_position_ = end_pos;
 
   // Check for "NaN" explicitly.
-  bool is_nan = (tok_str.size() == 3 &&
-                 std::tolower(tok_str[0]) == 'n' &&
-                 std::tolower(tok_str[1]) == 'a' &&
-                 std::tolower(tok_str[2]) == 'n');
+  bool is_nan =
+      (tok_str.size() == 3 && std::tolower(tok_str[0]) == 'n' &&
+       std::tolower(tok_str[1]) == 'a' && std::tolower(tok_str[2]) == 'n');
 
   // Starts with an alpha is a string.
-  if (!is_nan &&
-      !std::isdigit(tok_str[0]) &&
+  if (!is_nan && !std::isdigit(tok_str[0]) &&
       !(tok_str[0] == '-' && tok_str.size() >= 2 && std::isdigit(tok_str[1])) &&
       !(tok_str[0] == '.' && tok_str.size() >= 2 && std::isdigit(tok_str[1]))) {
     // If we've got a continuation, skip over the end of line and get the next

--- a/src/tokenizer_test.cc
+++ b/src/tokenizer_test.cc
@@ -15,6 +15,7 @@
 #include "src/tokenizer.h"
 
 #include <limits>
+#include <cmath>
 
 #include "gtest/gtest.h"
 
@@ -75,6 +76,33 @@ TEST_F(TokenizerTest, ProcessDouble) {
   next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
   EXPECT_TRUE(next->IsEOS());
+}
+
+namespace {
+
+void TestNaN(const std::string &nan_str) {
+  Tokenizer t(nan_str);
+  auto next = t.NextToken();
+  ASSERT_TRUE(next != nullptr);
+  EXPECT_TRUE(next->IsDouble());
+  EXPECT_TRUE(std::isnan(next->AsDouble()));
+
+  next = t.NextToken();
+  ASSERT_TRUE(next != nullptr);
+  EXPECT_TRUE(next->IsEOS());
+}
+
+} // anonymous.
+
+TEST_F(TokenizerTest, ProcessNaN) {
+  TestNaN("nan");
+  TestNaN("naN");
+  TestNaN("nAn");
+  TestNaN("nAN");
+  TestNaN("Nan");
+  TestNaN("NaN");
+  TestNaN("NAn");
+  TestNaN("NAN");
 }
 
 TEST_F(TokenizerTest, ProcessNegativeDouble) {

--- a/src/tokenizer_test.cc
+++ b/src/tokenizer_test.cc
@@ -92,7 +92,7 @@ void TestNaN(const std::string &nan_str) {
   EXPECT_TRUE(next->IsEOS());
 }
 
-} // anonymous.
+}  // namespace
 
 TEST_F(TokenizerTest, ProcessNaN) {
   TestNaN("nan");

--- a/src/tokenizer_test.cc
+++ b/src/tokenizer_test.cc
@@ -14,8 +14,8 @@
 
 #include "src/tokenizer.h"
 
-#include <limits>
 #include <cmath>
+#include <limits>
 
 #include "gtest/gtest.h"
 
@@ -80,7 +80,7 @@ TEST_F(TokenizerTest, ProcessDouble) {
 
 namespace {
 
-void TestNaN(const std::string &nan_str) {
+void TestNaN(const std::string& nan_str) {
   Tokenizer t(nan_str);
   auto next = t.NextToken();
   ASSERT_TRUE(next != nullptr);


### PR DESCRIPTION
This PR adds support for "NaN", "nan" and other lowercase/uppercase combinations to be interpreted as a double value token and read using strtod in the tokenizer.

This is interesting for an upcoming VK-GL-CTS CL I'm preparing in which I test some SPIR-V instructions like OpFOrdEqual or OpFUnordEqual. To make the new tests interesting I'd like to be able to pass NaN to amber and make sure it's properly taken into account for ordered and unordered instructions.