### PR TITLE
Upgrade cmake on bots

### DIFF
--- a/kokoro/scripts/linux/build.sh
+++ b/kokoro/scripts/linux/build.sh
@@ -48,7 +48,7 @@ echo y | sudo apt-get purge --auto-remove cmake
 # install new cmake version
 echo y | sudo apt-get install cmake
 
-echo $(date): cmake --version
+echo $(date): $(cmake --version)
 
 # Get ninja
 wget -q https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip


### PR DESCRIPTION
This CL forces the bots to use a newer cmake then the 3.7 on the bots. This is required in order to roll the Vulkan-Headers dependency.