### PR TITLE
Avoid uninitialized-var warning

### DIFF
--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -1260,26 +1260,25 @@ Result EngineDawn::DoPatchParameterVertices(
 Result EngineDawn::DoBuffer(const BufferCommand* command) {
   Result result;
 
-  ::dawn::Buffer* dawn_buffer;
+  ::dawn::Buffer* dawn_buffer = nullptr;
+
+  const auto descriptor_set = command->GetDescriptorSet();
+  const auto binding = command->GetBinding();
 
   RenderPipelineInfo* render_pipeline = GetRenderPipeline(command);
   if (render_pipeline) {
-    if (render_pipeline->buffer_map.find(
-            {command->GetDescriptorSet(), command->GetBinding()}) !=
-        render_pipeline->buffer_map.end()) {
-      auto dawn_buffer_index = render_pipeline->buffer_map[{
-          command->GetDescriptorSet(), command->GetBinding()}];
+    auto where = render_pipeline->buffer_map.find({descriptor_set, binding});
+    if (where != render_pipeline->buffer_map.end()) {
+      const auto dawn_buffer_index = where->second;
       dawn_buffer = &render_pipeline->buffers[dawn_buffer_index];
     }
   }
 
   ComputePipelineInfo* compute_pipeline = GetComputePipeline(command);
   if (compute_pipeline) {
-    if (compute_pipeline->buffer_map.find(
-            {command->GetDescriptorSet(), command->GetBinding()}) !=
-        compute_pipeline->buffer_map.end()) {
-      auto dawn_buffer_index = compute_pipeline->buffer_map[{
-          command->GetDescriptorSet(), command->GetBinding()}];
+    auto where = compute_pipeline->buffer_map.find({descriptor_set, binding});
+    if (where != compute_pipeline->buffer_map.end()) {
+      const auto dawn_buffer_index = where->second;
       dawn_buffer = &compute_pipeline->buffers[dawn_buffer_index];
     }
   }
@@ -1288,6 +1287,11 @@ Result EngineDawn::DoBuffer(const BufferCommand* command) {
     return Result("DoBuffer: invoked on invalid or missing pipeline");
   if (!command->IsSSBO() && !command->IsUniform())
     return Result("DoBuffer: only supports SSBO and uniform buffer type");
+  if (!dawn_buffer) {
+    return Result("DoBuffer: no Dawn buffer at descriptor set " +
+                  std::to_string(descriptor_set) + " and binding " +
+                  std::to_string(binding));
+  }
 
   Buffer* amber_buffer = command->GetBuffer();
   if (amber_buffer) {


### PR DESCRIPTION
The warning was on dawn_buffer.  
Initialized it with nullptr and add an early return with message in case it was in fact not initialized