### PR TITLE
Clear all colour buffers in Vulkan engine. 

### DIFF
--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -799,7 +799,7 @@ Result GraphicsPipeline::ClearBuffer(const VkClearValue& clear_value,
     for (size_t i = 0; i < color_buffers_.size(); ++i) {
       VkClearAttachment clear_attachment = VkClearAttachment();
       clear_attachment.aspectMask = aspect;
-      clear_attachment.colorAttachment = i;
+      clear_attachment.colorAttachment = static_cast<uint32_t>(i);
       clear_attachment.clearValue = clear_value;
 
       clears.push_back(clear_attachment);

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -795,10 +795,15 @@ Result GraphicsPipeline::ClearBuffer(const VkClearValue& clear_value,
   {
     RenderPassGuard render_pass_guard(this);
 
-    VkClearAttachment clear_attachment = VkClearAttachment();
-    clear_attachment.aspectMask = aspect;
-    clear_attachment.colorAttachment = 0;
-    clear_attachment.clearValue = clear_value;
+    std::vector<VkClearAttachment> clears;
+    for (size_t i = 0; i < color_buffers_.size(); ++i) {
+      VkClearAttachment clear_attachment = VkClearAttachment();
+      clear_attachment.aspectMask = aspect;
+      clear_attachment.colorAttachment = i;
+      clear_attachment.clearValue = clear_value;
+
+      clears.push_back(clear_attachment);
+    }
 
     VkClearRect clear_rect;
     clear_rect.rect = {{0, 0}, {frame_width_, frame_height_}};
@@ -806,7 +811,8 @@ Result GraphicsPipeline::ClearBuffer(const VkClearValue& clear_value,
     clear_rect.layerCount = 1;
 
     device_->GetPtrs()->vkCmdClearAttachments(
-        command_->GetVkCommandBuffer(), 1, &clear_attachment, 1, &clear_rect);
+        command_->GetVkCommandBuffer(), static_cast<uint32_t>(clears.size()),
+        clears.data(), 1, &clear_rect);
   }
 
   frame_->TransferColorImagesToHost(command_.get());

--- a/tests/cases/clear_multiple.amber
+++ b/tests/cases/clear_multiple.amber
@@ -1,0 +1,39 @@
+#!amber
+# Copyright 2019 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHADER vertex vtex_shader PASSTHROUGH
+SHADER fragment frag_shader GLSL
+#version 430
+
+void main() {
+}
+END
+
+BUFFER img_buf_0 FORMAT B8G8R8A8_UNORM
+BUFFER img_buf_1 FORMAT B8G8R8A8_UNORM
+
+PIPELINE graphics my_pipeline
+  ATTACH vtex_shader
+  ATTACH frag_shader
+
+  FRAMEBUFFER_SIZE 256 256
+  BIND BUFFER img_buf_0 AS color LOCATION 0
+  BIND BUFFER img_buf_1 AS color LOCATION 1
+END
+
+CLEAR_COLOR my_pipeline 255 0 0 255
+CLEAR my_pipeline
+EXPECT img_buf_0 IDX 0 0 SIZE 256 256 EQ_RGBA 255 0 0 255
+EXPECT img_buf_1 IDX 0 0 SIZE 256 256 EQ_RGBA 255 0 0 255


### PR DESCRIPTION
Currently the Vulkan engine only issues a clear for the first colour
attachment. This CL updates the code to clear all colour attachments.

Fixes #612