### PR TITLE
Use enum for available layouts.

### DIFF
--- a/src/buffer_test.cc
+++ b/src/buffer_test.cc
@@ -87,7 +87,7 @@ TEST_F(BufferTest, SizeMatrixStd140) {
   FormatParser fp;
   auto fmt = fp.Parse("R16G16_SINT");
   fmt->SetColumnCount(3);
-  fmt->SetIsStd140();
+  fmt->SetLayout(Format::Layout::kStd140);
 
   Buffer b(BufferType::kColor);
   b.SetFormat(std::move(fmt));

--- a/src/format.cc
+++ b/src/format.cc
@@ -22,7 +22,7 @@ Format::Format() = default;
 
 Format::Format(const Format& b) {
   type_ = b.type_;
-  is_std140_ = b.is_std140_;
+  layout_ = b.layout_;
   pack_size_in_bytes_ = b.pack_size_in_bytes_;
   column_count_ = b.column_count_;
 
@@ -37,7 +37,7 @@ Format::~Format() = default;
 
 Format& Format::operator=(const Format& b) {
   type_ = b.type_;
-  is_std140_ = b.is_std140_;
+  layout_ = b.layout_;
   pack_size_in_bytes_ = b.pack_size_in_bytes_;
   column_count_ = b.column_count_;
 
@@ -67,7 +67,7 @@ bool Format::AreAllComponents(FormatMode mode, uint32_t bits) const {
 }
 
 bool Format::Equal(const Format* b) const {
-  if (type_ != b->type_ || is_std140_ != b->is_std140_ ||
+  if (type_ != b->type_ || layout_ != b->layout_ ||
       pack_size_in_bytes_ != b->pack_size_in_bytes_ ||
       column_count_ != b->column_count_) {
     return false;
@@ -108,8 +108,8 @@ void Format::SetColumnCount(uint32_t c) {
   RebuildSegments();
 }
 
-void Format::SetIsStd140() {
-  is_std140_ = true;
+void Format::SetLayout(Layout layout) {
+  layout_ = layout;
   RebuildSegments();
 }
 
@@ -125,7 +125,7 @@ void Format::RebuildSegments() {
     // which rounds up to a vec4.
     //
     // In std140 and std430 a vector of size 3N will round up to a vector of 4N.
-    if ((is_std140_ && column_count_ > 1) || RowCount() == 3) {
+    if ((layout_ == Layout::kStd140 && column_count_ > 1) || RowCount() == 3) {
       for (size_t k = 0; k < (4 - RowCount()); ++k) {
         // TODO(dsinclair): This component will be wrong if all the components
         // aren't the same size. This will be the case when we have struct

--- a/src/format.h
+++ b/src/format.h
@@ -24,7 +24,7 @@
 
 namespace amber {
 
-/// The format class describes requested image formats. (eg. R8G8B8A8_UINT).
+/// The format class describes requested  data formats. (eg. R8G8B8A8_UINT).
 ///
 /// There is a distinction between the input values needed and the values needed
 /// for a given format. The input values is the number needed to be read to fill
@@ -37,6 +37,8 @@ namespace amber {
 /// smaller then the values per element.
 class Format {
  public:
+  enum Layout { kStd140 = 0, kStd430 };
+
   /// Describes an individual component of a format.
   struct Component {
     Component(FormatComponentType t, FormatMode m, uint8_t bits)
@@ -133,7 +135,7 @@ class Format {
   void SetFormatType(FormatType type) { type_ = type; }
   FormatType GetFormatType() const { return type_; }
 
-  void SetIsStd140();
+  void SetLayout(Layout layout);
 
   /// Set the number of bytes this format is packed into, if provided.
   void SetPackSize(uint8_t size_in_bytes) {
@@ -204,7 +206,7 @@ class Format {
   void RebuildSegments();
 
   FormatType type_ = FormatType::kUnknown;
-  bool is_std140_ = false;
+  Layout layout_ = Layout::kStd430;
   uint8_t pack_size_in_bytes_ = 0;
   uint32_t column_count_ = 1;
   std::vector<std::unique_ptr<Component>> components_;

--- a/src/format_test.cc
+++ b/src/format_test.cc
@@ -24,7 +24,7 @@ using FormatTest = testing::Test;
 
 TEST_F(FormatTest, Copy) {
   Format fmt;
-  fmt.SetIsStd140();
+  fmt.SetLayout(Format::Layout::kStd140);
   fmt.SetColumnCount(1);
   fmt.SetFormatType(FormatType::kR32G32B32_SFLOAT);
   fmt.AddComponent(FormatComponentType::kR, FormatMode::kSFloat, 32);
@@ -73,7 +73,7 @@ TEST_F(FormatTest, SizeInBytesMatrixStd140) {
   auto fmt = fp.Parse("R32G32_SFLOAT");
   ASSERT_TRUE(fmt != nullptr);
   fmt->SetColumnCount(2);
-  fmt->SetIsStd140();
+  fmt->SetLayout(Format::Layout::kStd140);
 
   EXPECT_EQ(32U, fmt->SizeInBytes());
 }
@@ -103,7 +103,7 @@ TEST_P(FormatStdTest, Test) {
 
   fmt->SetColumnCount(test_data.column_count);
   if (test_data.is_std140)
-    fmt->SetIsStd140();
+    fmt->SetLayout(Format::Layout::kStd140);
 
   EXPECT_EQ(test_data.size_in_bytes, fmt->SizeInBytes()) << test_data.name;
 }

--- a/src/vkscript/command_parser.cc
+++ b/src/vkscript/command_parser.cc
@@ -743,7 +743,7 @@ Result CommandParser::ProcessUniform() {
 
   // uniform is always std140.
   if (is_ubo)
-    fmt->SetIsStd140();
+    fmt->SetLayout(Format::Layout::kStd140);
 
   auto* buf = cmd->GetBuffer();
   if (buf->FormatIsDefault() || !buf->GetFormat())


### PR DESCRIPTION
This CL removes the is_std_140 boolean from the Format class and uses an
enum instead.