### PR TITLE
Add Vulkan device selection support

### DIFF
--- a/samples/config_helper.cc
+++ b/samples/config_helper.cc
@@ -40,6 +40,7 @@ amber::Result ConfigHelper::CreateConfig(
     amber::EngineType engine,
     uint32_t engine_major,
     uint32_t engine_minor,
+    int32_t selected_device,
     const std::vector<std::string>& required_features,
     const std::vector<std::string>& required_instance_extensions,
     const std::vector<std::string>& required_device_extensions,
@@ -67,7 +68,7 @@ amber::Result ConfigHelper::CreateConfig(
     return amber::Result("Unable to create config helper");
 
   return impl_->CreateConfig(
-      engine_major, engine_minor, required_features,
+      engine_major, engine_minor, selected_device, required_features,
       required_instance_extensions, required_device_extensions,
       disable_validation_layer, show_version_info, config);
 }

--- a/samples/config_helper.h
+++ b/samples/config_helper.h
@@ -35,6 +35,7 @@ class ConfigHelperImpl {
   virtual amber::Result CreateConfig(
       uint32_t engine_major,
       uint32_t engine_minor,
+      int32_t selected_device,
       const std::vector<std::string>& required_features,
       const std::vector<std::string>& required_instance_extensions,
       const std::vector<std::string>& required_device_extensions,
@@ -58,6 +59,7 @@ class ConfigHelper {
       amber::EngineType engine,
       uint32_t engine_major,
       uint32_t engine_minor,
+      int32_t selected_device,
       const std::vector<std::string>& required_features,
       const std::vector<std::string>& required_instance_extensions,
       const std::vector<std::string>& required_device_extensions,

--- a/samples/config_helper_dawn.cc
+++ b/samples/config_helper_dawn.cc
@@ -51,6 +51,7 @@ void PrintDeviceError(DawnErrorType errorType, const char* message, void*) {
 amber::Result ConfigHelperDawn::CreateConfig(
     uint32_t,
     uint32_t,
+    int32_t,
     const std::vector<std::string>&,
     const std::vector<std::string>&,
     const std::vector<std::string>&,

--- a/samples/config_helper_dawn.h
+++ b/samples/config_helper_dawn.h
@@ -39,6 +39,7 @@ class ConfigHelperDawn : public ConfigHelperImpl {
   amber::Result CreateConfig(
       uint32_t engine_major,
       uint32_t engine_minor,
+      int32_t selected_device,
       const std::vector<std::string>& required_features,
       const std::vector<std::string>& required_instance_extensions,
       const std::vector<std::string>& required_device_extensions,

--- a/samples/config_helper_vulkan.h
+++ b/samples/config_helper_vulkan.h
@@ -44,6 +44,7 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
   amber::Result CreateConfig(
       uint32_t engine_major,
       uint32_t engine_minor,
+      int32_t selected_device,
       const std::vector<std::string>& required_features,
       const std::vector<std::string>& required_instance_extensions,
       const std::vector<std::string>& required_device_extensions,
@@ -63,11 +64,19 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
   /// via debugCallback() function in config_helper_vulkan.cc.
   amber::Result CreateDebugReportCallback();
 
+  /// Check if |physical_device| supports both
+  /// |required_features| and |required_extensions|.
+  amber::Result CheckVulkanPhysicalDeviceRequirements(
+      const VkPhysicalDevice physical_device,
+      const std::vector<std::string>& required_features,
+      const std::vector<std::string>& required_extensions);
+
   /// Choose Vulkan physical device that supports both
   /// |required_features| and |required_extensions|.
   amber::Result ChooseVulkanPhysicalDevice(
       const std::vector<std::string>& required_features,
-      const std::vector<std::string>& required_extensions);
+      const std::vector<std::string>& required_extensions,
+      const int32_t selected_device);
 
   /// Create Vulkan logical device that enables both
   /// |required_features| and |required_extensions|.


### PR DESCRIPTION
Add the `-D` command line option for selecting a physical Vulkan device to run with. Only choose from enumerated physical devices in ChooseVulkanPhysicalDevice and move feature and extension checks to a new CheckVulkanPhysicalDeviceRequirements function.

I tried to add support for Dawn as well but had issues building Amber with Dawn support.

Fixes #619