### PR TITLE
Rename Buffer::ResizeTo to Buffer::SetSizeInElements.

### DIFF
--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -330,7 +330,7 @@ uint32_t Buffer::WriteValueFromComponent(const Value& value,
   return 0;
 }
 
-void Buffer::ResizeTo(uint32_t element_count) {
+void Buffer::SetSizeInElements(uint32_t element_count) {
   element_count_ = element_count;
   bytes_.resize(element_count * format_->SizeInBytes());
 }

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -148,13 +148,13 @@ class Buffer {
   /// Resizes the buffer to hold |element_count| elements. This is separate
   /// from SetElementCount() because we may not know the format when we set the
   /// initial count. This requires the format to have been set.
-  void ResizeTo(uint32_t element_count);
+  void SetSizeInElements(uint32_t element_count);
 
   /// Resizes the buffer to hold |size_in_bytes|/format_->SizeInBytes()
   /// number of elements while resizing the buffer to |size_in_bytes| bytes.
   /// This requires the format to have been set. This is separate from
-  /// ResizeTo() since the given argument here is |size_in_bytes| bytes vs
-  /// |element_count| elements
+  /// SetSizeInElements() since the given argument here is |size_in_bytes|
+  /// bytes vs |element_count| elements
   void SetSizeInBytes(uint32_t size_in_bytes);
 
   /// Sets the max_size_in_bytes_ to |max_size_in_bytes| bytes

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -556,7 +556,7 @@ Result Pipeline::GenerateOpenCLPodBuffers() {
 
     // Resize if necessary.
     if (buffer->ValueCount() < offset + arg_size) {
-      buffer->ResizeTo(offset + arg_size);
+      buffer->SetSizeInElements(offset + arg_size);
     }
     // Check the data size.
     if (arg_size != arg_info.type.SizeInBytes()) {

--- a/src/vulkan/buffer_descriptor.cc
+++ b/src/vulkan/buffer_descriptor.cc
@@ -150,11 +150,11 @@ void BufferDescriptor::UpdateDescriptorSetIfNeeded(
   is_descriptor_set_update_needed_ = false;
 }
 
-Result BufferDescriptor::ResizeTo(uint32_t element_count) {
+Result BufferDescriptor::SetSizeInElements(uint32_t element_count) {
   if (!amber_buffer_)
-    return Result("missing amber_buffer for ResizeTo call");
+    return Result("missing amber_buffer for SetSizeInElements call");
 
-  amber_buffer_->ResizeTo(element_count);
+  amber_buffer_->SetSizeInElements(element_count);
   return {};
 }
 

--- a/src/vulkan/buffer_descriptor.h
+++ b/src/vulkan/buffer_descriptor.h
@@ -68,7 +68,7 @@ class BufferDescriptor {
   Result MoveResourceToBufferOutput();
   void UpdateDescriptorSetIfNeeded(VkDescriptorSet descriptor_set);
 
-  Result ResizeTo(uint32_t element_count);
+  Result SetSizeInElements(uint32_t element_count);
   Result AddToBuffer(const std::vector<Value>& values, uint32_t offset);
 
  private:

--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -298,7 +298,7 @@ Result Pipeline::AddDescriptor(const BufferCommand* cmd) {
 
   auto* buf_desc = static_cast<BufferDescriptor*>(desc);
   if (cmd->GetValues().empty()) {
-    Result r = buf_desc->ResizeTo(cmd->GetBuffer()->ElementCount());
+    Result r = buf_desc->SetSizeInElements(cmd->GetBuffer()->ElementCount());
     if (!r.IsSuccess())
       return r;
   } else {


### PR DESCRIPTION
This makes the name clearer and matches SetSizeInBytes.

Fixes #597