### PR TITLE
Use Format for args instead of DatumType.

### DIFF
--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -840,11 +840,13 @@ Result Parser::ParsePipelineSet(Pipeline* pipeline) {
     token = tokenizer_->NextToken();
     if (!token->IsString())
       return Result("expected argument identifier");
+
     arg_name = token->AsString();
   } else if (token->AsString() == "ARG_NUMBER") {
     token = tokenizer_->NextToken();
     if (!token->IsInteger())
       return Result("expected argument number");
+
     arg_no = token->AsUint32();
   } else {
     return Result("expected ARG_NAME or ARG_NUMBER");
@@ -876,7 +878,7 @@ Result Parser::ParsePipelineSet(Pipeline* pipeline) {
   Pipeline::ArgSetInfo info;
   info.name = arg_name;
   info.ordinal = arg_no;
-  info.type = arg_type;
+  info.fmt = arg_type.AsFormat();
   info.value = value;
   pipeline->SetArg(std::move(info));
   return ValidateEndOfStatement("SET command");

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -245,7 +245,7 @@ class Pipeline {
   struct ArgSetInfo {
     std::string name;
     uint32_t ordinal = 0;
-    DatumType type;
+    std::unique_ptr<Format> fmt;
     Value value;
   };
 

--- a/src/pipeline_test.cc
+++ b/src/pipeline_test.cc
@@ -692,7 +692,6 @@ TEST_F(PipelineTest, OpenCLClone) {
   Value int_value;
   int_value.SetIntValue(1);
 
-
   auto int_fmt = MakeUnique<Format>();
   int_fmt->AddComponent(FormatComponentType::kR, FormatMode::kSInt, 32);
 

--- a/src/pipeline_test.cc
+++ b/src/pipeline_test.cc
@@ -523,29 +523,31 @@ TEST_F(PipelineTest, OpenCLGeneratePodBuffers) {
   // Set commands.
   Value int_value;
   int_value.SetIntValue(1);
-  DatumType int_type;
-  int_type.SetType(DataType::kInt32);
-  DatumType char_type;
-  char_type.SetType(DataType::kInt8);
+
+  auto int_fmt = MakeUnique<Format>();
+  int_fmt->AddComponent(FormatComponentType::kR, FormatMode::kSInt, 32);
+
+  auto char_fmt = MakeUnique<Format>();
+  char_fmt->AddComponent(FormatComponentType::kR, FormatMode::kSInt, 8);
 
   Pipeline::ArgSetInfo arg_info1;
   arg_info1.name = "arg_a";
   arg_info1.ordinal = 99;
-  arg_info1.type = int_type;
+  arg_info1.fmt = MakeUnique<Format>(*int_fmt);
   arg_info1.value = int_value;
   p.SetArg(std::move(arg_info1));
 
   Pipeline::ArgSetInfo arg_info2;
   arg_info2.name = "arg_b";
   arg_info2.ordinal = 99;
-  arg_info2.type = char_type;
+  arg_info2.fmt = MakeUnique<Format>(*char_fmt);
   arg_info2.value = int_value;
   p.SetArg(std::move(arg_info2));
 
   Pipeline::ArgSetInfo arg_info3;
   arg_info3.name = "arg_c";
   arg_info3.ordinal = 99;
-  arg_info3.type = int_type;
+  arg_info1.fmt = MakeUnique<Format>(*int_fmt);
   arg_info3.value = int_value;
   p.SetArg(std::move(arg_info3));
 
@@ -587,13 +589,14 @@ TEST_F(PipelineTest, OpenCLGeneratePodBuffersBadName) {
   // Set commands.
   Value int_value;
   int_value.SetIntValue(1);
-  DatumType int_type;
-  int_type.SetType(DataType::kInt32);
+
+  auto int_fmt = MakeUnique<Format>();
+  int_fmt->AddComponent(FormatComponentType::kR, FormatMode::kSInt, 32);
 
   Pipeline::ArgSetInfo arg_info1;
   arg_info1.name = "arg_z";
   arg_info1.ordinal = 99;
-  arg_info1.type = int_type;
+  arg_info1.fmt = std::move(int_fmt);
   arg_info1.value = int_value;
   p.SetArg(std::move(arg_info1));
 
@@ -628,13 +631,14 @@ TEST_F(PipelineTest, OpenCLGeneratePodBuffersBadSize) {
   // Set commands.
   Value int_value;
   int_value.SetIntValue(1);
-  DatumType short_type;
-  short_type.SetType(DataType::kInt16);
+
+  auto short_fmt = MakeUnique<Format>();
+  short_fmt->AddComponent(FormatComponentType::kR, FormatMode::kSInt, 16);
 
   Pipeline::ArgSetInfo arg_info1;
   arg_info1.name = "";
   arg_info1.ordinal = 0;
-  arg_info1.type = short_type;
+  arg_info1.fmt = std::move(short_fmt);
   arg_info1.value = int_value;
   p.SetArg(std::move(arg_info1));
 
@@ -687,29 +691,32 @@ TEST_F(PipelineTest, OpenCLClone) {
   // Set commands.
   Value int_value;
   int_value.SetIntValue(1);
-  DatumType int_type;
-  int_type.SetType(DataType::kInt32);
-  DatumType char_type;
-  char_type.SetType(DataType::kInt8);
+
+
+  auto int_fmt = MakeUnique<Format>();
+  int_fmt->AddComponent(FormatComponentType::kR, FormatMode::kSInt, 32);
+
+  auto char_fmt = MakeUnique<Format>();
+  char_fmt->AddComponent(FormatComponentType::kR, FormatMode::kSInt, 8);
 
   Pipeline::ArgSetInfo arg_info1;
   arg_info1.name = "arg_a";
   arg_info1.ordinal = 99;
-  arg_info1.type = int_type;
+  arg_info1.fmt = MakeUnique<Format>(*int_fmt);
   arg_info1.value = int_value;
   p.SetArg(std::move(arg_info1));
 
   Pipeline::ArgSetInfo arg_info2;
   arg_info2.name = "arg_b";
   arg_info2.ordinal = 99;
-  arg_info2.type = char_type;
+  arg_info2.fmt = MakeUnique<Format>(*char_fmt);
   arg_info2.value = int_value;
   p.SetArg(std::move(arg_info2));
 
   Pipeline::ArgSetInfo arg_info3;
   arg_info3.name = "arg_c";
   arg_info3.ordinal = 99;
-  arg_info3.type = int_type;
+  arg_info3.fmt = MakeUnique<Format>(*int_fmt);
   arg_info3.value = int_value;
   p.SetArg(std::move(arg_info3));
 

--- a/src/pipeline_test.cc
+++ b/src/pipeline_test.cc
@@ -547,7 +547,7 @@ TEST_F(PipelineTest, OpenCLGeneratePodBuffers) {
   Pipeline::ArgSetInfo arg_info3;
   arg_info3.name = "arg_c";
   arg_info3.ordinal = 99;
-  arg_info1.fmt = MakeUnique<Format>(*int_fmt);
+  arg_info3.fmt = MakeUnique<Format>(*int_fmt);
   arg_info3.value = int_value;
   p.SetArg(std::move(arg_info3));
 


### PR DESCRIPTION
This CL converts the arg holder to store a Format instead of a
DatumType.