### PR TITLE
Remove GetComponents from the Format class.

### DIFF
--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -93,7 +93,8 @@ std::unique_ptr<Format> ToFormat(const std::string& str) {
     if (sub_fmt->RowCount() != 1 || sub_fmt->ColumnCount() != 1)
       return nullptr;
 
-    const auto& comp = sub_fmt->GetComponents()[0];
+    const auto* comp = sub_fmt->GetOnlyComponent();
+    // TODO(dsinclair): Make sure this isn't a struct.
     for (int i = 0; i < component_count; ++i)
       fmt->AddComponent(FORMAT_TYPES[i], comp->mode, comp->num_bits);
 
@@ -120,7 +121,8 @@ std::unique_ptr<Format> ToFormat(const std::string& str) {
 
     fmt->SetColumnCount(static_cast<uint32_t>(column_count));
 
-    const auto& comp = sub_fmt->GetComponents()[0];
+    const auto* comp = sub_fmt->GetOnlyComponent();
+    // TODO(dsinclair): Make sure this isn't a struct.
     for (int i = 0; i < row_count; ++i)
       fmt->AddComponent(FORMAT_TYPES[i], comp->mode, comp->num_bits);
 
@@ -133,32 +135,9 @@ std::unique_ptr<Format> ToFormat(const std::string& str) {
   //
   // There is no equivalent type for a matrix.
   if (!matrix) {
-    std::string name = "";
-    std::string parts = "ARGB";
-    const auto& comps = fmt->GetComponents();
-    for (const auto& comp : comps) {
-      name += parts[static_cast<uint8_t>(comp->type)] +
-              std::to_string(comp->num_bits);
-    }
-    name += "_";
-    switch (comps[0]->mode) {
-      case FormatMode::kUNorm:
-      case FormatMode::kUFloat:
-      case FormatMode::kUScaled:
-      case FormatMode::kSNorm:
-      case FormatMode::kSScaled:
-      case FormatMode::kSRGB:
-        return nullptr;
-      case FormatMode::kUInt:
-        name += "UINT";
-        break;
-      case FormatMode::kSInt:
-        name += "SINT";
-        break;
-      case FormatMode::kSFloat:
-        name += "SFLOAT";
-        break;
-    }
+    std::string name = fmt->GenerateName();
+    if (name == "")
+      return nullptr;
 
     fmt->SetFormatType(FormatParser::NameToType(name));
   }

--- a/src/amberscript/parser_buffer_test.cc
+++ b/src/amberscript/parser_buffer_test.cc
@@ -564,21 +564,21 @@ TEST_F(AmberScriptParserTest, BufferFormat) {
   EXPECT_EQ("my_buf", buffer->GetName());
 
   auto fmt = buffer->GetFormat();
-  auto& comps = fmt->GetComponents();
-  ASSERT_EQ(4U, comps.size());
+  auto& segs = fmt->GetSegments();
+  ASSERT_EQ(4U, segs.size());
 
-  EXPECT_EQ(FormatComponentType::kR, comps[0]->type);
-  EXPECT_EQ(FormatMode::kSInt, comps[0]->mode);
-  EXPECT_EQ(32U, comps[0]->num_bits);
-  EXPECT_EQ(FormatComponentType::kG, comps[1]->type);
-  EXPECT_EQ(FormatMode::kSInt, comps[1]->mode);
-  EXPECT_EQ(32U, comps[1]->num_bits);
-  EXPECT_EQ(FormatComponentType::kB, comps[2]->type);
-  EXPECT_EQ(FormatMode::kSInt, comps[2]->mode);
-  EXPECT_EQ(32U, comps[2]->num_bits);
-  EXPECT_EQ(FormatComponentType::kA, comps[3]->type);
-  EXPECT_EQ(FormatMode::kSInt, comps[3]->mode);
-  EXPECT_EQ(32U, comps[3]->num_bits);
+  EXPECT_EQ(FormatComponentType::kR, segs[0].GetComponent()->type);
+  EXPECT_EQ(FormatMode::kSInt, segs[0].GetComponent()->mode);
+  EXPECT_EQ(32U, segs[0].GetComponent()->num_bits);
+  EXPECT_EQ(FormatComponentType::kG, segs[1].GetComponent()->type);
+  EXPECT_EQ(FormatMode::kSInt, segs[1].GetComponent()->mode);
+  EXPECT_EQ(32U, segs[1].GetComponent()->num_bits);
+  EXPECT_EQ(FormatComponentType::kB, segs[2].GetComponent()->type);
+  EXPECT_EQ(FormatMode::kSInt, segs[2].GetComponent()->mode);
+  EXPECT_EQ(32U, segs[2].GetComponent()->num_bits);
+  EXPECT_EQ(FormatComponentType::kA, segs[3].GetComponent()->type);
+  EXPECT_EQ(FormatMode::kSInt, segs[3].GetComponent()->mode);
+  EXPECT_EQ(32U, segs[3].GetComponent()->num_bits);
 }
 
 struct BufferParseError {
@@ -699,8 +699,10 @@ TEST_P(AmberScriptParserBufferDataTypeTest, BufferTypes) {
   auto fmt = buffer->GetFormat();
   EXPECT_EQ(test_data.row_count, fmt->RowCount());
   EXPECT_EQ(test_data.column_count, fmt->ColumnCount());
-  EXPECT_EQ(test_data.type, fmt->GetComponents()[0]->mode);
-  EXPECT_EQ(test_data.num_bits, fmt->GetComponents()[0]->num_bits);
+
+  auto comp = fmt->GetSegments()[0].GetComponent();
+  EXPECT_EQ(test_data.type, comp->mode);
+  EXPECT_EQ(test_data.num_bits, comp->num_bits);
 }
 INSTANTIATE_TEST_SUITE_P(
     AmberScriptParserTestsDataType,

--- a/src/format.cc
+++ b/src/format.cc
@@ -137,4 +137,33 @@ void Format::RebuildSegments() {
   }
 }
 
+std::string Format::GenerateName() const {
+  std::string name = "";
+  std::string parts = "ARGB";
+  for (const auto& comp : components_) {
+    name += parts[static_cast<uint8_t>(comp->type)] +
+            std::to_string(comp->num_bits);
+  }
+  name += "_";
+  switch (components_[0]->mode) {
+    case FormatMode::kUNorm:
+    case FormatMode::kUFloat:
+    case FormatMode::kUScaled:
+    case FormatMode::kSNorm:
+    case FormatMode::kSScaled:
+    case FormatMode::kSRGB:
+      return "";
+    case FormatMode::kUInt:
+      name += "UINT";
+      break;
+    case FormatMode::kSInt:
+      name += "SINT";
+      break;
+    case FormatMode::kSFloat:
+      name += "SFLOAT";
+      break;
+  }
+  return name;
+}
+
 }  // namespace amber

--- a/src/format.h
+++ b/src/format.h
@@ -216,7 +216,7 @@ class Format {
   bool IsDouble() const { return AreAllComponents(FormatMode::kSFloat, 64); }
 
   /// Generates the image format name for this format if possible. Returns
-  /// name if generated or "" otherwise.
+  /// the name if generated or "" otherwise.
   std::string GenerateName() const;
 
  private:

--- a/src/format.h
+++ b/src/format.h
@@ -170,8 +170,8 @@ class Format {
            type_ == FormatType::kS8_UINT;
   }
 
-  /// Returns true if the format components are scaled
-  bool IsScaled() const {
+  /// Returns true if the format components are normalized.
+  bool IsNormalized() const {
     FormatMode mode = components_.back()->mode;
     return mode == FormatMode::kUNorm || mode == FormatMode::kSNorm ||
            mode == FormatMode::kSRGB;

--- a/src/format_parser_test.cc
+++ b/src/format_parser_test.cc
@@ -1183,13 +1183,22 @@ TEST_F(FormatParserTest, Formats) {
     EXPECT_EQ(fmt.type, format->GetFormatType()) << fmt.name;
     EXPECT_EQ(fmt.pack_size, format->GetPackSize()) << fmt.name;
 
-    auto& comps = format->GetComponents();
-    ASSERT_EQ(fmt.component_count, comps.size());
+    auto& segs = format->GetSegments();
+    ASSERT_TRUE(fmt.component_count <= segs.size()) << fmt.name;
 
     for (size_t i = 0; i < fmt.component_count; ++i) {
-      EXPECT_EQ(fmt.components[i].type, comps[i]->type) << fmt.name;
-      EXPECT_EQ(fmt.components[i].mode, comps[i]->mode) << fmt.name;
-      EXPECT_EQ(fmt.components[i].num_bits, comps[i]->num_bits) << fmt.name;
+      EXPECT_EQ(fmt.components[i].type, segs[i].GetComponent()->type)
+          << fmt.name;
+      EXPECT_EQ(fmt.components[i].mode, segs[i].GetComponent()->mode)
+          << fmt.name;
+      EXPECT_EQ(fmt.components[i].num_bits, segs[i].GetComponent()->num_bits)
+          << fmt.name;
+    }
+
+    if (fmt.component_count < segs.size()) {
+      // Only one padding added
+      EXPECT_EQ(1, segs.size() - fmt.component_count);
+      EXPECT_TRUE(segs.back().IsPadding());
     }
   }
 }  // NOLINT(readability/fn_size)
@@ -1214,18 +1223,20 @@ TEST_F(FormatParserTest, GlslString) {
   EXPECT_EQ(FormatType::kR32G32B32_SFLOAT, format->GetFormatType());
   EXPECT_EQ(static_cast<size_t>(0U), format->GetPackSize());
 
-  auto& comps = format->GetComponents();
-  ASSERT_EQ(3U, comps.size());
+  auto& segs = format->GetSegments();
+  ASSERT_EQ(4U, segs.size());
 
-  EXPECT_EQ(FormatComponentType::kR, comps[0]->type);
-  EXPECT_EQ(FormatMode::kSFloat, comps[0]->mode);
-  EXPECT_EQ(32U, comps[0]->num_bits);
-  EXPECT_EQ(FormatComponentType::kG, comps[1]->type);
-  EXPECT_EQ(FormatMode::kSFloat, comps[1]->mode);
-  EXPECT_EQ(32U, comps[1]->num_bits);
-  EXPECT_EQ(FormatComponentType::kB, comps[2]->type);
-  EXPECT_EQ(FormatMode::kSFloat, comps[2]->mode);
-  EXPECT_EQ(32U, comps[2]->num_bits);
+  EXPECT_EQ(FormatComponentType::kR, segs[0].GetComponent()->type);
+  EXPECT_EQ(FormatMode::kSFloat, segs[0].GetComponent()->mode);
+  EXPECT_EQ(32U, segs[0].GetComponent()->num_bits);
+  EXPECT_EQ(FormatComponentType::kG, segs[1].GetComponent()->type);
+  EXPECT_EQ(FormatMode::kSFloat, segs[1].GetComponent()->mode);
+  EXPECT_EQ(32U, segs[1].GetComponent()->num_bits);
+  EXPECT_EQ(FormatComponentType::kB, segs[2].GetComponent()->type);
+  EXPECT_EQ(FormatMode::kSFloat, segs[2].GetComponent()->mode);
+  EXPECT_EQ(32U, segs[2].GetComponent()->num_bits);
+
+  EXPECT_TRUE(segs[3].IsPadding());
 }
 
 TEST_F(FormatParserTest, GlslStrings) {

--- a/src/format_test.cc
+++ b/src/format_test.cc
@@ -34,19 +34,20 @@ TEST_F(FormatTest, Copy) {
   auto copy = MakeUnique<Format>(fmt);
   EXPECT_TRUE(copy->IsFloat());
   EXPECT_EQ(16U, copy->SizeInBytes());
-  EXPECT_EQ(3U, copy->GetComponents().size());
+  EXPECT_EQ(4U, copy->GetSegments().size());
   EXPECT_EQ(FormatType::kR32G32B32_SFLOAT, copy->GetFormatType());
 
-  auto& comp = copy->GetComponents();
-  EXPECT_EQ(FormatComponentType::kR, comp[0]->type);
-  EXPECT_EQ(FormatMode::kSFloat, comp[0]->mode);
-  EXPECT_EQ(32U, comp[0]->num_bits);
-  EXPECT_EQ(FormatComponentType::kG, comp[1]->type);
-  EXPECT_EQ(FormatMode::kSFloat, comp[1]->mode);
-  EXPECT_EQ(32U, comp[1]->num_bits);
-  EXPECT_EQ(FormatComponentType::kB, comp[2]->type);
-  EXPECT_EQ(FormatMode::kSFloat, comp[2]->mode);
-  EXPECT_EQ(32U, comp[2]->num_bits);
+  auto& segs = copy->GetSegments();
+  EXPECT_EQ(FormatComponentType::kR, segs[0].GetComponent()->type);
+  EXPECT_EQ(FormatMode::kSFloat, segs[0].GetComponent()->mode);
+  EXPECT_EQ(32U, segs[0].GetComponent()->num_bits);
+  EXPECT_EQ(FormatComponentType::kG, segs[1].GetComponent()->type);
+  EXPECT_EQ(FormatMode::kSFloat, segs[1].GetComponent()->mode);
+  EXPECT_EQ(32U, segs[1].GetComponent()->num_bits);
+  EXPECT_EQ(FormatComponentType::kB, segs[2].GetComponent()->type);
+  EXPECT_EQ(FormatMode::kSFloat, segs[2].GetComponent()->mode);
+  EXPECT_EQ(32U, segs[2].GetComponent()->num_bits);
+  EXPECT_TRUE(segs[3].IsPadding());
 }
 
 TEST_F(FormatTest, SizeInBytesVector) {

--- a/src/verifier.cc
+++ b/src/verifier.cc
@@ -581,7 +581,7 @@ Result Verifier::Probe(const ProbeCommand* command,
   }
 
   if (count_of_invalid_pixels) {
-    float scale_factor_for_error_report = fmt->IsScaled() ? 255.f : 1.f;
+    float scale_factor_for_error_report = fmt->IsNormalized() ? 255.f : 1.f;
 
     return Result(
         "Line " + std::to_string(command->GetLine()) +

--- a/src/vkscript/datum_type_parser.cc
+++ b/src/vkscript/datum_type_parser.cc
@@ -111,32 +111,9 @@ std::unique_ptr<Format> DatumTypeParser::Parse(const std::string& data) {
   //
   // There is no equivalent type for a matrix.
   if (!matrix) {
-    std::string name = "";
-    std::string parts = "ARGB";
-    const auto& comps = fmt->GetComponents();
-    for (const auto& comp : comps) {
-      name += parts[static_cast<uint8_t>(comp->type)] +
-              std::to_string(comp->num_bits);
-    }
-    name += "_";
-    switch (comps[0]->mode) {
-      case FormatMode::kUNorm:
-      case FormatMode::kUFloat:
-      case FormatMode::kUScaled:
-      case FormatMode::kSNorm:
-      case FormatMode::kSScaled:
-      case FormatMode::kSRGB:
-        return nullptr;
-      case FormatMode::kUInt:
-        name += "UINT";
-        break;
-      case FormatMode::kSInt:
-        name += "SINT";
-        break;
-      case FormatMode::kSFloat:
-        name += "SFLOAT";
-        break;
-    }
+    std::string name = fmt->GenerateName();
+    if (name == "")
+      return nullptr;
 
     fmt->SetFormatType(FormatParser::NameToType(name));
   }

--- a/src/vkscript/datum_type_parser_test.cc
+++ b/src/vkscript/datum_type_parser_test.cc
@@ -21,9 +21,13 @@ namespace vkscript {
 namespace {
 
 bool AllCompsAreType(Format* fmt, FormatMode mode, uint8_t num_bits) {
-  for (auto& comp : fmt->GetComponents()) {
-    if (comp->mode != mode || comp->num_bits != num_bits)
+  for (auto& seg : fmt->GetSegments()) {
+    if (seg.IsPadding())
+      continue;
+    if (seg.GetComponent()->mode != mode ||
+        seg.GetComponent()->num_bits != num_bits) {
       return false;
+    }
   }
 
   return true;

--- a/src/vkscript/parser_test.cc
+++ b/src/vkscript/parser_test.cc
@@ -383,21 +383,23 @@ TEST_F(VkScriptParserTest, VertexDataHeaderGlslString) {
   EXPECT_EQ(FormatType::kR32G32_SFLOAT,
             buffers[1]->GetFormat()->GetFormatType());
 
-  auto& comps1 = buffers[1]->GetFormat()->GetComponents();
-  ASSERT_EQ(2U, comps1.size());
-  EXPECT_EQ(FormatMode::kSFloat, comps1[0]->mode);
-  EXPECT_EQ(FormatMode::kSFloat, comps1[1]->mode);
+  auto& segs1 = buffers[1]->GetFormat()->GetSegments();
+  ASSERT_EQ(2U, segs1.size());
+  EXPECT_EQ(FormatMode::kSFloat, segs1[0].GetComponent()->mode);
+  EXPECT_EQ(FormatMode::kSFloat, segs1[1].GetComponent()->mode);
   EXPECT_EQ(static_cast<uint32_t>(0), buffers[1]->ElementCount());
 
   ASSERT_EQ(BufferType::kVertex, buffers[2]->GetBufferType());
   EXPECT_EQ(1U, pipeline_buffers[1].location);
   EXPECT_EQ(FormatType::kR32G32B32_SINT,
             buffers[2]->GetFormat()->GetFormatType());
-  auto& comps2 = buffers[2]->GetFormat()->GetComponents();
-  ASSERT_EQ(3U, comps2.size());
-  EXPECT_EQ(FormatMode::kSInt, comps2[0]->mode);
-  EXPECT_EQ(FormatMode::kSInt, comps2[1]->mode);
-  EXPECT_EQ(FormatMode::kSInt, comps2[2]->mode);
+
+  auto& segs2 = buffers[2]->GetFormat()->GetSegments();
+  ASSERT_EQ(4, segs2.size());
+  EXPECT_EQ(FormatMode::kSInt, segs2[0].GetComponent()->mode);
+  EXPECT_EQ(FormatMode::kSInt, segs2[1].GetComponent()->mode);
+  EXPECT_EQ(FormatMode::kSInt, segs2[2].GetComponent()->mode);
+  EXPECT_TRUE(segs2[3].IsPadding());
   EXPECT_EQ(static_cast<uint32_t>(0), buffers[2]->ElementCount());
 }
 


### PR DESCRIPTION
With this change, it is no longer possible to get a list of components
from a Format. Instead, the segments should be used and the padding
taken into account.

A GetOnlyComponent was added for the usage in the amberscript parser but
requires there to only be a single component in the format.