### PR TITLE
Build fixes for updating dEQP's version of amber

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,18 +194,20 @@ function(amber_default_compile_options TARGET)
       -Wall
       -Werror
       -Wextra
-      -Wno-c++98-compat
-      -Wno-c++98-compat-pedantic
-      -Wno-format-pedantic
       -Wno-padded
       -Wno-switch-enum
       -Wno-unknown-pragmas
-      -Wno-unknown-warning-option
       -pedantic-errors
     )
 
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-      target_compile_options(${TARGET} PRIVATE -Weverything)
+      target_compile_options(${TARGET} PRIVATE
+        -Wno-c++98-compat
+        -Wno-c++98-compat-pedantic
+        -Wno-format-pedantic
+        -Wno-unknown-warning-option
+        -Weverything
+      )
     endif()
   endif()
 

--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -193,7 +193,7 @@ Result Buffer::CompareRMSE(Buffer* buffer, float tolerance) const {
   for (const auto val : diffs)
     sum += (val * val);
 
-  sum /= diffs.size();
+  sum /= static_cast<double>(diffs.size());
   double rmse = std::sqrt(sum);
   if (rmse > static_cast<double>(tolerance)) {
     return Result("Root Mean Square Error of " + std::to_string(rmse) +


### PR DESCRIPTION
Successful build can be seen here: https://gerrit.khronos.org/#/c/4546/

Required moving clang-only warning flags out of the `if(${COMPILER_IS_LIKE_GNU})` block and into the `if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")` block. See:
https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
https://clang.llvm.org/docs/DiagnosticsReference.html
for lists of accepted GCC and Clang warning flags.

This PR also include's @dneto0 's implicit cast fix, but I've used `static_cast` instead.
