### PR TITLE
Add segments to format class

### DIFF
--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -95,7 +95,7 @@ std::unique_ptr<Format> ToFormat(const std::string& str) {
 
     const auto& comp = sub_fmt->GetComponents()[0];
     for (int i = 0; i < component_count; ++i)
-      fmt->AddComponent(FORMAT_TYPES[i], comp.mode, comp.num_bits);
+      fmt->AddComponent(FORMAT_TYPES[i], comp->mode, comp->num_bits);
 
   } else if (str.length() > 9 && str.substr(0, 3) == "mat") {
     if (str[4] != 'x' || str[6] != '<' || str[str.length() - 1] != '>')
@@ -122,7 +122,7 @@ std::unique_ptr<Format> ToFormat(const std::string& str) {
 
     const auto& comp = sub_fmt->GetComponents()[0];
     for (int i = 0; i < row_count; ++i)
-      fmt->AddComponent(FORMAT_TYPES[i], comp.mode, comp.num_bits);
+      fmt->AddComponent(FORMAT_TYPES[i], comp->mode, comp->num_bits);
 
   } else {
     return nullptr;
@@ -137,11 +137,11 @@ std::unique_ptr<Format> ToFormat(const std::string& str) {
     std::string parts = "ARGB";
     const auto& comps = fmt->GetComponents();
     for (const auto& comp : comps) {
-      name += parts[static_cast<uint8_t>(comp.type)] +
-              std::to_string(comp.num_bits);
+      name += parts[static_cast<uint8_t>(comp->type)] +
+              std::to_string(comp->num_bits);
     }
     name += "_";
-    switch (comps[0].mode) {
+    switch (comps[0]->mode) {
       case FormatMode::kUNorm:
       case FormatMode::kUFloat:
       case FormatMode::kUScaled:

--- a/src/amberscript/parser_buffer_test.cc
+++ b/src/amberscript/parser_buffer_test.cc
@@ -388,18 +388,18 @@ TEST_F(AmberScriptParserTest, BufferFormat) {
   auto& comps = fmt->GetComponents();
   ASSERT_EQ(4U, comps.size());
 
-  EXPECT_EQ(FormatComponentType::kR, comps[0].type);
-  EXPECT_EQ(FormatMode::kSInt, comps[0].mode);
-  EXPECT_EQ(32U, comps[0].num_bits);
-  EXPECT_EQ(FormatComponentType::kG, comps[1].type);
-  EXPECT_EQ(FormatMode::kSInt, comps[1].mode);
-  EXPECT_EQ(32U, comps[1].num_bits);
-  EXPECT_EQ(FormatComponentType::kB, comps[2].type);
-  EXPECT_EQ(FormatMode::kSInt, comps[2].mode);
-  EXPECT_EQ(32U, comps[2].num_bits);
-  EXPECT_EQ(FormatComponentType::kA, comps[3].type);
-  EXPECT_EQ(FormatMode::kSInt, comps[3].mode);
-  EXPECT_EQ(32U, comps[3].num_bits);
+  EXPECT_EQ(FormatComponentType::kR, comps[0]->type);
+  EXPECT_EQ(FormatMode::kSInt, comps[0]->mode);
+  EXPECT_EQ(32U, comps[0]->num_bits);
+  EXPECT_EQ(FormatComponentType::kG, comps[1]->type);
+  EXPECT_EQ(FormatMode::kSInt, comps[1]->mode);
+  EXPECT_EQ(32U, comps[1]->num_bits);
+  EXPECT_EQ(FormatComponentType::kB, comps[2]->type);
+  EXPECT_EQ(FormatMode::kSInt, comps[2]->mode);
+  EXPECT_EQ(32U, comps[2]->num_bits);
+  EXPECT_EQ(FormatComponentType::kA, comps[3]->type);
+  EXPECT_EQ(FormatMode::kSInt, comps[3]->mode);
+  EXPECT_EQ(32U, comps[3]->num_bits);
 }
 
 struct BufferParseError {
@@ -520,8 +520,8 @@ TEST_P(AmberScriptParserBufferDataTypeTest, BufferTypes) {
   auto fmt = buffer->GetFormat();
   EXPECT_EQ(test_data.row_count, fmt->RowCount());
   EXPECT_EQ(test_data.column_count, fmt->ColumnCount());
-  EXPECT_EQ(test_data.type, fmt->GetComponents()[0].mode);
-  EXPECT_EQ(test_data.num_bits, fmt->GetComponents()[0].num_bits);
+  EXPECT_EQ(test_data.type, fmt->GetComponents()[0]->mode);
+  EXPECT_EQ(test_data.num_bits, fmt->GetComponents()[0]->num_bits);
 }
 INSTANTIATE_TEST_SUITE_P(
     AmberScriptParserTestsDataType,

--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -156,8 +156,7 @@ std::vector<double> Buffer::CalculateDiffs(const Buffer* buffer) const {
 
   auto* buf_1_ptr = GetValues<uint8_t>();
   auto* buf_2_ptr = buffer->GetValues<uint8_t>();
-  auto& segments = format_->GetSegments();
-
+  const auto& segments = format_->GetSegments();
   for (size_t i = 0; i < ElementCount(); ++i) {
     for (const auto& seg : segments) {
       if (!seg.IsPadding())

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -94,7 +94,7 @@ class Buffer {
   // | Value | Value | Value | Value |   ValueCount == 4
   // | | | | | | | | | | | | | | | | |  SizeInBytes == 16
   // Note, the SizeInBytes maybe be greater then the size of the values. If
-  // the format IsStd140() and there are 3 rows, the SizeInBytes will be
+  // the format is std140 and there are 3 rows, the SizeInBytes will be
   // inflated to 4 values per row, instead of 3.
 
   /// Sets the number of elements in the buffer.
@@ -198,7 +198,7 @@ class Buffer {
 
  private:
   uint32_t WriteValueFromComponent(const Value& value,
-                                   const Format::Component& comp,
+                                   const Format::Component* comp,
                                    uint8_t* ptr);
 
   // Calculates the difference between the value stored in this buffer and

--- a/src/buffer_test.cc
+++ b/src/buffer_test.cc
@@ -69,7 +69,7 @@ TEST_F(BufferTest, SizeFromDataDoesNotOverrideSize) {
   EXPECT_EQ(20 * sizeof(float), b.GetSizeInBytes());
 }
 
-TEST_F(BufferTest, SizeMatrix) {
+TEST_F(BufferTest, SizeMatrixStd430) {
   FormatParser fp;
   auto fmt = fp.Parse("R16G16_SINT");
   fmt->SetColumnCount(3);
@@ -83,7 +83,22 @@ TEST_F(BufferTest, SizeMatrix) {
   EXPECT_EQ(60 * sizeof(int16_t), b.GetSizeInBytes());
 }
 
-TEST_F(BufferTest, SizeMatrixPadded) {
+TEST_F(BufferTest, SizeMatrixStd140) {
+  FormatParser fp;
+  auto fmt = fp.Parse("R16G16_SINT");
+  fmt->SetColumnCount(3);
+  fmt->SetIsStd140();
+
+  Buffer b(BufferType::kColor);
+  b.SetFormat(std::move(fmt));
+  b.SetElementCount(10);
+
+  EXPECT_EQ(10, b.ElementCount());
+  EXPECT_EQ(120, b.ValueCount());
+  EXPECT_EQ(120 * sizeof(int16_t), b.GetSizeInBytes());
+}
+
+TEST_F(BufferTest, SizeMatrixPaddedStd430) {
   FormatParser fp;
   auto fmt = fp.Parse("R32G32B32_SINT");
   fmt->SetColumnCount(3);

--- a/src/format.cc
+++ b/src/format.cc
@@ -35,10 +35,25 @@ Format::Format(const Format& b) {
 
 Format::~Format() = default;
 
+Format& Format::operator=(const Format& b) {
+  type_ = b.type_;
+  is_std140_ = b.is_std140_;
+  pack_size_in_bytes_ = b.pack_size_in_bytes_;
+  column_count_ = b.column_count_;
+
+  for (const auto& comp : b.components_) {
+    components_.push_back(
+        MakeUnique<Component>(comp->type, comp->mode, comp->num_bits));
+  }
+  RebuildSegments();
+
+  return *this;
+}
+
 uint32_t Format::SizeInBytes() const {
   uint32_t size = 0;
   for (const auto& seg : segments_)
-    size += seg.GetComponent()->SizeInBytes();
+    size += static_cast<uint32_t>(seg.GetComponent()->SizeInBytes());
 
   return size;
 }

--- a/src/format.cc
+++ b/src/format.cc
@@ -20,38 +20,32 @@ namespace amber {
 
 Format::Format() = default;
 
-Format::Format(const Format&) = default;
+Format::Format(const Format& b) {
+  type_ = b.type_;
+  is_std140_ = b.is_std140_;
+  pack_size_in_bytes_ = b.pack_size_in_bytes_;
+  column_count_ = b.column_count_;
+
+  for (const auto& comp : b.components_) {
+    components_.push_back(
+        MakeUnique<Component>(comp->type, comp->mode, comp->num_bits));
+  }
+  RebuildSegments();
+}
 
 Format::~Format() = default;
 
-uint32_t Format::SizeInBytesPerRow() const {
-  uint32_t bits = 0;
-  for (const auto& comp : components_)
-    bits += comp.num_bits;
-
-  uint32_t inflate = 0;
-  // Std140 always has 4 elements. std430 expands 3 elements to 4.
-  if ((is_std140_ && column_count_ > 1) || components_.size() == 3)
-    inflate = 4U - static_cast<uint32_t>(components_.size());
-
-  for (uint32_t i = 0; i < inflate; ++i)
-    bits += components_[0].num_bits;
-
-  uint32_t bytes_per_element = bits / 8;
-  // Odd number of bits, inflate byte count to accommodate
-  if ((bits % 8) != 0)
-    bytes_per_element += 1;
-
-  return bytes_per_element;
-}
-
 uint32_t Format::SizeInBytes() const {
-  return SizeInBytesPerRow() * column_count_;
+  uint32_t size = 0;
+  for (const auto& seg : segments_)
+    size += seg.GetComponent()->SizeInBytes();
+
+  return size;
 }
 
 bool Format::AreAllComponents(FormatMode mode, uint32_t bits) const {
   for (const auto& comp : components_) {
-    if (comp.mode != mode || comp.num_bits != bits)
+    if (comp->mode != mode || comp->num_bits != bits)
       return false;
   }
   return true;
@@ -67,13 +61,65 @@ bool Format::Equal(const Format* b) const {
     return false;
 
   for (uint32_t i = 0; i < components_.size(); ++i) {
-    if (components_[i].type != b->components_[i].type ||
-        components_[i].mode != b->components_[i].mode ||
-        components_[i].num_bits != b->components_[i].num_bits) {
+    if (components_[i]->type != b->components_[i]->type ||
+        components_[i]->mode != b->components_[i]->mode ||
+        components_[i]->num_bits != b->components_[i]->num_bits) {
       return false;
     }
   }
   return true;
+}
+
+uint32_t Format::InputNeededPerElement() const {
+  uint32_t count = 0;
+  for (const auto& seg : segments_) {
+    if (seg.IsPadding())
+      continue;
+
+    count += 1;
+  }
+  return count;
+}
+
+void Format::AddComponent(FormatComponentType type,
+                          FormatMode mode,
+                          uint8_t bits) {
+  components_.push_back(MakeUnique<Component>(type, mode, bits));
+  RebuildSegments();
+}
+
+void Format::SetColumnCount(uint32_t c) {
+  column_count_ = c;
+  RebuildSegments();
+}
+
+void Format::SetIsStd140() {
+  is_std140_ = true;
+  RebuildSegments();
+}
+
+void Format::RebuildSegments() {
+  segments_.clear();
+
+  for (size_t i = 0; i < column_count_; ++i) {
+    for (size_t k = 0; k < components_.size(); ++k) {
+      segments_.push_back(Segment{components_[k].get()});
+    }
+
+    // In std140 a matrix (column count > 1) has each row stored like an array
+    // which rounds up to a vec4.
+    //
+    // In std140 and std430 a vector of size 3N will round up to a vector of 4N.
+    if ((is_std140_ && column_count_ > 1) || RowCount() == 3) {
+      for (size_t k = 0; k < (4 - RowCount()); ++k) {
+        // TODO(dsinclair): This component will be wrong if all the components
+        // aren't the same size. This will be the case when we have struct
+        // support ....
+        segments_.push_back(Segment{components_[0].get()});
+        segments_.back().SetIsPadding();
+      }
+    }
+  }
 }
 
 }  // namespace amber

--- a/src/format.h
+++ b/src/format.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "src/format_data.h"
+#include "src/make_unique.h"
 
 namespace amber {
 
@@ -98,12 +99,27 @@ class Format {
     }
   };
 
+  class Segment {
+   public:
+    Segment(Component* component) : component_(component) {}
+    ~Segment() = default;
+
+    void SetIsPadding() { is_padding_ = true; }
+    bool IsPadding() const { return is_padding_; }
+
+    Component* GetComponent() const { return component_; }
+
+   private:
+    Component* component_;
+    bool is_padding_ = false;
+  };
+
   /// Creates a format of unknown type.
   Format();
   Format(const Format&);
   ~Format();
 
-  Format& operator=(const Format&) = default;
+  Format& operator=(const Format&) = delete;
 
   /// Returns true if |b| describes the same format as this object.
   bool Equal(const Format* b) const;
@@ -114,8 +130,7 @@ class Format {
   void SetFormatType(FormatType type) { type_ = type; }
   FormatType GetFormatType() const { return type_; }
 
-  void SetIsStd140() { is_std140_ = true; }
-  bool IsStd140() const { return is_std140_; }
+  void SetIsStd140();
 
   /// Set the number of bytes this format is packed into, if provided.
   void SetPackSize(uint8_t size_in_bytes) {
@@ -124,15 +139,16 @@ class Format {
   /// Retrieves the number of bytes this format is packed into.
   uint8_t GetPackSize() const { return pack_size_in_bytes_; }
 
-  void AddComponent(FormatComponentType type, FormatMode mode, uint8_t bits) {
-    components_.emplace_back(type, mode, bits);
+  void AddComponent(FormatComponentType type, FormatMode mode, uint8_t bits);
+  const std::vector<std::unique_ptr<Component>>& GetComponents() const {
+    return components_;
   }
-  const std::vector<Component>& GetComponents() const { return components_; }
+
+  /// The segment is the individual pieces of the components including padding.
+  const std::vector<Segment>& GetSegments() const { return segments_; }
 
   /// Returns the number of bytes this format requires.
   uint32_t SizeInBytes() const;
-  /// Returns the number of bytes per single row this format requires.
-  uint32_t SizeInBytesPerRow() const;
 
   bool IsFormatKnown() const { return type_ != FormatType::kUnknown; }
   bool HasStencilComponent() const {
@@ -145,23 +161,19 @@ class Format {
   /// Returns the number of input values required for an item of this format.
   /// This differs from ValuesPerElement because it doesn't take padding into
   /// account.
-  uint32_t InputNeededPerElement() const { return RowCount() * column_count_; }
+  uint32_t InputNeededPerElement() const;
 
-  /// Returns the number of values for a given row.
-  uint32_t ValuesPerRow() const {
-    if ((is_std140_ && column_count_ > 1) || RowCount() == 3)
-      return 4;
-    return RowCount();
+  /// Returns the number of values for a given row, including padding.
+  uint32_t ValuesPerElement() const {
+    return static_cast<uint32_t>(segments_.size());
   }
 
-  /// Returns the number of values for each instance of this format.
-  uint32_t ValuesPerElement() const { return ValuesPerRow() * column_count_; }
-
+  /// Returns the number of values for a given row, excluding padding.
   uint32_t RowCount() const {
     return static_cast<uint32_t>(components_.size());
   }
   uint32_t ColumnCount() const { return column_count_; }
-  void SetColumnCount(uint32_t c) { column_count_ = c; }
+  void SetColumnCount(uint32_t c);
 
   /// Returns true if all components of this format are an 8 bit signed int.
   bool IsInt8() const { return AreAllComponents(FormatMode::kSInt, 8); }
@@ -186,12 +198,14 @@ class Format {
 
  private:
   bool AreAllComponents(FormatMode mode, uint32_t bits) const;
+  void RebuildSegments();
 
   FormatType type_ = FormatType::kUnknown;
   bool is_std140_ = false;
   uint8_t pack_size_in_bytes_ = 0;
   uint32_t column_count_ = 1;
-  std::vector<Component> components_;
+  std::vector<std::unique_ptr<Component>> components_;
+  std::vector<Segment> segments_;
 };
 
 }  // namespace amber

--- a/src/format.h
+++ b/src/format.h
@@ -102,7 +102,10 @@ class Format {
   class Segment {
    public:
     explicit Segment(Component* component) : component_(component) {}
+    Segment(const Segment&) = default;
     ~Segment() = default;
+
+    Segment& operator=(const Segment&) = default;
 
     void SetIsPadding() { is_padding_ = true; }
     bool IsPadding() const { return is_padding_; }

--- a/src/format.h
+++ b/src/format.h
@@ -101,7 +101,7 @@ class Format {
 
   class Segment {
    public:
-    Segment(Component* component) : component_(component) {}
+    explicit Segment(Component* component) : component_(component) {}
     ~Segment() = default;
 
     void SetIsPadding() { is_padding_ = true; }

--- a/src/format.h
+++ b/src/format.h
@@ -122,7 +122,7 @@ class Format {
   Format(const Format&);
   ~Format();
 
-  Format& operator=(const Format&) = delete;
+  Format& operator=(const Format&);
 
   /// Returns true if |b| describes the same format as this object.
   bool Equal(const Format* b) const;

--- a/src/format_parser_test.cc
+++ b/src/format_parser_test.cc
@@ -1187,9 +1187,9 @@ TEST_F(FormatParserTest, Formats) {
     ASSERT_EQ(fmt.component_count, comps.size());
 
     for (size_t i = 0; i < fmt.component_count; ++i) {
-      EXPECT_EQ(fmt.components[i].type, comps[i].type) << fmt.name;
-      EXPECT_EQ(fmt.components[i].mode, comps[i].mode) << fmt.name;
-      EXPECT_EQ(fmt.components[i].num_bits, comps[i].num_bits) << fmt.name;
+      EXPECT_EQ(fmt.components[i].type, comps[i]->type) << fmt.name;
+      EXPECT_EQ(fmt.components[i].mode, comps[i]->mode) << fmt.name;
+      EXPECT_EQ(fmt.components[i].num_bits, comps[i]->num_bits) << fmt.name;
     }
   }
 }  // NOLINT(readability/fn_size)
@@ -1217,15 +1217,15 @@ TEST_F(FormatParserTest, GlslString) {
   auto& comps = format->GetComponents();
   ASSERT_EQ(3U, comps.size());
 
-  EXPECT_EQ(FormatComponentType::kR, comps[0].type);
-  EXPECT_EQ(FormatMode::kSFloat, comps[0].mode);
-  EXPECT_EQ(32U, comps[0].num_bits);
-  EXPECT_EQ(FormatComponentType::kG, comps[1].type);
-  EXPECT_EQ(FormatMode::kSFloat, comps[1].mode);
-  EXPECT_EQ(32U, comps[1].num_bits);
-  EXPECT_EQ(FormatComponentType::kB, comps[2].type);
-  EXPECT_EQ(FormatMode::kSFloat, comps[2].mode);
-  EXPECT_EQ(32U, comps[2].num_bits);
+  EXPECT_EQ(FormatComponentType::kR, comps[0]->type);
+  EXPECT_EQ(FormatMode::kSFloat, comps[0]->mode);
+  EXPECT_EQ(32U, comps[0]->num_bits);
+  EXPECT_EQ(FormatComponentType::kG, comps[1]->type);
+  EXPECT_EQ(FormatMode::kSFloat, comps[1]->mode);
+  EXPECT_EQ(32U, comps[1]->num_bits);
+  EXPECT_EQ(FormatComponentType::kB, comps[2]->type);
+  EXPECT_EQ(FormatMode::kSFloat, comps[2]->mode);
+  EXPECT_EQ(32U, comps[2]->num_bits);
 }
 
 TEST_F(FormatParserTest, GlslStrings) {

--- a/src/format_test.cc
+++ b/src/format_test.cc
@@ -35,19 +35,18 @@ TEST_F(FormatTest, Copy) {
   EXPECT_TRUE(copy->IsFloat());
   EXPECT_EQ(16U, copy->SizeInBytes());
   EXPECT_EQ(3U, copy->GetComponents().size());
-  EXPECT_TRUE(copy->IsStd140());
   EXPECT_EQ(FormatType::kR32G32B32_SFLOAT, copy->GetFormatType());
 
   auto& comp = copy->GetComponents();
-  EXPECT_EQ(FormatComponentType::kR, comp[0].type);
-  EXPECT_EQ(FormatMode::kSFloat, comp[0].mode);
-  EXPECT_EQ(32U, comp[0].num_bits);
-  EXPECT_EQ(FormatComponentType::kG, comp[1].type);
-  EXPECT_EQ(FormatMode::kSFloat, comp[1].mode);
-  EXPECT_EQ(32U, comp[1].num_bits);
-  EXPECT_EQ(FormatComponentType::kB, comp[2].type);
-  EXPECT_EQ(FormatMode::kSFloat, comp[2].mode);
-  EXPECT_EQ(32U, comp[2].num_bits);
+  EXPECT_EQ(FormatComponentType::kR, comp[0]->type);
+  EXPECT_EQ(FormatMode::kSFloat, comp[0]->mode);
+  EXPECT_EQ(32U, comp[0]->num_bits);
+  EXPECT_EQ(FormatComponentType::kG, comp[1]->type);
+  EXPECT_EQ(FormatMode::kSFloat, comp[1]->mode);
+  EXPECT_EQ(32U, comp[1]->num_bits);
+  EXPECT_EQ(FormatComponentType::kB, comp[2]->type);
+  EXPECT_EQ(FormatMode::kSFloat, comp[2]->mode);
+  EXPECT_EQ(32U, comp[2]->num_bits);
 }
 
 TEST_F(FormatTest, SizeInBytesVector) {
@@ -56,9 +55,7 @@ TEST_F(FormatTest, SizeInBytesVector) {
   ASSERT_TRUE(fmt != nullptr);
 
   EXPECT_EQ(3U, fmt->InputNeededPerElement());
-  EXPECT_EQ(4U, fmt->ValuesPerElement());
   EXPECT_EQ(16U, fmt->SizeInBytes());
-  EXPECT_EQ(16U, fmt->SizeInBytesPerRow());
 }
 
 TEST_F(FormatTest, SizeInBytesMatrix) {
@@ -68,10 +65,7 @@ TEST_F(FormatTest, SizeInBytesMatrix) {
   fmt->SetColumnCount(3);
 
   EXPECT_EQ(9U, fmt->InputNeededPerElement());
-  EXPECT_EQ(4U, fmt->ValuesPerRow());
-  EXPECT_EQ(12U, fmt->ValuesPerElement());
   EXPECT_EQ(48U, fmt->SizeInBytes());
-  EXPECT_EQ(16U, fmt->SizeInBytesPerRow());
 }
 
 TEST_F(FormatTest, SizeInBytesMatrixStd140) {
@@ -82,7 +76,6 @@ TEST_F(FormatTest, SizeInBytesMatrixStd140) {
   fmt->SetIsStd140();
 
   EXPECT_EQ(32U, fmt->SizeInBytes());
-  EXPECT_EQ(16U, fmt->SizeInBytesPerRow());
 }
 
 TEST_F(FormatTest, RowCount) {
@@ -98,8 +91,6 @@ struct StdData {
   const char* fmt;
   uint32_t column_count;
   bool is_std140;
-  uint32_t values_per_element;
-  uint32_t size_in_bytes_per_row;
   uint32_t size_in_bytes;
 };
 using FormatStdTest = testing::TestWithParam<StdData>;
@@ -114,39 +105,33 @@ TEST_P(FormatStdTest, Test) {
   if (test_data.is_std140)
     fmt->SetIsStd140();
 
-  EXPECT_EQ(test_data.values_per_element, fmt->ValuesPerElement())
-      << test_data.name;
   EXPECT_EQ(test_data.size_in_bytes, fmt->SizeInBytes()) << test_data.name;
-  EXPECT_EQ(test_data.size_in_bytes_per_row, fmt->SizeInBytesPerRow())
-      << test_data.name;
 }
 
 INSTANTIATE_TEST_SUITE_P(
     FormatStdTestSamples,
     FormatStdTest,
     testing::Values(
-        StdData{"mat2x2-std140", "R32G32_SFLOAT", 2, true, 8U, 16U, 32U},
-        StdData{"mat2x3-std140", "R32G32B32_SFLOAT", 2, true, 8U, 16U, 32U},
-        StdData{"mat2x4-std140", "R32G32B32A32_SFLOAT", 2, true, 8U, 16U, 32U},
-        StdData{"mat3x2-std140", "R32G32_SFLOAT", 3, true, 12U, 16U, 48U},
-        StdData{"mat3x3-std140", "R32G32B32_SFLOAT", 3, true, 12U, 16U, 48U},
-        StdData{"mat3x4-std140", "R32G32B32A32_SFLOAT", 3, true, 12U, 16U, 48U},
-        StdData{"mat4x2-std140", "R32G32_SFLOAT", 4, true, 16U, 16U, 64U},
-        StdData{"mat4x3-std140", "R32G32B32_SFLOAT", 4, true, 16U, 16U, 64U},
-        StdData{"mat4x4-std140", "R32G32B32A32_SFLOAT", 4, true, 16U, 16U, 64U},
-        StdData{"mat2x2-std430", "R32G32_SFLOAT", 2, false, 4U, 8U, 16U},
-        StdData{"mat2x3-std430", "R32G32B32_SFLOAT", 2, false, 8U, 16U, 32U},
-        StdData{"mat2x4-std430", "R32G32B32A32_SFLOAT", 2, false, 8U, 16U, 32U},
-        StdData{"mat3x2-std430", "R32G32_SFLOAT", 3, false, 6U, 8U, 24U},
-        StdData{"mat3x3-std430", "R32G32B32_SFLOAT", 3, false, 12U, 16U, 48U},
-        StdData{"mat3x4-std430", "R32G32B32A32_SFLOAT", 3, false, 12U, 16U,
-                48U},
-        StdData{"mat4x2-std430", "R32G32_SFLOAT", 4, false, 8U, 8U, 32U},
-        StdData{"mat4x3-std430", "R32G32B32_SFLOAT", 4, false, 16U, 16U, 64U},
-        StdData{"mat4x4-std430", "R32G32B32A32_SFLOAT", 4, false, 16U, 16U,
-                64U},
-        StdData{"float-std140", "R32_SFLOAT", 1, true, 1U, 4U, 4U},
-        StdData{"float-std430", "R32_SFLOAT", 1, false, 1U, 4U,
+        StdData{"mat2x2-std140", "R32G32_SFLOAT", 2, true, 32U},
+        StdData{"mat2x3-std140", "R32G32B32_SFLOAT", 2, true, 32U},
+        StdData{"mat2x4-std140", "R32G32B32A32_SFLOAT", 2, true, 32U},
+        StdData{"mat3x2-std140", "R32G32_SFLOAT", 3, true, 48U},
+        StdData{"mat3x3-std140", "R32G32B32_SFLOAT", 3, true, 48U},
+        StdData{"mat3x4-std140", "R32G32B32A32_SFLOAT", 3, true, 48U},
+        StdData{"mat4x2-std140", "R32G32_SFLOAT", 4, true, 64U},
+        StdData{"mat4x3-std140", "R32G32B32_SFLOAT", 4, true, 64U},
+        StdData{"mat4x4-std140", "R32G32B32A32_SFLOAT", 4, true, 64U},
+        StdData{"mat2x2-std430", "R32G32_SFLOAT", 2, false, 16U},
+        StdData{"mat2x3-std430", "R32G32B32_SFLOAT", 2, false, 32U},
+        StdData{"mat2x4-std430", "R32G32B32A32_SFLOAT", 2, false, 32U},
+        StdData{"mat3x2-std430", "R32G32_SFLOAT", 3, false, 24U},
+        StdData{"mat3x3-std430", "R32G32B32_SFLOAT", 3, false, 48U},
+        StdData{"mat3x4-std430", "R32G32B32A32_SFLOAT", 3, false, 48U},
+        StdData{"mat4x2-std430", "R32G32_SFLOAT", 4, false, 32U},
+        StdData{"mat4x3-std430", "R32G32B32_SFLOAT", 4, false, 64U},
+        StdData{"mat4x4-std430", "R32G32B32A32_SFLOAT", 4, false, 64U},
+        StdData{"float-std140", "R32_SFLOAT", 1, true, 4U},
+        StdData{"float-std430", "R32_SFLOAT", 1, false,
                 4U}));  // NOLINT(whitespace/parens)
 
 }  // namespace amber

--- a/src/verifier_test.cc
+++ b/src/verifier_test.cc
@@ -1462,7 +1462,7 @@ TEST_F(VerifierTest, ProbeSSBOWithPadding) {
   probe_ssbo.SetValues(std::move(values));
 
   // The vec2 will get padded to 4 bytes in std430.
-  const float ssbo[8] = {1.9, 0.73, 0.0, 0.0, 9.99, 1234.560, 0.0, 0.0};
+  const float ssbo[8] = {1.9f, 0.73f, 0.0f, 0.0f, 9.99f, 1234.560f, 0.0f, 0.0f};
 
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, 4, ssbo);

--- a/src/verifier_test.cc
+++ b/src/verifier_test.cc
@@ -713,7 +713,7 @@ TEST_F(VerifierTest, ProbeSSBOUint8Single) {
   Verifier verifier;
   Result r =
       verifier.ProbeSSBO(&probe_ssbo, 1, static_cast<const void*>(&ssbo));
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBOUint8Multiple) {
@@ -737,7 +737,7 @@ TEST_F(VerifierTest, ProbeSSBOUint8Multiple) {
 
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, 3, ssbo);
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBOUint8Many) {
@@ -765,7 +765,7 @@ TEST_F(VerifierTest, ProbeSSBOUint8Many) {
 
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, 200, ssbo.data());
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBOUint32Single) {
@@ -788,7 +788,7 @@ TEST_F(VerifierTest, ProbeSSBOUint32Single) {
   Verifier verifier;
   Result r =
       verifier.ProbeSSBO(&probe_ssbo, 1, static_cast<const void*>(&ssbo));
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBOUint32Multiple) {
@@ -813,7 +813,7 @@ TEST_F(VerifierTest, ProbeSSBOUint32Multiple) {
 
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, 4, ssbo);
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBOUint32Many) {
@@ -841,7 +841,7 @@ TEST_F(VerifierTest, ProbeSSBOUint32Many) {
 
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, 200, ssbo.data());
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBOFloatSingle) {
@@ -864,7 +864,7 @@ TEST_F(VerifierTest, ProbeSSBOFloatSingle) {
   Verifier verifier;
   Result r =
       verifier.ProbeSSBO(&probe_ssbo, 1, static_cast<const void*>(&ssbo));
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBOFloatMultiple) {
@@ -889,7 +889,7 @@ TEST_F(VerifierTest, ProbeSSBOFloatMultiple) {
 
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, 4, ssbo);
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBOFloatMany) {
@@ -917,7 +917,7 @@ TEST_F(VerifierTest, ProbeSSBOFloatMany) {
 
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, 200, ssbo.data());
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBODoubleSingle) {
@@ -940,7 +940,7 @@ TEST_F(VerifierTest, ProbeSSBODoubleSingle) {
   Verifier verifier;
   Result r =
       verifier.ProbeSSBO(&probe_ssbo, 1, static_cast<const void*>(&ssbo));
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBODoubleMultiple) {
@@ -965,7 +965,7 @@ TEST_F(VerifierTest, ProbeSSBODoubleMultiple) {
 
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, 4, ssbo);
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBODoubleMany) {
@@ -993,7 +993,7 @@ TEST_F(VerifierTest, ProbeSSBODoubleMany) {
 
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, 200, ssbo.data());
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBOEqualFail) {
@@ -1054,7 +1054,7 @@ TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithAbsoluteTolerance) {
   const double ssbo_less[4] = {2.801, 0.631, 9.901, 1234.461};
 
   r = verifier.ProbeSSBO(&probe_ssbo, 4, ssbo_less);
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithAbsoluteToleranceFail) {
@@ -1114,12 +1114,12 @@ TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithRelativeTolerance) {
 
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, 4, ssbo_more);
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 
   const double ssbo_less[4] = {2.8972, 0.72928, 9.991, 1233.32545};
 
   r = verifier.ProbeSSBO(&probe_ssbo, sizeof(double) * 4, ssbo_less);
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithRelativeToleranceFail) {
@@ -1175,7 +1175,7 @@ TEST_F(VerifierTest, ProbeSSBONotEqual) {
 
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, 4, ssbo);
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBONotEqualFail) {
@@ -1227,7 +1227,7 @@ TEST_F(VerifierTest, ProbeSSBOLess) {
 
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, 4, ssbo);
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBOLessFail) {
@@ -1279,7 +1279,7 @@ TEST_F(VerifierTest, ProbeSSBOLessOrEqual) {
 
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, 4, ssbo);
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBOLessOrEqualFail) {
@@ -1331,7 +1331,7 @@ TEST_F(VerifierTest, ProbeSSBOGreater) {
 
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, 4, ssbo);
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBOGreaterFail) {
@@ -1383,7 +1383,7 @@ TEST_F(VerifierTest, ProbeSSBOGreaterOrEqual) {
 
   Verifier verifier;
   Result r = verifier.ProbeSSBO(&probe_ssbo, sizeof(double) * 4, ssbo);
-  EXPECT_TRUE(r.IsSuccess());
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 TEST_F(VerifierTest, ProbeSSBOGreaterOrEqualFail) {
@@ -1439,6 +1439,34 @@ TEST_F(VerifierTest, CheckRGBAOrderForFailure) {
       "0.000000, 76.500000\n  Actual RGBA: 75.000000, 14.000000, 255.000000, "
       "8.000000\nProbe failed in 1 pixels",
       r.Error());
+}
+
+TEST_F(VerifierTest, ProbeSSBOWithPadding) {
+  Pipeline pipeline(PipelineType::kGraphics);
+  auto color_buf = pipeline.GenerateDefaultColorAttachmentBuffer();
+
+  ProbeSSBOCommand probe_ssbo(color_buf.get());
+
+  FormatParser fp;
+  probe_ssbo.SetFormat(fp.Parse("float/vec2"));
+  ASSERT_TRUE(probe_ssbo.GetFormat() != nullptr);
+
+  probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kLessOrEqual);
+
+  std::vector<Value> values;
+  values.resize(4);
+  values[0].SetDoubleValue(2.9);
+  values[1].SetDoubleValue(0.73);
+  values[2].SetDoubleValue(10.0);
+  values[3].SetDoubleValue(1234.56);
+  probe_ssbo.SetValues(std::move(values));
+
+  // The vec2 will get padded to 4 bytes in std430.
+  const float ssbo[8] = {1.9, 0.73, 0.0, 0.0, 9.99, 1234.560, 0.0, 0.0};
+
+  Verifier verifier;
+  Result r = verifier.ProbeSSBO(&probe_ssbo, 4, ssbo);
+  EXPECT_TRUE(r.IsSuccess()) << r.Error();
 }
 
 }  // namespace amber

--- a/src/vkscript/datum_type_parser.cc
+++ b/src/vkscript/datum_type_parser.cc
@@ -115,11 +115,11 @@ std::unique_ptr<Format> DatumTypeParser::Parse(const std::string& data) {
     std::string parts = "ARGB";
     const auto& comps = fmt->GetComponents();
     for (const auto& comp : comps) {
-      name += parts[static_cast<uint8_t>(comp.type)] +
-              std::to_string(comp.num_bits);
+      name += parts[static_cast<uint8_t>(comp->type)] +
+              std::to_string(comp->num_bits);
     }
     name += "_";
-    switch (comps[0].mode) {
+    switch (comps[0]->mode) {
       case FormatMode::kUNorm:
       case FormatMode::kUFloat:
       case FormatMode::kUScaled:

--- a/src/vkscript/datum_type_parser_test.cc
+++ b/src/vkscript/datum_type_parser_test.cc
@@ -22,7 +22,7 @@ namespace {
 
 bool AllCompsAreType(Format* fmt, FormatMode mode, uint8_t num_bits) {
   for (auto& comp : fmt->GetComponents()) {
-    if (comp.mode != mode || comp.num_bits != num_bits)
+    if (comp->mode != mode || comp->num_bits != num_bits)
       return false;
   }
 

--- a/src/vkscript/parser.cc
+++ b/src/vkscript/parser.cc
@@ -384,19 +384,21 @@ Result Parser::ProcessVertexDataBlock(const SectionParser::Section& section) {
         v.SetIntValue(token->AsHex());
         value_data.push_back(v);
       } else {
-        auto& comps = header.format->GetComponents();
-        for (size_t i = 0; i < comps.size();
-             ++i, token = tokenizer.NextToken()) {
+        auto& segs = header.format->GetSegments();
+        for (const auto& seg : segs) {
+          if (seg.IsPadding())
+            continue;
+
           if (token->IsEOS() || token->IsEOL()) {
             return Result(make_error(tokenizer,
                                      "Too few cells in given vertex data row"));
           }
 
-          auto& comp = comps[i];
+          auto comp = seg.GetComponent();
 
           Value v;
-          if (comp.mode == FormatMode::kUFloat ||
-              comp.mode == FormatMode::kSFloat) {
+          if (comp->mode == FormatMode::kUFloat ||
+              comp->mode == FormatMode::kSFloat) {
             Result r = token->ConvertToDouble();
             if (!r.IsSuccess())
               return r;
@@ -410,6 +412,7 @@ Result Parser::ProcessVertexDataBlock(const SectionParser::Section& section) {
           }
 
           value_data.push_back(v);
+          token = tokenizer.NextToken();
         }
       }
     }

--- a/src/vkscript/parser_test.cc
+++ b/src/vkscript/parser_test.cc
@@ -385,8 +385,8 @@ TEST_F(VkScriptParserTest, VertexDataHeaderGlslString) {
 
   auto& comps1 = buffers[1]->GetFormat()->GetComponents();
   ASSERT_EQ(2U, comps1.size());
-  EXPECT_EQ(FormatMode::kSFloat, comps1[0].mode);
-  EXPECT_EQ(FormatMode::kSFloat, comps1[1].mode);
+  EXPECT_EQ(FormatMode::kSFloat, comps1[0]->mode);
+  EXPECT_EQ(FormatMode::kSFloat, comps1[1]->mode);
   EXPECT_EQ(static_cast<uint32_t>(0), buffers[1]->ElementCount());
 
   ASSERT_EQ(BufferType::kVertex, buffers[2]->GetBufferType());
@@ -395,9 +395,9 @@ TEST_F(VkScriptParserTest, VertexDataHeaderGlslString) {
             buffers[2]->GetFormat()->GetFormatType());
   auto& comps2 = buffers[2]->GetFormat()->GetComponents();
   ASSERT_EQ(3U, comps2.size());
-  EXPECT_EQ(FormatMode::kSInt, comps2[0].mode);
-  EXPECT_EQ(FormatMode::kSInt, comps2[1].mode);
-  EXPECT_EQ(FormatMode::kSInt, comps2[2].mode);
+  EXPECT_EQ(FormatMode::kSInt, comps2[0]->mode);
+  EXPECT_EQ(FormatMode::kSInt, comps2[1]->mode);
+  EXPECT_EQ(FormatMode::kSInt, comps2[2]->mode);
   EXPECT_EQ(static_cast<uint32_t>(0), buffers[2]->ElementCount());
 }
 

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -154,12 +154,12 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
       return Result("Vulkan color attachment format is not supported");
   }
 
-  Format depth_fmt;
+  Format* depth_fmt = nullptr;
   if (pipeline->GetDepthBuffer().buffer) {
     const auto& depth_info = pipeline->GetDepthBuffer();
 
-    depth_fmt = *depth_info.buffer->GetFormat();
-    if (!device_->IsFormatSupportedByPhysicalDevice(depth_fmt,
+    depth_fmt = depth_info.buffer->GetFormat();
+    if (!device_->IsFormatSupportedByPhysicalDevice(*depth_fmt,
                                                     depth_info.buffer)) {
       return Result("Vulkan depth attachment format is not supported");
     }

--- a/src/vulkan/frame_buffer.cc
+++ b/src/vulkan/frame_buffer.cc
@@ -44,7 +44,7 @@ FrameBuffer::~FrameBuffer() {
 }
 
 Result FrameBuffer::Initialize(VkRenderPass render_pass,
-                               const Format& depth_format) {
+                               const Format* depth_format) {
   std::vector<VkImageView> attachments;
 
   if (!color_attachments_.empty()) {
@@ -75,10 +75,10 @@ Result FrameBuffer::Initialize(VkRenderPass render_pass,
     }
   }
 
-  if (depth_format.IsFormatKnown()) {
+  if (depth_format && depth_format->IsFormatKnown()) {
     depth_image_ = MakeUnique<TransferImage>(
-        device_, depth_format,
-        static_cast<VkImageAspectFlags>(depth_format.HasStencilComponent()
+        device_, *depth_format,
+        static_cast<VkImageAspectFlags>(depth_format->HasStencilComponent()
                                             ? VK_IMAGE_ASPECT_DEPTH_BIT |
                                                   VK_IMAGE_ASPECT_STENCIL_BIT
                                             : VK_IMAGE_ASPECT_DEPTH_BIT),

--- a/src/vulkan/frame_buffer.h
+++ b/src/vulkan/frame_buffer.h
@@ -37,7 +37,7 @@ class FrameBuffer {
       uint32_t height);
   ~FrameBuffer();
 
-  Result Initialize(VkRenderPass render_pass, const Format& depth_format);
+  Result Initialize(VkRenderPass render_pass, const Format* depth_format);
 
   void ChangeFrameToDrawLayout(CommandBuffer* command);
   void ChangeFrameToProbeLayout(CommandBuffer* command);

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -381,7 +381,7 @@ class RenderPassGuard {
 GraphicsPipeline::GraphicsPipeline(
     Device* device,
     const std::vector<amber::Pipeline::BufferInfo>& color_buffers,
-    const Format& depth_stencil_format,
+    Format* depth_stencil_format,
     uint32_t fence_timeout_ms,
     const std::vector<VkPipelineShaderStageCreateInfo>& shader_stage_info)
     : Pipeline(PipelineType::kGraphics,
@@ -426,9 +426,10 @@ Result GraphicsPipeline::CreateRenderPass() {
   subpass_desc.colorAttachmentCount = static_cast<uint32_t>(color_refer.size());
   subpass_desc.pColorAttachments = color_refer.data();
 
-  if (depth_stencil_format_.IsFormatKnown()) {
+  if (depth_stencil_format_ && depth_stencil_format_->IsFormatKnown()) {
     attachment_desc.push_back(kDefaultAttachmentDesc);
-    attachment_desc.back().format = device_->GetVkFormat(depth_stencil_format_);
+    attachment_desc.back().format =
+        device_->GetVkFormat(*depth_stencil_format_);
     attachment_desc.back().initialLayout =
         VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     attachment_desc.back().finalLayout =
@@ -649,7 +650,7 @@ Result GraphicsPipeline::CreateVkGraphicsPipeline(
   }
 
   VkPipelineDepthStencilStateCreateInfo depthstencil_info;
-  if (depth_stencil_format_.IsFormatKnown()) {
+  if (depth_stencil_format_ && depth_stencil_format_->IsFormatKnown()) {
     depthstencil_info = GetVkPipelineDepthStencilInfo(pipeline_data);
     pipeline_info.pDepthStencilState = &depthstencil_info;
   }
@@ -740,7 +741,7 @@ Result GraphicsPipeline::SetClearColor(float r, float g, float b, float a) {
 }
 
 Result GraphicsPipeline::SetClearStencil(uint32_t stencil) {
-  if (!depth_stencil_format_.IsFormatKnown()) {
+  if (!depth_stencil_format_ || !depth_stencil_format_->IsFormatKnown()) {
     return Result(
         "Vulkan::ClearStencilCommand No DepthStencil Buffer for FrameBuffer "
         "Exists");
@@ -751,7 +752,7 @@ Result GraphicsPipeline::SetClearStencil(uint32_t stencil) {
 }
 
 Result GraphicsPipeline::SetClearDepth(float depth) {
-  if (!depth_stencil_format_.IsFormatKnown()) {
+  if (!depth_stencil_format_ || !depth_stencil_format_->IsFormatKnown()) {
     return Result(
         "Vulkan::ClearStencilCommand No DepthStencil Buffer for FrameBuffer "
         "Exists");
@@ -770,16 +771,17 @@ Result GraphicsPipeline::Clear() {
   if (!r.IsSuccess())
     return r;
 
-  if (!depth_stencil_format_.IsFormatKnown())
+  if (!depth_stencil_format_ || !depth_stencil_format_->IsFormatKnown())
     return {};
 
   VkClearValue depth_clear;
   depth_clear.depthStencil = {clear_depth_, clear_stencil_};
 
   return ClearBuffer(
-      depth_clear, depth_stencil_format_.HasStencilComponent()
-                       ? VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT
-                       : VK_IMAGE_ASPECT_DEPTH_BIT);
+      depth_clear,
+      depth_stencil_format_ && depth_stencil_format_->HasStencilComponent()
+          ? VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT
+          : VK_IMAGE_ASPECT_DEPTH_BIT);
 }
 
 Result GraphicsPipeline::ClearBuffer(const VkClearValue& clear_value,

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -387,8 +387,10 @@ GraphicsPipeline::GraphicsPipeline(
     : Pipeline(PipelineType::kGraphics,
                device,
                fence_timeout_ms,
-               shader_stage_info),
-      depth_stencil_format_(depth_stencil_format) {
+               shader_stage_info) {
+  if (depth_stencil_format != nullptr)
+    depth_stencil_format_ = *depth_stencil_format;
+
   for (const auto& info : color_buffers)
     color_buffers_.push_back(&info);
 }
@@ -426,10 +428,9 @@ Result GraphicsPipeline::CreateRenderPass() {
   subpass_desc.colorAttachmentCount = static_cast<uint32_t>(color_refer.size());
   subpass_desc.pColorAttachments = color_refer.data();
 
-  if (depth_stencil_format_ && depth_stencil_format_->IsFormatKnown()) {
+  if (depth_stencil_format_.IsFormatKnown()) {
     attachment_desc.push_back(kDefaultAttachmentDesc);
-    attachment_desc.back().format =
-        device_->GetVkFormat(*depth_stencil_format_);
+    attachment_desc.back().format = device_->GetVkFormat(depth_stencil_format_);
     attachment_desc.back().initialLayout =
         VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     attachment_desc.back().finalLayout =
@@ -650,7 +651,7 @@ Result GraphicsPipeline::CreateVkGraphicsPipeline(
   }
 
   VkPipelineDepthStencilStateCreateInfo depthstencil_info;
-  if (depth_stencil_format_ && depth_stencil_format_->IsFormatKnown()) {
+  if (depth_stencil_format_.IsFormatKnown()) {
     depthstencil_info = GetVkPipelineDepthStencilInfo(pipeline_data);
     pipeline_info.pDepthStencilState = &depthstencil_info;
   }
@@ -695,7 +696,7 @@ Result GraphicsPipeline::Initialize(uint32_t width,
     return r;
 
   frame_ = MakeUnique<FrameBuffer>(device_, color_buffers_, width, height);
-  r = frame_->Initialize(render_pass_, depth_stencil_format_);
+  r = frame_->Initialize(render_pass_, &depth_stencil_format_);
   if (!r.IsSuccess())
     return r;
 
@@ -741,7 +742,7 @@ Result GraphicsPipeline::SetClearColor(float r, float g, float b, float a) {
 }
 
 Result GraphicsPipeline::SetClearStencil(uint32_t stencil) {
-  if (!depth_stencil_format_ || !depth_stencil_format_->IsFormatKnown()) {
+  if (!depth_stencil_format_.IsFormatKnown()) {
     return Result(
         "Vulkan::ClearStencilCommand No DepthStencil Buffer for FrameBuffer "
         "Exists");
@@ -752,7 +753,7 @@ Result GraphicsPipeline::SetClearStencil(uint32_t stencil) {
 }
 
 Result GraphicsPipeline::SetClearDepth(float depth) {
-  if (!depth_stencil_format_ || !depth_stencil_format_->IsFormatKnown()) {
+  if (!depth_stencil_format_.IsFormatKnown()) {
     return Result(
         "Vulkan::ClearStencilCommand No DepthStencil Buffer for FrameBuffer "
         "Exists");
@@ -771,17 +772,16 @@ Result GraphicsPipeline::Clear() {
   if (!r.IsSuccess())
     return r;
 
-  if (!depth_stencil_format_ || !depth_stencil_format_->IsFormatKnown())
+  if (!depth_stencil_format_.IsFormatKnown())
     return {};
 
   VkClearValue depth_clear;
   depth_clear.depthStencil = {clear_depth_, clear_stencil_};
 
   return ClearBuffer(
-      depth_clear,
-      depth_stencil_format_ && depth_stencil_format_->HasStencilComponent()
-          ? VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT
-          : VK_IMAGE_ASPECT_DEPTH_BIT);
+      depth_clear, depth_stencil_format_.HasStencilComponent()
+                       ? VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT
+                       : VK_IMAGE_ASPECT_DEPTH_BIT);
 }
 
 Result GraphicsPipeline::ClearBuffer(const VkClearValue& clear_value,

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -42,7 +42,7 @@ class GraphicsPipeline : public Pipeline {
   GraphicsPipeline(
       Device* device,
       const std::vector<amber::Pipeline::BufferInfo>& color_buffers,
-      const Format& depth_stencil_format,
+      Format* depth_stencil_format,
       uint32_t fence_timeout_ms,
       const std::vector<VkPipelineShaderStageCreateInfo>&);
   ~GraphicsPipeline() override;
@@ -90,7 +90,7 @@ class GraphicsPipeline : public Pipeline {
 
   // color buffers are owned by the amber::Pipeline.
   std::vector<const amber::Pipeline::BufferInfo*> color_buffers_;
-  Format depth_stencil_format_;
+  Format* depth_stencil_format_;
   std::unique_ptr<IndexBuffer> index_buffer_;
 
   uint32_t frame_width_ = 0;

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -90,7 +90,7 @@ class GraphicsPipeline : public Pipeline {
 
   // color buffers are owned by the amber::Pipeline.
   std::vector<const amber::Pipeline::BufferInfo*> color_buffers_;
-  Format* depth_stencil_format_;
+  Format depth_stencil_format_;
   std::unique_ptr<IndexBuffer> index_buffer_;
 
   uint32_t frame_width_ = 0;


### PR DESCRIPTION
This CL adds the concept of 'segments' to the format class. The segments
incorporate the spacing needed for padding of the format structure as it
is read/written to memory.