### PR TITLE
Cleanup DatumType methods.

### DIFF
--- a/src/datum_type.cc
+++ b/src/datum_type.cc
@@ -19,6 +19,24 @@
 #include "src/format_parser.h"
 
 namespace amber {
+namespace {
+
+uint32_t ElementSizeInBytes(DataType type) {
+  if (type == DataType::kInt8 || type == DataType::kUint8)
+    return 1;
+  if (type == DataType::kInt16 || type == DataType::kUint16)
+    return 2;
+  if (type == DataType::kInt32 || type == DataType::kUint32)
+    return 4;
+  if (type == DataType::kInt64 || type == DataType::kUint64)
+    return 8;
+  if (type == DataType::kFloat)
+    return sizeof(float);
+
+  return sizeof(double);
+}
+
+}  // namespace
 
 DatumType::DatumType() = default;
 
@@ -26,40 +44,8 @@ DatumType::DatumType(const DatumType&) = default;
 
 DatumType::~DatumType() = default;
 
-DatumType& DatumType::operator=(const DatumType&) = default;
-
-uint32_t DatumType::ElementSizeInBytes() const {
-  uint32_t s;
-  if (type_ == DataType::kInt8 || type_ == DataType::kUint8)
-    s = 1;
-  else if (type_ == DataType::kInt16 || type_ == DataType::kUint16)
-    s = 2;
-  else if (type_ == DataType::kInt32 || type_ == DataType::kUint32)
-    s = 4;
-  else if (type_ == DataType::kInt64 || type_ == DataType::kUint64)
-    s = 8;
-  else if (type_ == DataType::kFloat)
-    s = sizeof(float);
-  else
-    s = sizeof(double);
-
-  return s;
-}
-
-uint32_t DatumType::SizeInBytes() const {
-  uint32_t s = ElementSizeInBytes();
-  uint32_t bytes = s * column_count_ * row_count_;
-
-  // For a vector of size 3 in std140 we need to have alignment of 4N. For a
-  // matrix, we update each row to 4N.
-  if (is_std140_ && row_count_ == 3)
-    bytes += (s * column_count_);
-
-  return bytes;
-}
-
 std::unique_ptr<Format> DatumType::AsFormat() const {
-  uint32_t bits_per_element = ElementSizeInBytes() * 8;
+  uint32_t bits_per_element = ElementSizeInBytes(type_) * 8;
   static const char* prefixes = "RGBA";
   std::string name = "";
   for (size_t i = 0; i < row_count_; ++i)

--- a/src/datum_type.h
+++ b/src/datum_type.h
@@ -45,8 +45,6 @@ class DatumType {
   DatumType(const DatumType&);
   ~DatumType();
 
-  DatumType& operator=(const DatumType&);
-
   bool IsInt8() const { return type_ == DataType::kInt8; }
   bool IsInt16() const { return type_ == DataType::kInt16; }
   bool IsInt32() const { return type_ == DataType::kInt32; }
@@ -66,9 +64,6 @@ class DatumType {
 
   void SetRowCount(uint32_t count) { row_count_ = count; }
   uint32_t RowCount() const { return row_count_; }
-
-  uint32_t ElementSizeInBytes() const;
-  uint32_t SizeInBytes() const;
 
   std::unique_ptr<Format> AsFormat() const;
 


### PR DESCRIPTION
This Cl removes unused methods from DatumType and hides the
ElementSizeInBytes method.