### PR TITLE
CTS unused variable error fix

### DIFF
--- a/src/executor.cc
+++ b/src/executor.cc
@@ -34,8 +34,7 @@ Result Executor::CompileShaders(const amber::Script* script,
                                 Options* options) {
   for (auto& pipeline : script->GetPipelines()) {
     for (auto& shader_info : pipeline->GetShaders()) {
-      ShaderCompiler sc(script->GetSpvTargetEnv(),
-                        options->disable_spirv_validation);
+      ShaderCompiler sc(script->GetSpvTargetEnv());
 
       Result r;
       std::vector<uint32_t> data;

--- a/src/shader_compiler.cc
+++ b/src/shader_compiler.cc
@@ -47,9 +47,8 @@ namespace amber {
 
 ShaderCompiler::ShaderCompiler() = default;
 
-ShaderCompiler::ShaderCompiler(const std::string& env,
-                               bool disable_spirv_validation)
-    : spv_env_(env), disable_spirv_validation_(disable_spirv_validation) {}
+ShaderCompiler::ShaderCompiler(const std::string& env)
+    : spv_env_(env) {}
 
 ShaderCompiler::~ShaderCompiler() = default;
 

--- a/src/shader_compiler.h
+++ b/src/shader_compiler.h
@@ -30,7 +30,7 @@ namespace amber {
 class ShaderCompiler {
  public:
   ShaderCompiler();
-  ShaderCompiler(const std::string& env, bool disable_spirv_validation);
+  ShaderCompiler(const std::string& env);
   ~ShaderCompiler();
 
   /// Returns a result code and a compilation of the given shader.
@@ -53,7 +53,6 @@ class ShaderCompiler {
                         std::vector<uint32_t>* result) const;
 
   std::string spv_env_;
-  bool disable_spirv_validation_ = false;
 };
 
 // Parses the SPIR-V environment string, and returns the corresponding


### PR DESCRIPTION
When trying to update amber within VK-GL-CTS, the sanity script fails due to unused private variable when building with clang. These changes remove that variable.