### PR TITLE
Disable warning in shader_compiler.cc.

### DIFF
--- a/src/shader_compiler.cc
+++ b/src/shader_compiler.cc
@@ -162,6 +162,9 @@ std::pair<Result, std::vector<uint32_t>> ShaderCompiler::Compile(
     if (!optimizer.Run(results.data(), results.size(), &results))
       return {Result("Optimizations failed: " + spv_errors), {}};
   }
+#else
+  // disable warning: private field 'disable_spirv_validation_' is not used
+  (void)disable_spirv_validation_;
 #endif  // AMBER_ENABLE_SPIRV_TOOLS
 
   return {{}, results};


### PR DESCRIPTION
This warning is treated as an error in dEQP.