### PR TITLE
Add validation layers to local build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ third_party/spirv-tools
 third_party/spirv-headers
 third_party/swiftshader
 third_party/vulkan-headers
+third_party/vulkan-validationlayers/
 third_party/vulkan-loader
 .vs
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10.2)
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()

--- a/DEPS
+++ b/DEPS
@@ -20,6 +20,7 @@ vars = {
   'spirv_tools_revision': 'c0e9807094ef6e345ef0a4d5f17af81af063cd27',
   'swiftshader_revision': 'ef44b4402722658648ec9d10a76bd990776be1c0',
   'vulkan_headers_revision': 'e3f96a9ccab9397481eb81c4d9bce4ea7590dc33',
+  'vulkan_validationlayers_revision': '0e65e191c4b9044d8e42727cc82ccc04d8055b0a',
   'vulkan_loader_revision': '1bb7f68564fe565de2927071c79008bd6ede5af5',
 }
 
@@ -59,6 +60,9 @@ deps = {
 
   'third_party/vulkan-headers': vars['khronos_git'] + '/Vulkan-Headers.git@' +
       vars['vulkan_headers_revision'],
+
+  'third_party/vulkan-validationlayers': vars['khronos_git'] + '/Vulkan-ValidationLayers.git@' +
+      vars['vulkan_validationlayers_revision'],
 
   'third_party/vulkan-loader': vars['khronos_git'] + '/Vulkan-Loader.git@' +
       vars['vulkan_loader_revision'],

--- a/kokoro/android/build.sh
+++ b/kokoro/android/build.sh
@@ -26,6 +26,18 @@ ANDROID_ABI="armeabi-v7a with NEON"
 
 TOOLCHAIN_PATH=$ANDROID_NDK/build/cmake/android.toolchain.cmake
 
+# removing the old version
+echo y | sudo apt-get purge --auto-remove cmake
+
+# Installing the 3.10.2 version
+wget http://www.cmake.org/files/v3.10/cmake-3.10.2.tar.gz
+tar -xvzf cmake-3.10.2.tar.gz
+cd cmake-3.10.2/
+./configure
+make
+sudo make install
+echo $(date): $(cmake --version)
+
 # Get NINJA.
 wget -q https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip
 unzip -q ninja-linux.zip

--- a/kokoro/scripts/linux/build.sh
+++ b/kokoro/scripts/linux/build.sh
@@ -43,10 +43,16 @@ then
   BUILD_TYPE="RelWithDebInfo"
 fi
 
-# # removing the old cmake version
-# echo y | sudo apt-get purge --auto-remove cmake
-# # install new cmake version
-# echo y | sudo apt-get install cmake
+# removing the old version
+echo y | sudo apt-get purge --auto-remove cmake
+
+# Installing the 3.10.2 version
+wget http://www.cmake.org/files/v3.10/cmake-3.10.2.tar.gz
+tar -xvzf cmake-3.10.2.tar.gz
+cd cmake-3.10.2/
+./configure
+make
+sudo make install
 
 echo $(date): $(cmake --version)
 

--- a/kokoro/scripts/linux/build.sh
+++ b/kokoro/scripts/linux/build.sh
@@ -43,10 +43,10 @@ then
   BUILD_TYPE="RelWithDebInfo"
 fi
 
-# removing the old cmake version
-echo y | sudo apt-get purge --auto-remove cmake
-# install new cmake version
-echo y | sudo apt-get install cmake
+# # removing the old cmake version
+# echo y | sudo apt-get purge --auto-remove cmake
+# # install new cmake version
+# echo y | sudo apt-get install cmake
 
 echo $(date): $(cmake --version)
 

--- a/kokoro/scripts/linux/build_dawn.sh
+++ b/kokoro/scripts/linux/build_dawn.sh
@@ -39,6 +39,18 @@ then
   BUILD_TYPE="RelWithDebInfo"
 fi
 
+# removing the old version
+echo y | sudo apt-get purge --auto-remove cmake
+
+# Installing the 3.10.2 version
+wget http://www.cmake.org/files/v3.10/cmake-3.10.2.tar.gz
+tar -xvzf cmake-3.10.2.tar.gz
+cd cmake-3.10.2/
+./configure
+make
+sudo make install
+echo $(date): $(cmake --version)
+
 # Get ninja
 wget -q https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip
 unzip -q ninja-linux.zip

--- a/setup_debug_local.env
+++ b/setup_debug_local.env
@@ -1,0 +1,3 @@
+export VK_LAYER_PATH=out/Debug/third_party/vulkan-validationlayers/layers
+export LD_LIBRARY_PATH=out/Debug/third_party/vulkan-loader/loader
+

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -62,6 +62,7 @@ if (${AMBER_USE_LOCAL_VULKAN})
   set(BUILD_WSI_XLIB_SUPPORT OFF CACHE BOOL "" FORCE)
 
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vulkan-loader)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/vulkan-validationlayers)
 endif()
 
 if (${AMBER_ENABLE_SWIFTSHADER})


### PR DESCRIPTION
This CL adds the validation layers into the local vulkan build for Amber. There is a simple shell script to setup these layers when using a debug build.

Fixes #539 