### PR TITLE
Rolling 6 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -13,17 +13,17 @@ vars = {
   'clspv_llvm_revision': '6ba5cbf3ea2315acf1b7f1c39c6fec6cca5560ca',
   'clspv_revision': 'f26dac9ae5d6fab98ca027a26e375937074770cf',
   'cpplint_revision': '26470f9ccb354ff2f6d098f831271a1833701b28',
-  'dxc_revision': '23b84f584c12f4bc16246f42fbe35164cee60c01',
+  'dxc_revision': '815358229dc74a43f57905cbf10fd805ab26c049',
   'glslang_revision': '38b4db48f98c4e3a9cc405de3a76547b857e1c37',
   'googletest_revision': '679bfec6db73c021b0226e386c65ec1baee7a09f',
   'lodepng_revision': 'dc3f19b5aeaa26ff94f48f52a1c7cb5b1ef4ed3c',
-  'shaderc_revision': 'da52fae116b3968baa4996e86a05aa45ec1f06ec',
+  'shaderc_revision': 'ff260580c07e8f9eae471b3d02dd2fe589c73198',
   'spirv_headers_revision': '204cd131c42b90d129073719f2766293ce35c081',
   'spirv_tools_revision': '85f3e93d13f32d45bd7f9999aa51baddf2452aae',
-  'swiftshader_revision': 'aee3c369516a24caa8ebc9a38fc57da708ceccbc',
-  'vulkan_headers_revision': '24347673152e093a48efbf65dfd3b06026b6ed33',
-  'vulkan_validationlayers_revision': '5efc3922e3e863cc69fb487b040c1d1e563de1bc',
-  'vulkan_loader_revision': '08d344208e60e0bb8c8fbe25b9b1f2bf63801e2f',
+  'swiftshader_revision': '663dcefa22ea5eec1b108feebaf40a683fb104ff',
+  'vulkan_headers_revision': '2b89fd4e2734b728ca0be72a13f2265c5f5aa88e',
+  'vulkan_validationlayers_revision': '8c954d5a413d4fa724c0c3a6c8e37a7132c68e72',
+  'vulkan_loader_revision': 'fc962d08075e295cb563ce586f0c94c815c4e847',
 }
 
 deps = {


### PR DESCRIPTION
Roll third_party/dxc/ 23b84f584..815358229 (1 commit)

https://github.com/Microsoft/DirectXShaderCompiler/compare/23b84f584c12...815358229dc7

$ git log 23b84f584..815358229 --date=short --no-merges --format='%ad %ae %s'
2019-11-25 python3kgae Use TAG_auto_variable for local variable which converted from global … (#2602)

Roll third_party/shaderc/ da52fae11..ff260580c (1 commit)

https://github.com/google/shaderc/compare/da52fae116b3...ff260580c07e

$ git log da52fae11..ff260580c --date=short --no-merges --format='%ad %ae %s'
2019-11-25 9856269+sarahM0 spvc: Changing the default to pass through - update known_spvc_failure file (#904)

Roll third_party/swiftshader/ aee3c3695..663dcefa2 (14 commits)

https://swiftshader.googlesource.com/SwiftShader.git/+log/aee3c369516a..663dcefa22ea

$ git log aee3c3695..663dcefa2 --date=short --no-merges --format='%ad %ae %s'
2019-11-26 bclayton Reactor: Work around new MSVC brokenness.
2019-11-26 swiftshader.regress Regres: Update test lists @ f2637d0d
2019-11-25 jonahr Present should return OUT_OF_DATE if the window size outdated
2019-11-22 cwallez Make GN builds produce an ICD JSON in the build dir
2019-11-25 chrisforbes Add missing vkCmdSetLineStippleEXT function
2019-11-21 sugoi Improved pNext pointer handling
2019-11-18 awoloszyn Fix vkQueuePresentKHR is pResults is not null.
2019-11-25 swiftshader.regress Regres: Update test lists @ d44d6151
2019-11-20 kadam ExecutionEngine: add preliminary support for COFF ARM64
2019-11-25 bclayton Fix build: Do not return stack temporary.
2019-11-24 bclayton Fix chrome build: Use spaces (not tabs) in .gn files (2/2)
2019-11-24 bclayton Fix chrome build: Use spaces (not tabs) in .gn files
2019-11-18 bclayton Squashed 'third_party/SPIRV-Tools/' changes from 65e362b7a..c3f22f7cb
2019-11-18 bclayton Squashed 'third_party/SPIRV-Headers/' changes from e4322e3be..af64a9e82

Roll third_party/vulkan-headers/ 243476731..2b89fd4e2 (1 commit)

https://github.com/KhronosGroup/Vulkan-Headers/compare/24347673152e...2b89fd4e2734

$ git log 243476731..2b89fd4e2 --date=short --no-merges --format='%ad %ae %s'
2019-11-25 oddhack Update for Vulkan-Docs 1.1.129

Roll third_party/vulkan-loader/ 08d344208..fc962d080 (1 commit)

https://github.com/KhronosGroup/Vulkan-Loader/compare/08d344208e60...fc962d08075e

$ git log 08d344208..fc962d080 --date=short --no-merges --format='%ad %ae %s'
2019-11-22 mikes build: Add Cfgmgr32.lib to GN build

Roll third_party/vulkan-validationlayers/ 5efc3922e..8c954d5a4 (3 commits)

https://github.com/KhronosGroup/Vulkan-ValidationLayers/compare/5efc3922e3e8...8c954d5a413d

$ git log 5efc3922e..8c954d5a4 --date=short --no-merges --format='%ad %ae %s'
2019-11-25 locke tests: Using wrong queue
2019-10-17 locke tests: pipeline stage conditional rednering
2019-10-16 locke layers: Add conditional rendering

Created with:
  roll-dep third_party/dxc third_party/glslang third_party/googletest third_party/lodepng third_party/shaderc third_party/spirv-headers third_party/spirv-tools third_party/swiftshader third_party/vulkan-headers third_party/vulkan-loader third_party/vulkan-validationlayers