### PR TITLE
Create Format directly instead of going through DatumType.

### DIFF
--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -540,9 +540,10 @@ Result Pipeline::GenerateOpenCLPodBuffers() {
               : BufferType::kUniform);
       // Use an 8-bit type because all the data in the descriptor map is
       // byte-based and it simplifies the logic for sizing below.
-      DatumType char_type;
-      char_type.SetType(DataType::kUint8);
-      buffer->SetFormat(char_type.AsFormat());
+      auto fmt = MakeUnique<Format>();
+      fmt->AddComponent(FormatComponentType::kR, FormatMode::kUInt, 8);
+
+      buffer->SetFormat(std::move(fmt));
       buffer->SetName(GetName() + "_pod_buffer_" +
                       std::to_string(descriptor_set) + "_" +
                       std::to_string(binding));

--- a/src/vkscript/command_parser.cc
+++ b/src/vkscript/command_parser.cc
@@ -2061,7 +2061,7 @@ Result CommandParser::ProcessProbeSSBO() {
 
   auto fmt = tp.GetType().AsFormat();
   if (buffer->FormatIsDefault() || !buffer->GetFormat())
-    buffer->SetFormat(tp.GetType().AsFormat());
+    buffer->SetFormat(MakeUnique<Format>(*fmt));
   else if (buffer->GetFormat() && !buffer->GetFormat()->Equal(fmt.get()))
     return Result("probe format does not match buffer format");
 

--- a/src/vkscript/parser.cc
+++ b/src/vkscript/parser.cc
@@ -287,13 +287,13 @@ Result Parser::ProcessIndicesBlock(const SectionParser::Section& section) {
   }
 
   if (!indices.empty()) {
-    DatumType type;
-    type.SetType(DataType::kUint32);
+    auto fmt = MakeUnique<Format>();
+    fmt->AddComponent(FormatComponentType::kR, FormatMode::kUInt, 32);
 
     auto b = MakeUnique<Buffer>(BufferType::kIndex);
     auto* buf = b.get();
     b->SetName("indices");
-    b->SetFormat(type.AsFormat());
+    b->SetFormat(std::move(fmt));
     b->SetData(std::move(indices));
     Result r = script_->AddBuffer(std::move(b));
     if (!r.IsSuccess())


### PR DESCRIPTION
This CL switches some DatumType uses to directly creating Formats
instead of converting after creation.