### PR TITLE
Allow recipe to change fence timeout.

### DIFF
--- a/include/amber/recipe.h
+++ b/include/amber/recipe.h
@@ -40,6 +40,9 @@ class RecipeImpl {
   /// Returns required instance extensions in the given recipe.
   virtual std::vector<std::string> GetRequiredInstanceExtensions() const = 0;
 
+  /// Sets the fence timeout value to |timeout_ms|.
+  virtual void SetFenceTimeout(uint32_t timeout_ms) = 0;
+
  protected:
   RecipeImpl();
 };
@@ -65,6 +68,9 @@ class Recipe {
 
   /// Returns required instance extensions in the given recipe.
   std::vector<std::string> GetRequiredInstanceExtensions() const;
+
+  /// Sets the timeout value for fences to |timeout_ms|.
+  void SetFenceTimeout(uint32_t timeout_ms);
 
  private:
   RecipeImpl* impl_;

--- a/src/engine.h
+++ b/src/engine.h
@@ -31,7 +31,7 @@ namespace amber {
 /// EngineData stores information used during engine execution.
 struct EngineData {
   /// The timeout to use for fences, in milliseconds.
-  uint32_t fence_timeout_ms = 100;
+  uint32_t fence_timeout_ms = 1000;
 };
 
 /// Abstract class which describes a backing engine for Amber.

--- a/src/executor_test.cc
+++ b/src/executor_test.cc
@@ -238,8 +238,6 @@ logicOp)";
 
   const auto& extensions = ToStub(engine.get())->GetDeviceExtensions();
   ASSERT_EQ(static_cast<size_t>(0U), extensions.size());
-
-  EXPECT_EQ(100U, ToStub(engine.get())->GetFenceTimeoutMs());
 }
 
 TEST_F(VkScriptExecutorTest, ExecutesRequiredExtensions) {
@@ -269,8 +267,6 @@ VK_KHR_variable_pointers)";
   ASSERT_EQ(2U, extensions.size());
   EXPECT_EQ("VK_KHR_storage_buffer_storage_class", extensions[0]);
   EXPECT_EQ("VK_KHR_variable_pointers", extensions[1]);
-
-  EXPECT_EQ(100U, ToStub(engine.get())->GetFenceTimeoutMs());
 }
 
 TEST_F(VkScriptExecutorTest, ExecutesRequiredFrameBuffers) {
@@ -298,8 +294,6 @@ depthstencil D24_UNORM_S8_UINT)";
 
   const auto& extensions = ToStub(engine.get())->GetDeviceExtensions();
   ASSERT_EQ(static_cast<size_t>(0U), extensions.size());
-
-  EXPECT_EQ(100U, ToStub(engine.get())->GetFenceTimeoutMs());
 }
 
 TEST_F(VkScriptExecutorTest, ExecutesRequiredFenceTimeout) {

--- a/src/recipe.cc
+++ b/src/recipe.cc
@@ -45,4 +45,9 @@ std::vector<std::string> Recipe::GetRequiredInstanceExtensions() const {
                : std::vector<std::string>();
 }
 
+void Recipe::SetFenceTimeout(uint32_t timeout_ms) {
+  if (impl_)
+    impl_->SetFenceTimeout(timeout_ms);
+}
+
 }  // namespace amber

--- a/src/script.h
+++ b/src/script.h
@@ -58,6 +58,11 @@ class Script : public RecipeImpl {
     return engine_info_.required_instance_extensions;
   }
 
+  /// Sets the fence timeout to |timeout_ms|.
+  void SetFenceTimeout(uint32_t timeout_ms) override {
+    engine_data_.fence_timeout_ms = timeout_ms;
+  }
+
   /// Adds |pipeline| to the list of known pipelines. The |pipeline| must have
   /// a unique name over all pipelines in the script.
   Result AddPipeline(std::unique_ptr<Pipeline> pipeline) {


### PR DESCRIPTION
This CL adds an API to the recipe class to set the fence timeout for a
given script.

The default fence timeout is also bumped from 100ms to 1000ms.