### PR TITLE
Store formats in pipeline and scripts.

### DIFF
--- a/samples/image_diff.cc
+++ b/samples/image_diff.cc
@@ -115,11 +115,11 @@ int main(int argc, const char** argv) {
     return 1;
   }
 
+  amber::FormatParser fp;
+  auto fmt = fp.Parse("R8G8B8A8_UNORM");
   amber::Buffer buffers[2];
-
   for (size_t i = 0; i < 2; ++i) {
-    amber::FormatParser fp;
-    buffers[i].SetFormat(fp.Parse("R8G8B8A8_UNORM"));
+    buffers[i].SetFormat(fmt.get());
     amber::Result res =
         LoadPngToBuffer(options.input_filenames[i], &buffers[i]);
     if (!res.IsSuccess()) {

--- a/src/buffer.cc
+++ b/src/buffer.cc
@@ -113,7 +113,7 @@ Result Buffer::CopyTo(Buffer* buffer) const {
 }
 
 Result Buffer::IsEqual(Buffer* buffer) const {
-  if (!buffer->format_->Equal(format_.get()))
+  if (!buffer->format_->Equal(format_))
     return Result{"Buffers have a different format"};
   if (buffer->element_count_ != element_count_)
     return Result{"Buffers have a different size"};
@@ -172,7 +172,7 @@ std::vector<double> Buffer::CalculateDiffs(const Buffer* buffer) const {
 }
 
 Result Buffer::CompareRMSE(Buffer* buffer, float tolerance) const {
-  if (!buffer->format_->Equal(format_.get()))
+  if (!buffer->format_->Equal(format_))
     return Result{"Buffers have a different format"};
   if (buffer->element_count_ != element_count_)
     return Result{"Buffers have a different size"};

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -66,12 +66,12 @@ class Buffer {
   void SetBufferType(BufferType type) { buffer_type_ = type; }
 
   /// Sets the Format of the buffer to |format|.
-  void SetFormat(std::unique_ptr<Format> format) {
+  void SetFormat(Format* format) {
     format_is_default_ = false;
-    format_ = std::move(format);
+    format_ = format;
   }
   /// Returns the Format describing the buffer data.
-  Format* GetFormat() const { return format_.get(); }
+  Format* GetFormat() const { return format_; }
 
   void SetFormatIsDefault(bool val) { format_is_default_ = val; }
   bool FormatIsDefault() const { return format_is_default_; }
@@ -215,7 +215,7 @@ class Buffer {
   uint32_t height_ = 0;
   bool format_is_default_ = false;
   std::vector<uint8_t> bytes_;
-  std::unique_ptr<Format> format_;
+  Format* format_ = nullptr;
 };
 
 }  // namespace amber

--- a/src/buffer_test.cc
+++ b/src/buffer_test.cc
@@ -32,8 +32,10 @@ TEST_F(BufferTest, EmptyByDefault) {
 
 TEST_F(BufferTest, Size) {
   FormatParser fp;
+  auto fmt = fp.Parse("R16_SINT");
+
   Buffer b(BufferType::kColor);
-  b.SetFormat(fp.Parse("R16_SINT"));
+  b.SetFormat(fmt.get());
   b.SetElementCount(10);
   EXPECT_EQ(10, b.ElementCount());
   EXPECT_EQ(10, b.ValueCount());
@@ -45,8 +47,10 @@ TEST_F(BufferTest, SizeFromData) {
   values.resize(5);
 
   FormatParser fp;
+  auto fmt = fp.Parse("R32_SFLOAT");
+
   Buffer b(BufferType::kColor);
-  b.SetFormat(fp.Parse("R32_SFLOAT"));
+  b.SetFormat(fmt.get());
   b.SetData(std::move(values));
 
   EXPECT_EQ(5, b.ElementCount());
@@ -59,8 +63,10 @@ TEST_F(BufferTest, SizeFromDataDoesNotOverrideSize) {
   values.resize(5);
 
   FormatParser fp;
+  auto fmt = fp.Parse("R32_SFLOAT");
+
   Buffer b(BufferType::kColor);
-  b.SetFormat(fp.Parse("R32_SFLOAT"));
+  b.SetFormat(fmt.get());
   b.SetElementCount(20);
   b.SetData(std::move(values));
 
@@ -75,7 +81,7 @@ TEST_F(BufferTest, SizeMatrixStd430) {
   fmt->SetColumnCount(3);
 
   Buffer b(BufferType::kColor);
-  b.SetFormat(std::move(fmt));
+  b.SetFormat(fmt.get());
   b.SetElementCount(10);
 
   EXPECT_EQ(10, b.ElementCount());
@@ -90,7 +96,7 @@ TEST_F(BufferTest, SizeMatrixStd140) {
   fmt->SetLayout(Format::Layout::kStd140);
 
   Buffer b(BufferType::kColor);
-  b.SetFormat(std::move(fmt));
+  b.SetFormat(fmt.get());
   b.SetElementCount(10);
 
   EXPECT_EQ(10, b.ElementCount());
@@ -104,7 +110,7 @@ TEST_F(BufferTest, SizeMatrixPaddedStd430) {
   fmt->SetColumnCount(3);
 
   Buffer b(BufferType::kColor);
-  b.SetFormat(std::move(fmt));
+  b.SetFormat(fmt.get());
   b.SetValueCount(9);
 
   EXPECT_EQ(1U, b.ElementCount());

--- a/src/command.h
+++ b/src/command.h
@@ -396,8 +396,8 @@ class ProbeSSBOCommand : public Probe {
   void SetOffset(uint32_t offset) { offset_ = offset; }
   uint32_t GetOffset() const { return offset_; }
 
-  void SetFormat(std::unique_ptr<Format> fmt) { format_ = std::move(fmt); }
-  Format* GetFormat() const { return format_.get(); }
+  void SetFormat(Format* fmt) { format_ = fmt; }
+  Format* GetFormat() const { return format_; }
 
   void SetValues(std::vector<Value>&& values) { values_ = std::move(values); }
   const std::vector<Value>& GetValues() const { return values_; }
@@ -409,7 +409,7 @@ class ProbeSSBOCommand : public Probe {
   uint32_t descriptor_set_id_ = 0;
   uint32_t binding_num_ = 0;
   uint32_t offset_ = 0;
-  std::unique_ptr<Format> format_;
+  Format* format_;
   std::vector<Value> values_;
 };
 

--- a/src/format.cc
+++ b/src/format.cc
@@ -20,35 +20,7 @@ namespace amber {
 
 Format::Format() = default;
 
-Format::Format(const Format& b) {
-  type_ = b.type_;
-  layout_ = b.layout_;
-  pack_size_in_bytes_ = b.pack_size_in_bytes_;
-  column_count_ = b.column_count_;
-
-  for (const auto& comp : b.components_) {
-    components_.push_back(
-        MakeUnique<Component>(comp->type, comp->mode, comp->num_bits));
-  }
-  RebuildSegments();
-}
-
 Format::~Format() = default;
-
-Format& Format::operator=(const Format& b) {
-  type_ = b.type_;
-  layout_ = b.layout_;
-  pack_size_in_bytes_ = b.pack_size_in_bytes_;
-  column_count_ = b.column_count_;
-
-  for (const auto& comp : b.components_) {
-    components_.push_back(
-        MakeUnique<Component>(comp->type, comp->mode, comp->num_bits));
-  }
-  RebuildSegments();
-
-  return *this;
-}
 
 uint32_t Format::SizeInBytes() const {
   uint32_t size = 0;

--- a/src/format.h
+++ b/src/format.h
@@ -123,10 +123,7 @@ class Format {
 
   /// Creates a format of unknown type.
   Format();
-  Format(const Format&);
   ~Format();
-
-  Format& operator=(const Format&);
 
   /// Returns true if |b| describes the same format as this object.
   bool Equal(const Format* b) const;

--- a/src/format_test.cc
+++ b/src/format_test.cc
@@ -22,31 +22,6 @@ namespace amber {
 
 using FormatTest = testing::Test;
 
-TEST_F(FormatTest, Copy) {
-  FormatParser fp;
-  auto fmt = fp.Parse("R32G32B32_SFLOAT");
-  fmt->SetLayout(Format::Layout::kStd140);
-  fmt->SetColumnCount(1);
-
-  auto copy = MakeUnique<Format>(*fmt.get());
-  EXPECT_TRUE(copy->IsFloat());
-  EXPECT_EQ(16U, copy->SizeInBytes());
-  EXPECT_EQ(4U, copy->GetSegments().size());
-  EXPECT_EQ(FormatType::kR32G32B32_SFLOAT, copy->GetFormatType());
-
-  auto& segs = copy->GetSegments();
-  EXPECT_EQ(FormatComponentType::kR, segs[0].GetComponent()->type);
-  EXPECT_EQ(FormatMode::kSFloat, segs[0].GetComponent()->mode);
-  EXPECT_EQ(32U, segs[0].GetComponent()->num_bits);
-  EXPECT_EQ(FormatComponentType::kG, segs[1].GetComponent()->type);
-  EXPECT_EQ(FormatMode::kSFloat, segs[1].GetComponent()->mode);
-  EXPECT_EQ(32U, segs[1].GetComponent()->num_bits);
-  EXPECT_EQ(FormatComponentType::kB, segs[2].GetComponent()->type);
-  EXPECT_EQ(FormatMode::kSFloat, segs[2].GetComponent()->mode);
-  EXPECT_EQ(32U, segs[2].GetComponent()->num_bits);
-  EXPECT_TRUE(segs[3].IsPadding());
-}
-
 TEST_F(FormatTest, SizeInBytesVector) {
   FormatParser fp;
   auto fmt = fp.Parse("R32G32B32_SFLOAT");

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -237,15 +237,15 @@ class Pipeline {
   Result Validate() const;
 
   /// Generates a default color attachment in B8G8R8A8_UNORM.
-  std::unique_ptr<Buffer> GenerateDefaultColorAttachmentBuffer() const;
+  std::unique_ptr<Buffer> GenerateDefaultColorAttachmentBuffer();
   /// Generates a default depth attachment in D32_SFLOAT_S8_UINT format.
-  std::unique_ptr<Buffer> GenerateDefaultDepthAttachmentBuffer() const;
+  std::unique_ptr<Buffer> GenerateDefaultDepthAttachmentBuffer();
 
   /// Information on values set for OpenCL-C plain-old-data args.
   struct ArgSetInfo {
     std::string name;
     uint32_t ordinal = 0;
-    std::unique_ptr<Format> fmt;
+    Format* fmt = nullptr;
     Value value;
   };
 
@@ -271,6 +271,7 @@ class Pipeline {
   std::vector<BufferInfo> color_attachments_;
   std::vector<BufferInfo> vertex_buffers_;
   std::vector<BufferInfo> buffers_;
+  std::vector<std::unique_ptr<Format>> formats_;
   BufferInfo depth_buffer_;
   BufferInfo push_constant_buffer_;
   Buffer* index_buffer_ = nullptr;

--- a/src/pipeline_test.cc
+++ b/src/pipeline_test.cc
@@ -532,21 +532,21 @@ TEST_F(PipelineTest, OpenCLGeneratePodBuffers) {
   Pipeline::ArgSetInfo arg_info1;
   arg_info1.name = "arg_a";
   arg_info1.ordinal = 99;
-  arg_info1.fmt = MakeUnique<Format>(*int_fmt);
+  arg_info1.fmt = int_fmt.get();
   arg_info1.value = int_value;
   p.SetArg(std::move(arg_info1));
 
   Pipeline::ArgSetInfo arg_info2;
   arg_info2.name = "arg_b";
   arg_info2.ordinal = 99;
-  arg_info2.fmt = MakeUnique<Format>(*char_fmt);
+  arg_info2.fmt = char_fmt.get();
   arg_info2.value = int_value;
   p.SetArg(std::move(arg_info2));
 
   Pipeline::ArgSetInfo arg_info3;
   arg_info3.name = "arg_c";
   arg_info3.ordinal = 99;
-  arg_info3.fmt = MakeUnique<Format>(*int_fmt);
+  arg_info3.fmt = int_fmt.get();
   arg_info3.value = int_value;
   p.SetArg(std::move(arg_info3));
 
@@ -595,7 +595,7 @@ TEST_F(PipelineTest, OpenCLGeneratePodBuffersBadName) {
   Pipeline::ArgSetInfo arg_info1;
   arg_info1.name = "arg_z";
   arg_info1.ordinal = 99;
-  arg_info1.fmt = std::move(int_fmt);
+  arg_info1.fmt = int_fmt.get();
   arg_info1.value = int_value;
   p.SetArg(std::move(arg_info1));
 
@@ -637,7 +637,7 @@ TEST_F(PipelineTest, OpenCLGeneratePodBuffersBadSize) {
   Pipeline::ArgSetInfo arg_info1;
   arg_info1.name = "";
   arg_info1.ordinal = 0;
-  arg_info1.fmt = std::move(short_fmt);
+  arg_info1.fmt = short_fmt.get();
   arg_info1.value = int_value;
   p.SetArg(std::move(arg_info1));
 
@@ -698,21 +698,21 @@ TEST_F(PipelineTest, OpenCLClone) {
   Pipeline::ArgSetInfo arg_info1;
   arg_info1.name = "arg_a";
   arg_info1.ordinal = 99;
-  arg_info1.fmt = MakeUnique<Format>(*int_fmt);
+  arg_info1.fmt = int_fmt.get();
   arg_info1.value = int_value;
   p.SetArg(std::move(arg_info1));
 
   Pipeline::ArgSetInfo arg_info2;
   arg_info2.name = "arg_b";
   arg_info2.ordinal = 99;
-  arg_info2.fmt = MakeUnique<Format>(*char_fmt);
+  arg_info2.fmt = char_fmt.get();
   arg_info2.value = int_value;
   p.SetArg(std::move(arg_info2));
 
   Pipeline::ArgSetInfo arg_info3;
   arg_info3.name = "arg_c";
   arg_info3.ordinal = 99;
-  arg_info3.fmt = MakeUnique<Format>(*int_fmt);
+  arg_info3.fmt = int_fmt.get();
   arg_info3.value = int_value;
   p.SetArg(std::move(arg_info3));
 

--- a/src/script.h
+++ b/src/script.h
@@ -27,6 +27,7 @@
 #include "src/buffer.h"
 #include "src/command.h"
 #include "src/engine.h"
+#include "src/format.h"
 #include "src/pipeline.h"
 #include "src/shader.h"
 
@@ -170,6 +171,11 @@ class Script : public RecipeImpl {
   /// Retrieves the SPIR-V target environment.
   const std::string& GetSpvTargetEnv() const { return spv_env_; }
 
+  Format* RegisterFormat(std::unique_ptr<Format> fmt) {
+    formats_.push_back(std::move(fmt));
+    return formats_.back().get();
+  }
+
  private:
   struct {
     std::vector<std::string> required_features;
@@ -186,6 +192,7 @@ class Script : public RecipeImpl {
   std::vector<std::unique_ptr<Command>> commands_;
   std::vector<std::unique_ptr<Buffer>> buffers_;
   std::vector<std::unique_ptr<Pipeline>> pipelines_;
+  std::vector<std::unique_ptr<Format>> formats_;
 };
 
 }  // namespace amber

--- a/src/verifier_test.cc
+++ b/src/verifier_test.cc
@@ -651,7 +651,8 @@ TEST_F(VerifierTest, ProbeSSBOUint8Single) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R8_UINT"));
+  auto fmt = fp.Parse("R8_UINT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -674,7 +675,9 @@ TEST_F(VerifierTest, ProbeSSBOUint8Multiple) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R8_UINT"));
+  auto fmt = fp.Parse("R8_UINT");
+
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -698,7 +701,9 @@ TEST_F(VerifierTest, ProbeSSBOUint8Many) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R8_UINT"));
+  auto fmt = fp.Parse("R8_UINT");
+
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -726,7 +731,8 @@ TEST_F(VerifierTest, ProbeSSBOUint32Single) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R32_UINT"));
+  auto fmt = fp.Parse("R32_UINT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -749,7 +755,8 @@ TEST_F(VerifierTest, ProbeSSBOUint32Multiple) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R32_UINT"));
+  auto fmt = fp.Parse("R32_UINT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -774,7 +781,8 @@ TEST_F(VerifierTest, ProbeSSBOUint32Many) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R32_UINT"));
+  auto fmt = fp.Parse("R32_UINT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -802,7 +810,8 @@ TEST_F(VerifierTest, ProbeSSBOFloatSingle) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R32_SFLOAT"));
+  auto fmt = fp.Parse("R32_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -825,7 +834,8 @@ TEST_F(VerifierTest, ProbeSSBOFloatMultiple) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R32_SFLOAT"));
+  auto fmt = fp.Parse("R32_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -850,7 +860,8 @@ TEST_F(VerifierTest, ProbeSSBOFloatMany) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R32_SFLOAT"));
+  auto fmt = fp.Parse("R32_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -878,7 +889,8 @@ TEST_F(VerifierTest, ProbeSSBODoubleSingle) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -901,7 +913,8 @@ TEST_F(VerifierTest, ProbeSSBODoubleMultiple) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -926,7 +939,8 @@ TEST_F(VerifierTest, ProbeSSBODoubleMany) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -954,7 +968,8 @@ TEST_F(VerifierTest, ProbeSSBOEqualFail) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kEqual);
 
   std::vector<Value> values;
@@ -981,7 +996,8 @@ TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithAbsoluteTolerance) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kFuzzyEqual);
 
   std::vector<Probe::Tolerance> tolerances;
@@ -1015,7 +1031,8 @@ TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithAbsoluteToleranceFail) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kFuzzyEqual);
 
   std::vector<Probe::Tolerance> tolerances;
@@ -1046,7 +1063,8 @@ TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithRelativeTolerance) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kFuzzyEqual);
 
   std::vector<Probe::Tolerance> tolerances;
@@ -1080,7 +1098,8 @@ TEST_F(VerifierTest, ProbeSSBOFuzzyEqualWithRelativeToleranceFail) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kFuzzyEqual);
 
   std::vector<Probe::Tolerance> tolerances;
@@ -1111,7 +1130,8 @@ TEST_F(VerifierTest, ProbeSSBONotEqual) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kNotEqual);
 
   std::vector<Value> values;
@@ -1136,7 +1156,8 @@ TEST_F(VerifierTest, ProbeSSBONotEqualFail) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kNotEqual);
 
   std::vector<Value> values;
@@ -1163,7 +1184,8 @@ TEST_F(VerifierTest, ProbeSSBOLess) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kLess);
 
   std::vector<Value> values;
@@ -1188,7 +1210,8 @@ TEST_F(VerifierTest, ProbeSSBOLessFail) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kLess);
 
   std::vector<Value> values;
@@ -1215,7 +1238,8 @@ TEST_F(VerifierTest, ProbeSSBOLessOrEqual) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kLessOrEqual);
 
   std::vector<Value> values;
@@ -1240,7 +1264,8 @@ TEST_F(VerifierTest, ProbeSSBOLessOrEqualFail) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kLessOrEqual);
 
   std::vector<Value> values;
@@ -1267,7 +1292,8 @@ TEST_F(VerifierTest, ProbeSSBOGreater) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kGreater);
 
   std::vector<Value> values;
@@ -1292,7 +1318,8 @@ TEST_F(VerifierTest, ProbeSSBOGreaterFail) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kGreater);
 
   std::vector<Value> values;
@@ -1319,7 +1346,8 @@ TEST_F(VerifierTest, ProbeSSBOGreaterOrEqual) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kGreaterOrEqual);
 
   std::vector<Value> values;
@@ -1344,7 +1372,8 @@ TEST_F(VerifierTest, ProbeSSBOGreaterOrEqualFail) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("R64_SFLOAT"));
+  auto fmt = fp.Parse("R64_SFLOAT");
+  probe_ssbo.SetFormat(fmt.get());
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kGreaterOrEqual);
 
   std::vector<Value> values;
@@ -1399,7 +1428,8 @@ TEST_F(VerifierTest, ProbeSSBOWithPadding) {
   ProbeSSBOCommand probe_ssbo(color_buf.get());
 
   FormatParser fp;
-  probe_ssbo.SetFormat(fp.Parse("float/vec2"));
+  auto fmt = fp.Parse("float/vec2");
+  probe_ssbo.SetFormat(fmt.get());
   ASSERT_TRUE(probe_ssbo.GetFormat() != nullptr);
 
   probe_ssbo.SetComparator(ProbeSSBOCommand::Comparator::kLessOrEqual);

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -411,7 +411,7 @@ Result EngineVulkan::DoDrawRect(const DrawRectCommand* command) {
   FormatParser fp;
   auto fmt = fp.Parse("R32G32_SFLOAT");
   auto buf = MakeUnique<Buffer>();
-  buf->SetFormat(std::move(fmt));
+  buf->SetFormat(fmt.get());
   buf->SetData(std::move(values));
 
   auto vertex_buffer = MakeUnique<VertexBuffer>(device_.get());

--- a/src/vulkan/graphics_pipeline.h
+++ b/src/vulkan/graphics_pipeline.h
@@ -90,7 +90,7 @@ class GraphicsPipeline : public Pipeline {
 
   // color buffers are owned by the amber::Pipeline.
   std::vector<const amber::Pipeline::BufferInfo*> color_buffers_;
-  Format depth_stencil_format_;
+  Format* depth_stencil_format_;
   std::unique_ptr<IndexBuffer> index_buffer_;
 
   uint32_t frame_width_ = 0;

--- a/src/vulkan/push_constant.cc
+++ b/src/vulkan/push_constant.cc
@@ -123,7 +123,7 @@ Result PushConstant::UpdateMemoryWithInput(const BufferInput& input) {
   }
 
   if (!buffer_->GetFormat()) {
-    buffer_->SetFormat(MakeUnique<Format>(*(input.buffer->GetFormat())));
+    buffer_->SetFormat(input.buffer->GetFormat());
   } else if (!buffer_->GetFormat()->Equal(input.buffer->GetFormat())) {
     return Result("Vulkan: push constants must all have the same format");
   }

--- a/src/vulkan/vertex_buffer_test.cc
+++ b/src/vulkan/vertex_buffer_test.cc
@@ -56,10 +56,10 @@ class VertexBufferTest : public testing::Test {
   ~VertexBufferTest() = default;
 
   Result SetIntData(uint8_t location,
-                    std::unique_ptr<Format> format,
+                    Format* format,
                     std::vector<Value> values) {
     auto buffer = MakeUnique<Buffer>();
-    buffer->SetFormat(std::move(format));
+    buffer->SetFormat(format);
     buffer->SetData(std::move(values));
 
     vertex_buffer_->SetData(location, buffer.get());
@@ -67,10 +67,10 @@ class VertexBufferTest : public testing::Test {
   }
 
   Result SetDoubleData(uint8_t location,
-                       std::unique_ptr<Format> format,
+                       Format* format,
                        std::vector<Value> values) {
     auto buffer = MakeUnique<Buffer>();
-    buffer->SetFormat(std::move(format));
+    buffer->SetFormat(format);
     buffer->SetData(std::move(values));
 
     vertex_buffer_->SetData(location, buffer.get());
@@ -100,7 +100,7 @@ TEST_F(VertexBufferTest, R8G8B8A8_UINT) {
   FormatParser fp;
   auto fmt = fp.Parse("R8G8B8A8_UINT");
 
-  Result r = SetIntData(0, std::move(fmt), values);
+  Result r = SetIntData(0, fmt.get(), values);
   const uint8_t* ptr = static_cast<const uint8_t*>(GetVkBufferPtr());
   EXPECT_EQ(55, ptr[0]);
   EXPECT_EQ(3, ptr[1]);
@@ -118,7 +118,7 @@ TEST_F(VertexBufferTest, R16G16B16A16_UINT) {
   FormatParser fp;
   auto fmt = fp.Parse("R16G16B16A16_UINT");
 
-  Result r = SetIntData(0, std::move(fmt), values);
+  Result r = SetIntData(0, fmt.get(), values);
   const uint16_t* ptr = static_cast<const uint16_t*>(GetVkBufferPtr());
   EXPECT_EQ(55, ptr[0]);
   EXPECT_EQ(3, ptr[1]);
@@ -136,7 +136,7 @@ TEST_F(VertexBufferTest, R32G32B32A32_UINT) {
   FormatParser fp;
   auto fmt = fp.Parse("R32G32B32A32_UINT");
 
-  Result r = SetIntData(0, std::move(fmt), values);
+  Result r = SetIntData(0, fmt.get(), values);
   const uint32_t* ptr = static_cast<const uint32_t*>(GetVkBufferPtr());
   EXPECT_EQ(55, ptr[0]);
   EXPECT_EQ(3, ptr[1]);
@@ -154,7 +154,7 @@ TEST_F(VertexBufferTest, R64G64B64A64_UINT) {
   FormatParser fp;
   auto fmt = fp.Parse("R64G64B64A64_UINT");
 
-  Result r = SetIntData(0, std::move(fmt), values);
+  Result r = SetIntData(0, fmt.get(), values);
   const uint64_t* ptr = static_cast<const uint64_t*>(GetVkBufferPtr());
   EXPECT_EQ(55, ptr[0]);
   EXPECT_EQ(3, ptr[1]);
@@ -172,7 +172,7 @@ TEST_F(VertexBufferTest, R8G8B8A8_SNORM) {
   FormatParser fp;
   auto fmt = fp.Parse("R8G8B8A8_SNORM");
 
-  Result r = SetIntData(0, std::move(fmt), values);
+  Result r = SetIntData(0, fmt.get(), values);
   const int8_t* ptr = static_cast<const int8_t*>(GetVkBufferPtr());
   EXPECT_EQ(-55, ptr[0]);
   EXPECT_EQ(3, ptr[1]);
@@ -190,7 +190,7 @@ TEST_F(VertexBufferTest, R16G16B16A16_SNORM) {
   FormatParser fp;
   auto fmt = fp.Parse("R16G16B16A16_SNORM");
 
-  Result r = SetIntData(0, std::move(fmt), values);
+  Result r = SetIntData(0, fmt.get(), values);
   const int16_t* ptr = static_cast<const int16_t*>(GetVkBufferPtr());
   EXPECT_EQ(-55, ptr[0]);
   EXPECT_EQ(3, ptr[1]);
@@ -208,7 +208,7 @@ TEST_F(VertexBufferTest, R32G32B32A32_SINT) {
   FormatParser fp;
   auto fmt = fp.Parse("R32G32B32A32_SINT");
 
-  Result r = SetIntData(0, std::move(fmt), values);
+  Result r = SetIntData(0, fmt.get(), values);
   const int32_t* ptr = static_cast<const int32_t*>(GetVkBufferPtr());
   EXPECT_EQ(-55, ptr[0]);
   EXPECT_EQ(3, ptr[1]);
@@ -226,7 +226,7 @@ TEST_F(VertexBufferTest, R64G64B64A64_SINT) {
   FormatParser fp;
   auto fmt = fp.Parse("R64G64B64A64_SINT");
 
-  Result r = SetIntData(0, std::move(fmt), values);
+  Result r = SetIntData(0, fmt.get(), values);
   const int64_t* ptr = static_cast<const int64_t*>(GetVkBufferPtr());
   EXPECT_EQ(-55, ptr[0]);
   EXPECT_EQ(3, ptr[1]);
@@ -243,7 +243,7 @@ TEST_F(VertexBufferTest, R32G32B32_SFLOAT) {
   FormatParser fp;
   auto fmt = fp.Parse("R32G32B32_SFLOAT");
 
-  Result r = SetDoubleData(0, std::move(fmt), values);
+  Result r = SetDoubleData(0, fmt.get(), values);
   const float* ptr = static_cast<const float*>(GetVkBufferPtr());
   EXPECT_FLOAT_EQ(-6.0f, ptr[0]);
   EXPECT_FLOAT_EQ(14.0f, ptr[1]);
@@ -259,7 +259,7 @@ TEST_F(VertexBufferTest, R64G64B64_SFLOAT) {
   FormatParser fp;
   auto fmt = fp.Parse("R64G64B64_SFLOAT");
 
-  Result r = SetDoubleData(0, std::move(fmt), values);
+  Result r = SetDoubleData(0, fmt.get(), values);
   const double* ptr = static_cast<const double*>(GetVkBufferPtr());
   EXPECT_DOUBLE_EQ(-6.0, ptr[0]);
   EXPECT_DOUBLE_EQ(14.0, ptr[1]);


### PR DESCRIPTION
This CL removes the unique_ptr from the probe and buffer classes and
stores pointers instead. The lifetimes are managed by the pipeline and
script objects.

This removes the need to do the copy and assignment operators for the
format class.