### PR TITLE
Roll Vulkan headers and loader to v1.1.114

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -19,8 +19,8 @@ vars = {
   'spirv_headers_revision': '38cafab379e5d16137cb97a485b9385191039b92',
   'spirv_tools_revision': 'c0e9807094ef6e345ef0a4d5f17af81af063cd27',
   'swiftshader_revision': 'ef44b4402722658648ec9d10a76bd990776be1c0',
-  'vulkan_headers_revision': '8e2c4cd554b644592a6d904f2c8000ebbd4aa77f',
-  'vulkan_loader_revision': '15fa85d92454f7823febeb68b56038d427e2a7a4',
+  'vulkan_headers_revision': 'e3f96a9ccab9397481eb81c4d9bce4ea7590dc33',
+  'vulkan_loader_revision': '1bb7f68564fe565de2927071c79008bd6ede5af5',
 }
 
 deps = {

--- a/kokoro/scripts/macos/build.sh
+++ b/kokoro/scripts/macos/build.sh
@@ -26,6 +26,8 @@ unzip -q ninja-mac.zip
 chmod +x ninja
 export PATH="$PWD:$PATH"
 
+echo $(date): $(cmake --version)
+
 cd $SRC
 ./tools/git-sync-deps
 

--- a/kokoro/scripts/windows/build.bat
+++ b/kokoro/scripts/windows/build.bat
@@ -18,7 +18,11 @@ set BUILD_ROOT=%cd%
 set SRC=%cd%\github\amber
 set BUILD_TYPE=%1
 
-set PATH=C:\python36;%PATH%
+choco install cmake --pre --yes --no-progress
+choco upgrade cmake --pre --yes --no-progress
+
+:: Force usage of python 3.6 and add cmake to the path.
+set PATH=C:\python36;"C:\Program Files\CMake\bin";%PATH%
 
 cd %SRC%
 python tools\git-sync-deps
@@ -28,6 +32,8 @@ python tools\git-sync-deps
 :: #########################################
 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
 echo "Using VS 2017..."
+
+cmake --version
 
 cd %SRC%
 mkdir build

--- a/src/vulkan/find_vulkan.cmake
+++ b/src/vulkan/find_vulkan.cmake
@@ -25,8 +25,12 @@ if (NOT ${Vulkan_FOUND})
     set(VulkanHeaders_INCLUDE_DIR
       ${PROJECT_SOURCE_DIR}/third_party/vulkan-headers/include
       CACHE PATH "vk headers dir" FORCE)
+    set(VulkanHeaders_INCLUDE_DIRS ${VulkanHeaders_INCLUDE_DIR}
+      CACHE PATH "vk headers dir" FORCE)
     set(VulkanRegistry_DIR
       ${PROJECT_SOURCE_DIR}/third_party/vulkan-headers/registry
+      CACHE PATH "vk_registry_dir" FORCE)
+    set(VulkanRegistry_DIRS ${VulkanRegistry_DIR}
       CACHE PATH "vk_registry_dir" FORCE)
     include_directories(BEFORE "${VulkanHeaders_INCLUDE_DIR}")
     set(VULKAN_LIB vulkan)


### PR DESCRIPTION
Roll up to the Vulkan 114 release which is before the WDK change.