### PR TITLE
Fix non-existent framebuffer name behavior

### DIFF
--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -471,6 +471,22 @@ int main(int argc, const char** argv) {
           pos != std::string::npos && image_filename.substr(pos + 1) == "png";
       for (const amber::BufferInfo& buffer_info : amber_options.extractions) {
         if (buffer_info.buffer_name == options.fb_names[i]) {
+          if (buffer_info.values.size() !=
+              (buffer_info.width * buffer_info.height)) {
+            result = amber::Result(
+                "Framebuffer (" + buffer_info.buffer_name + ") size (" +
+                std::to_string(buffer_info.values.size()) +
+                ") != " + "width * height (" +
+                std::to_string(buffer_info.width * buffer_info.height) + ")");
+            break;
+          }
+
+          if (buffer_info.values.empty()) {
+            result = amber::Result("Framebuffer (" + buffer_info.buffer_name +
+                                   ") empty or non-existent.");
+            break;
+          }
+
           if (usePNG) {
 #if AMBER_ENABLE_LODEPNG
             result = png::ConvertToPNG(buffer_info.width, buffer_info.height,

--- a/samples/png.cc
+++ b/samples/png.cc
@@ -50,16 +50,14 @@ amber::Result ConvertToPNG(uint32_t width,
                            uint32_t height,
                            const std::vector<amber::Value>& values,
                            std::vector<uint8_t>* buffer) {
-  if (values.size() != (width * height)) {
-    return amber::Result("Values size (" + std::to_string(values.size()) +
-                         ") != " + "width * height (" +
-                         std::to_string(width * height) + ")");
-  }
+  assert(values.size() == (width * height) &&
+         "Buffer values != width * height");
+  assert(!values.empty() && "Buffer empty");
 
   std::vector<uint8_t> data;
 
   // Prepare data as lodepng expects it
-  for (amber::Value value : values) {
+  for (const amber::Value& value : values) {
     const uint32_t pixel = value.AsUint32();
     data.push_back(byte2(pixel));  // R
     data.push_back(byte1(pixel));  // G

--- a/samples/ppm.cc
+++ b/samples/ppm.cc
@@ -42,7 +42,7 @@ amber::Result ConvertToPPM(uint32_t width,
                            uint32_t height,
                            const std::vector<amber::Value>& values,
                            std::vector<uint8_t>* buffer) {
-  assert(values.size() != (width * height) &&
+  assert(values.size() == (width * height) &&
          "Buffer values != width * height");
   assert(!values.empty() && "Buffer empty");
 

--- a/samples/ppm.cc
+++ b/samples/ppm.cc
@@ -42,11 +42,9 @@ amber::Result ConvertToPPM(uint32_t width,
                            uint32_t height,
                            const std::vector<amber::Value>& values,
                            std::vector<uint8_t>* buffer) {
-  if (values.size() != (width * height)) {
-    return amber::Result("Values size (" + std::to_string(values.size()) +
-                         ") != " + "width * height (" +
-                         std::to_string(width * height) + ")");
-  }
+  assert(values.size() != (width * height) &&
+         "Buffer values != width * height");
+  assert(!values.empty() && "Buffer empty");
 
   // Write PPM header
   std::string image = "P6\n";


### PR DESCRIPTION
Previously, a non-existent framebuffer name led to malformed PNG files. Also, any bad/non-existent framebuffer name caused all following framebuffer extractions to be skipped unnecessarily, leading to further malformed PNG files.

Now missing buffer names will lead to a warning message, and all extractions will be attempted.

Fix #699