### PR TITLE
Remove DatumType usage from AmberScript parser.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -27,7 +27,6 @@ LOCAL_SRC_FILES:= \
     src/buffer.cc \
     src/command.cc \
     src/command_data.cc \
-    src/datum_type.cc \
     src/descriptor_set_and_binding_parser.cc \
     src/engine.cc \
     src/executor.cc \
@@ -45,6 +44,7 @@ LOCAL_SRC_FILES:= \
     src/value.cc \
     src/verifier.cc \
     src/vkscript/command_parser.cc \
+    src/vkscript/datum_type.cc \
     src/vkscript/datum_type_parser.cc \
     src/vkscript/parser.cc \
     src/vkscript/section_parser.cc \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,6 @@ set(AMBER_SOURCES
     buffer.cc
     command.cc
     command_data.cc
-    datum_type.cc
     descriptor_set_and_binding_parser.cc
     engine.cc
     executor.cc
@@ -37,6 +36,7 @@ set(AMBER_SOURCES
     value.cc
     verifier.cc
     vkscript/command_parser.cc
+    vkscript/datum_type.cc
     vkscript/datum_type_parser.cc
     vkscript/parser.cc
     vkscript/section_parser.cc
@@ -133,7 +133,6 @@ if (${AMBER_ENABLE_TESTS})
     amberscript/parser_test.cc
     buffer_test.cc
     command_data_test.cc
-    datum_type_test.cc
     descriptor_set_and_binding_parser_test.cc
     executor_test.cc
     format_parser_test.cc
@@ -145,6 +144,7 @@ if (${AMBER_ENABLE_TESTS})
     tokenizer_test.cc
     verifier_test.cc
     vkscript/command_parser_test.cc
+    vkscript/datum_type_test.cc
     vkscript/datum_type_parser_test.cc
     vkscript/parser_test.cc
     vkscript/section_parser_test.cc

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -118,7 +118,7 @@ std::unique_ptr<Format> ToFormat(const std::string& str) {
     if (sub_fmt->RowCount() != 1 || sub_fmt->ColumnCount() != 1)
       return nullptr;
 
-    fmt->SetColumnCount(column_count);
+    fmt->SetColumnCount(static_cast<uint32_t>(column_count));
 
     const auto& comp = sub_fmt->GetComponents()[0];
     for (int i = 0; i < row_count; ++i)

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -29,6 +29,10 @@ namespace amber {
 namespace amberscript {
 namespace {
 
+FormatComponentType FORMAT_TYPES[] = {
+    FormatComponentType::kR, FormatComponentType::kG, FormatComponentType::kB,
+    FormatComponentType::kA};
+
 bool IsComparator(const std::string& in) {
   return in == "EQ" || in == "NE" || in == "GT" || in == "LT" || in == "GE" ||
          in == "LE";
@@ -48,6 +52,118 @@ ProbeSSBOCommand::Comparator ToComparator(const std::string& in) {
 
   assert(in == "LE");
   return ProbeSSBOCommand::Comparator::kLessOrEqual;
+}
+
+std::unique_ptr<Format> ToFormat(const std::string& str) {
+  auto fmt = MakeUnique<Format>();
+  bool matrix = false;
+
+  if (str == "int8") {
+    fmt->AddComponent(FormatComponentType::kR, FormatMode::kSInt, 8);
+  } else if (str == "int16") {
+    fmt->AddComponent(FormatComponentType::kR, FormatMode::kSInt, 16);
+  } else if (str == "int32") {
+    fmt->AddComponent(FormatComponentType::kR, FormatMode::kSInt, 32);
+  } else if (str == "int64") {
+    fmt->AddComponent(FormatComponentType::kR, FormatMode::kSInt, 64);
+  } else if (str == "uint8") {
+    fmt->AddComponent(FormatComponentType::kR, FormatMode::kUInt, 8);
+  } else if (str == "uint16") {
+    fmt->AddComponent(FormatComponentType::kR, FormatMode::kUInt, 16);
+  } else if (str == "uint32") {
+    fmt->AddComponent(FormatComponentType::kR, FormatMode::kUInt, 32);
+  } else if (str == "uint64") {
+    fmt->AddComponent(FormatComponentType::kR, FormatMode::kUInt, 64);
+  } else if (str == "float") {
+    fmt->AddComponent(FormatComponentType::kR, FormatMode::kSFloat, 32);
+  } else if (str == "double") {
+    fmt->AddComponent(FormatComponentType::kR, FormatMode::kSFloat, 64);
+  } else if (str.length() > 7 && str.substr(0, 3) == "vec") {
+    if (str[4] != '<' || str[str.length() - 1] != '>')
+      return nullptr;
+
+    uint8_t component_count = str[3] - '0';
+    if (component_count < 2 || component_count > 4)
+      return nullptr;
+
+    auto sub_fmt = ToFormat(str.substr(5, str.length() - 6));
+    if (!sub_fmt)
+      return nullptr;
+
+    if (sub_fmt->RowCount() != 1 || sub_fmt->ColumnCount() != 1)
+      return nullptr;
+
+    const auto& comp = sub_fmt->GetComponents()[0];
+    for (uint8_t i = 0; i < component_count; ++i)
+      fmt->AddComponent(FORMAT_TYPES[i], comp.mode, comp.num_bits);
+
+  } else if (str.length() > 9 && str.substr(0, 3) == "mat") {
+    if (str[4] != 'x' || str[6] != '<' || str[str.length() - 1] != '>')
+      return nullptr;
+
+    matrix = true;
+
+    uint8_t column_count = str[3] - '0';
+    if (column_count < 2 || column_count > 4)
+      return nullptr;
+
+    uint8_t row_count = str[5] - '0';
+    if (row_count < 2 || row_count > 4)
+      return nullptr;
+
+    auto sub_fmt = ToFormat(str.substr(7, str.length() - 8));
+    if (!sub_fmt)
+      return nullptr;
+
+    if (sub_fmt->RowCount() != 1 || sub_fmt->ColumnCount() != 1)
+      return nullptr;
+
+    fmt->SetColumnCount(column_count);
+
+    const auto& comp = sub_fmt->GetComponents()[0];
+    for (uint8_t i = 0; i < row_count; ++i)
+      fmt->AddComponent(FORMAT_TYPES[i], comp.mode, comp.num_bits);
+
+  } else {
+    return nullptr;
+  }
+
+  // Convert the name back into a FormatType so we can use it in the buffer
+  // later Otherwise, we end up with a type of Unknown.
+  //
+  // There is no equivalent type for a matrix.
+  if (!matrix) {
+    std::string name = "";
+    std::string parts = "ARGB";
+    const auto& comps = fmt->GetComponents();
+    for (const auto& comp : comps) {
+      name += parts[static_cast<uint8_t>(comp.type)] +
+              std::to_string(comp.num_bits);
+    }
+    name += "_";
+    switch (comps[0].mode) {
+      case FormatMode::kUNorm:
+      case FormatMode::kUFloat:
+      case FormatMode::kUScaled:
+      case FormatMode::kSNorm:
+      case FormatMode::kSScaled:
+      case FormatMode::kSRGB:
+        return nullptr;
+      case FormatMode::kUInt:
+        name += "UINT";
+        break;
+      case FormatMode::kSInt:
+        name += "SINT";
+        break;
+      case FormatMode::kSFloat:
+        name += "SFLOAT";
+        break;
+    }
+
+    fmt->SetFormatType(FormatParser::NameToType(name));
+  }
+
+  return fmt;
 }
 
 }  // namespace
@@ -203,90 +319,6 @@ Result Parser::ToPipelineType(const std::string& str, PipelineType* type) {
     *type = PipelineType::kGraphics;
   else
     return Result("unknown pipeline type: " + str);
-  return {};
-}
-
-Result Parser::ToDatumType(const std::string& str, DatumType* type) {
-  assert(type);
-
-  if (str == "int8") {
-    type->SetType(DataType::kInt8);
-  } else if (str == "int16") {
-    type->SetType(DataType::kInt16);
-  } else if (str == "int32") {
-    type->SetType(DataType::kInt32);
-  } else if (str == "int64") {
-    type->SetType(DataType::kInt64);
-  } else if (str == "uint8") {
-    type->SetType(DataType::kUint8);
-  } else if (str == "uint16") {
-    type->SetType(DataType::kUint16);
-  } else if (str == "uint32") {
-    type->SetType(DataType::kUint32);
-  } else if (str == "uint64") {
-    type->SetType(DataType::kUint64);
-  } else if (str == "float") {
-    type->SetType(DataType::kFloat);
-  } else if (str == "double") {
-    type->SetType(DataType::kDouble);
-  } else if (str.length() > 7 && str.substr(0, 3) == "vec") {
-    if (str[4] != '<' || str[str.length() - 1] != '>')
-      return Result("invalid data_type provided");
-
-    if (str[3] == '2')
-      type->SetRowCount(2);
-    else if (str[3] == '3')
-      type->SetRowCount(3);
-    else if (str[3] == '4')
-      type->SetRowCount(4);
-    else
-      return Result("invalid data_type provided");
-
-    DatumType subtype;
-    Result r = ToDatumType(str.substr(5, str.length() - 6), &subtype);
-    if (!r.IsSuccess())
-      return r;
-
-    if (subtype.RowCount() > 1 || subtype.ColumnCount() > 1)
-      return Result("invalid data_type provided");
-
-    type->SetType(subtype.GetType());
-
-  } else if (str.length() > 9 && str.substr(0, 3) == "mat") {
-    if (str[4] != 'x' || str[6] != '<' || str[str.length() - 1] != '>')
-      return Result("invalid data_type provided");
-
-    if (str[3] == '2')
-      type->SetColumnCount(2);
-    else if (str[3] == '3')
-      type->SetColumnCount(3);
-    else if (str[3] == '4')
-      type->SetColumnCount(4);
-    else
-      return Result("invalid data_type provided");
-
-    if (str[5] == '2')
-      type->SetRowCount(2);
-    else if (str[5] == '3')
-      type->SetRowCount(3);
-    else if (str[5] == '4')
-      type->SetRowCount(4);
-    else
-      return Result("invalid data_type provided");
-
-    DatumType subtype;
-    Result r = ToDatumType(str.substr(7, str.length() - 8), &subtype);
-    if (!r.IsSuccess())
-      return r;
-
-    if (subtype.RowCount() > 1 || subtype.ColumnCount() > 1)
-      return Result("invalid data_type provided");
-
-    type->SetType(subtype.GetType());
-  } else {
-    return Result("invalid data_type provided");
-  }
-
   return {};
 }
 
@@ -532,34 +564,30 @@ Result Parser::ParseShaderSpecialization(Pipeline* pipeline) {
   if (!token->IsString())
     return Result("expected data type in SPECIALIZE subcommand");
 
-  DatumType type;
-  auto r = ToDatumType(token->AsString(), &type);
-  if (!r.IsSuccess())
-    return r;
+  auto fmt = ToFormat(token->AsString());
+  if (!fmt)
+    return Result("invalid data_type provided");
 
   token = tokenizer_->NextToken();
   uint32_t value = 0;
-  switch (type.GetType()) {
-    case DataType::kUint32:
-    case DataType::kInt32:
-      value = token->AsUint32();
-      break;
-    case DataType::kFloat: {
-      r = token->ConvertToDouble();
-      if (!r.IsSuccess())
-        return Result("value is not a floating point value");
-      union {
-        uint32_t u;
-        float f;
-      } u;
-      u.f = token->AsFloat();
-      value = u.u;
-      break;
-    }
-    default:
-      return Result(
-          "only 32-bit types are currently accepted for specialization values");
+  if (fmt->IsUint32() || fmt->IsInt32()) {
+    value = token->AsUint32();
+  } else if (fmt->IsFloat()) {
+    Result r = token->ConvertToDouble();
+    if (!r.IsSuccess())
+      return Result("value is not a floating point value");
+
+    union {
+      uint32_t u;
+      float f;
+    } u;
+    u.f = token->AsFloat();
+    value = u.u;
+  } else {
+    return Result(
+        "only 32-bit types are currently accepted for specialization values");
   }
+
   auto& shader = pipeline->GetShaders()[pipeline->GetShaders().size() - 1];
   shader.AddSpecialization(spec_id, value);
   return {};
@@ -860,17 +888,16 @@ Result Parser::ParsePipelineSet(Pipeline* pipeline) {
   if (!token->IsString())
     return Result("expected data type");
 
-  DatumType arg_type;
-  auto r = ToDatumType(token->AsString(), &arg_type);
-  if (!r.IsSuccess())
-    return r;
+  auto fmt = ToFormat(token->AsString());
+  if (!fmt)
+    return Result("invalid data_type provided");
 
   token = tokenizer_->NextToken();
   if (!token->IsInteger() && !token->IsDouble())
     return Result("expected data value");
 
   Value value;
-  if (arg_type.IsFloat() || arg_type.IsDouble())
+  if (fmt->IsFloat() || fmt->IsDouble())
     value.SetDoubleValue(token->AsDouble());
   else
     value.SetIntValue(token->AsUint64());
@@ -878,7 +905,7 @@ Result Parser::ParsePipelineSet(Pipeline* pipeline) {
   Pipeline::ArgSetInfo info;
   info.name = arg_name;
   info.ordinal = arg_no;
-  info.fmt = arg_type.AsFormat();
+  info.fmt = std::move(fmt);
   info.value = value;
   pipeline->SetArg(std::move(info));
   return ValidateEndOfStatement("SET command");
@@ -940,12 +967,11 @@ Result Parser::ParseBufferInitializer(Buffer* buffer) {
   if (fmt != nullptr) {
     buffer->SetFormat(std::move(fmt));
   } else {
-    DatumType type;
-    Result r = ToDatumType(token->AsString(), &type);
-    if (!r.IsSuccess())
-      return r;
+    auto fmt = ToFormat(token->AsString());
+    if (!fmt)
+      return Result("invalid data_type provided");
 
-    buffer->SetFormat(type.AsFormat());
+    buffer->SetFormat(std::move(fmt));
   }
 
   token = tokenizer_->NextToken();

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -82,7 +82,7 @@ std::unique_ptr<Format> ToFormat(const std::string& str) {
     if (str[4] != '<' || str[str.length() - 1] != '>')
       return nullptr;
 
-    uint8_t component_count = str[3] - '0';
+    int component_count = str[3] - '0';
     if (component_count < 2 || component_count > 4)
       return nullptr;
 
@@ -94,7 +94,7 @@ std::unique_ptr<Format> ToFormat(const std::string& str) {
       return nullptr;
 
     const auto& comp = sub_fmt->GetComponents()[0];
-    for (uint8_t i = 0; i < component_count; ++i)
+    for (int i = 0; i < component_count; ++i)
       fmt->AddComponent(FORMAT_TYPES[i], comp.mode, comp.num_bits);
 
   } else if (str.length() > 9 && str.substr(0, 3) == "mat") {
@@ -103,11 +103,11 @@ std::unique_ptr<Format> ToFormat(const std::string& str) {
 
     matrix = true;
 
-    uint8_t column_count = str[3] - '0';
+    int column_count = str[3] - '0';
     if (column_count < 2 || column_count > 4)
       return nullptr;
 
-    uint8_t row_count = str[5] - '0';
+    int row_count = str[5] - '0';
     if (row_count < 2 || row_count > 4)
       return nullptr;
 
@@ -121,7 +121,7 @@ std::unique_ptr<Format> ToFormat(const std::string& str) {
     fmt->SetColumnCount(column_count);
 
     const auto& comp = sub_fmt->GetComponents()[0];
-    for (uint8_t i = 0; i < row_count; ++i)
+    for (int i = 0; i < row_count; ++i)
       fmt->AddComponent(FORMAT_TYPES[i], comp.mode, comp.num_bits);
 
   } else {
@@ -967,7 +967,7 @@ Result Parser::ParseBufferInitializer(Buffer* buffer) {
   if (fmt != nullptr) {
     buffer->SetFormat(std::move(fmt));
   } else {
-    auto fmt = ToFormat(token->AsString());
+    fmt = ToFormat(token->AsString());
     if (!fmt)
       return Result("invalid data_type provided");
 

--- a/src/amberscript/parser.h
+++ b/src/amberscript/parser.h
@@ -44,7 +44,6 @@ class Parser : public amber::Parser {
   Result ToShaderType(const std::string& str, ShaderType* type);
   Result ToBufferType(const std::string& str, BufferType* type);
   Result ToShaderFormat(const std::string& str, ShaderFormat* fmt);
-  Result ToDatumType(const std::string& str, DatumType* type);
   Result ToPipelineType(const std::string& str, PipelineType* type);
   Result ValidateEndOfStatement(const std::string& name);
 

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -23,8 +23,8 @@
 
 #include "amber/result.h"
 #include "amber/value.h"
-#include "src/datum_type.h"
 #include "src/format.h"
+#include "src/vkscript/datum_type.h"
 
 namespace amber {
 

--- a/src/format_parser.cc
+++ b/src/format_parser.cc
@@ -155,6 +155,7 @@ void FormatParser::ProcessChunk(Format* fmt, const std::string& data) {
   }
 }
 
+// static
 FormatType FormatParser::NameToType(const std::string& data) {
   if (data == "A1R5G5B5_UNORM_PACK16")
     return FormatType::kA1R5G5B5_UNORM_PACK16;

--- a/src/format_parser.h
+++ b/src/format_parser.h
@@ -26,6 +26,8 @@ namespace amber {
 /// Parses a Vulkan image string into a format object.
 class FormatParser {
  public:
+  static FormatType NameToType(const std::string& data);
+
   FormatParser();
   ~FormatParser();
 
@@ -34,7 +36,6 @@ class FormatParser {
  private:
   std::unique_ptr<Format> ParseGlslFormat(const std::string& fmt);
   void ProcessChunk(Format*, const std::string&);
-  FormatType NameToType(const std::string& data);
   void AddPiece(FormatComponentType type, uint8_t bits);
   void FlushPieces(Format* fmt, FormatMode mode);
 

--- a/src/vkscript/command_parser.h
+++ b/src/vkscript/command_parser.h
@@ -22,10 +22,10 @@
 
 #include "amber/result.h"
 #include "src/command.h"
-#include "src/datum_type.h"
 #include "src/pipeline.h"
 #include "src/pipeline_data.h"
 #include "src/script.h"
+#include "src/vkscript/datum_type.h"
 
 namespace amber {
 

--- a/src/vkscript/datum_type.cc
+++ b/src/vkscript/datum_type.cc
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "src/datum_type.h"
+#include "src/vkscript/datum_type.h"
 
 #include <string>
 
 #include "src/format_parser.h"
 
 namespace amber {
+namespace vkscript {
 namespace {
 
 uint32_t ElementSizeInBytes(DataType type) {
@@ -71,4 +72,5 @@ std::unique_ptr<Format> DatumType::AsFormat() const {
   return fmt;
 }
 
+}  // namespace vkscript
 }  // namespace amber

--- a/src/vkscript/datum_type.h
+++ b/src/vkscript/datum_type.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SRC_DATUM_TYPE_H_
-#define SRC_DATUM_TYPE_H_
+#ifndef SRC_VKSCRIPT_DATUM_TYPE_H_
+#define SRC_VKSCRIPT_DATUM_TYPE_H_
 
 #include <cstddef>
 #include <cstdint>
@@ -22,6 +22,7 @@
 #include "src/format.h"
 
 namespace amber {
+namespace vkscript {
 
 enum class DataType {
   kInt8 = 0,
@@ -74,6 +75,7 @@ class DatumType {
   bool is_std140_ = true;
 };
 
+}  // namespace vkscript
 }  // namespace amber
 
-#endif  // SRC_DATUM_TYPE_H_
+#endif  // SRC_VKSCRIPT_DATUM_TYPE_H_

--- a/src/vkscript/datum_type_parser.h
+++ b/src/vkscript/datum_type_parser.h
@@ -18,7 +18,7 @@
 #include <string>
 
 #include "amber/result.h"
-#include "src/datum_type.h"
+#include "src/vkscript/datum_type.h"
 
 namespace amber {
 namespace vkscript {

--- a/src/vkscript/datum_type_test.cc
+++ b/src/vkscript/datum_type_test.cc
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "src/datum_type.h"
+#include "src/vkscript/datum_type.h"
 
 #include "gtest/gtest.h"
 
 namespace amber {
+namespace vkscript {
 
 using DatumTypeTest = testing::Test;
 
@@ -85,4 +86,5 @@ INSTANTIATE_TEST_SUITE_P(
         Data{DataType::kDouble, 4,
              FormatType::kR64G64B64A64_SFLOAT}));  // NOLINT(whitespace/parens)
 
+}  // namespace vkscript
 }  // namespace amber


### PR DESCRIPTION
This CL changes ToDatumType to be ToFormat and uses the generated format
within the amber script parser. The DatumType class is moved into the
vkscript/ folder as that is the only remaining usage.