### PR TITLE
Remove buffer type from BufferInfo struct

### DIFF
--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -363,7 +363,6 @@ void Pipeline::AddBuffer(Buffer* buf,
   auto& info = buffers_.back();
   info.descriptor_set = descriptor_set;
   info.binding = binding;
-  info.type = buf->GetBufferType();
 }
 
 void Pipeline::AddBuffer(Buffer* buf, const std::string& arg_name) {

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -134,7 +134,10 @@ class Pipeline {
     uint32_t location = 0;
     std::string arg_name = "";
     uint32_t arg_no = 0;
-    BufferType type = BufferType::kUnknown;
+
+    // Note, don't cache buffer information here as the buffer information
+    // can change after the BufferInfo object is created (this happens in the
+    // case of OpenCL buffers which set the type late.
   };
 
   /// Information on a sampler attached to the pipeline.

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -230,17 +230,18 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
 
   for (const auto& buf_info : pipeline->GetBuffers()) {
     auto type = BufferCommand::BufferType::kSSBO;
-    if (buf_info.type == BufferType::kStorageImage) {
+		auto buf_type = buf_info.buffer->GetBufferType();
+    if (buf_type == BufferType::kStorageImage) {
       type = BufferCommand::BufferType::kStorageImage;
-    } else if (buf_info.type == BufferType::kSampledImage) {
+    } else if (buf_type == BufferType::kSampledImage) {
       type = BufferCommand::BufferType::kSampledImage;
-    } else if (buf_info.type == BufferType::kCombinedImageSampler) {
+    } else if (buf_type == BufferType::kCombinedImageSampler) {
       type = BufferCommand::BufferType::kCombinedImageSampler;
-    } else if (buf_info.type == BufferType::kUniform) {
+    } else if (buf_type == BufferType::kUniform) {
       type = BufferCommand::BufferType::kUniform;
-    } else if (buf_info.type != BufferType::kStorage) {
+    } else if (buf_type != BufferType::kStorage) {
       return Result("Vulkan: CreatePipeline - unknown buffer type: " +
-                    std::to_string(static_cast<uint32_t>(buf_info.type)));
+                    std::to_string(static_cast<uint32_t>(buf_type)));
     }
 
     auto cmd = MakeUnique<BufferCommand>(type, pipeline);

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -230,7 +230,7 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
 
   for (const auto& buf_info : pipeline->GetBuffers()) {
     auto type = BufferCommand::BufferType::kSSBO;
-		auto buf_type = buf_info.buffer->GetBufferType();
+    auto buf_type = buf_info.buffer->GetBufferType();
     if (buf_type == BufferType::kStorageImage) {
       type = BufferCommand::BufferType::kStorageImage;
     } else if (buf_type == BufferType::kSampledImage) {

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -43,28 +43,22 @@ SUPPRESSIONS = {
     "multiple_ubo_update_with_graphics_pipeline.vkscript",
     # DXC not currently building on bot
     "draw_triangle_list_hlsl.amber",
-    # CLSPV not built by default
-    "opencl_bind_buffer.amber",
-    "opencl_c_copy.amber",
-    "opencl_set_arg.amber"
   ],
   "Linux": [
     # DXC not currently building on bot
     "draw_triangle_list_hlsl.amber",
-    # CLSPV not built by default
-    "opencl_bind_buffer.amber",
-    "opencl_c_copy.amber",
-    "opencl_set_arg.amber"
   ],
   "Win": [
     # DXC not currently building on bot
     "draw_triangle_list_hlsl.amber",
-    # CLSPV not built by default
-    "opencl_bind_buffer.amber",
-    "opencl_c_copy.amber",
-    "opencl_set_arg.amber"
    ]
  }
+
+OPENCL_CASES = [
+  "opencl_bind_buffer.amber",
+  "opencl_c_copy.amber",
+  "opencl_set_arg.amber"
+]
 
 SUPPRESSIONS_DAWN = [
   # Dawn does not support push constants
@@ -125,10 +119,11 @@ SUPPRESSIONS_DAWN = [
 ]
 
 class TestCase:
-  def __init__(self, input_path, parse_only, use_dawn):
+  def __init__(self, input_path, parse_only, use_dawn, use_opencl):
     self.input_path = input_path
     self.parse_only = parse_only
     self.use_dawn = use_dawn
+    self.use_opencl = use_opencl
 
     self.results = {}
 
@@ -138,10 +133,19 @@ class TestCase:
 
   def IsSuppressed(self):
     system = platform.system()
+
+    base = os.path.basename(self.input_path)
+    is_dawn_suppressed = base in SUPPRESSIONS_DAWN
+    if self.use_dawn and is_dawn_suppressed:
+      return True
+
+    is_opencl_test = base in OPENCL_CASES
+    if not self.use_opencl and is_opencl_test:
+      return True
+
     if system in SUPPRESSIONS.keys():
-      is_system_suppressed = os.path.basename(self.input_path) in SUPPRESSIONS[system]
-      is_dawn_suppressed = os.path.basename(self.input_path) in SUPPRESSIONS_DAWN
-      return is_system_suppressed | (self.use_dawn & is_dawn_suppressed)
+      is_system_suppressed = base in SUPPRESSIONS[system]
+      return is_system_suppressed
 
     return False
 
@@ -239,6 +243,9 @@ class TestRunner:
     parser.add_option('--use-dawn',
                       action="store_true", default=False,
                       help='Use dawn as the backend; Default is Vulkan')
+    parser.add_option('--use-opencl',
+                      action="store_true", default=False,
+                      help='Enable OpenCL tests')
 
     self.options, self.args = parser.parse_args()
 
@@ -264,7 +271,8 @@ class TestRunner:
           print "Cannot find test file '%s'" % filename
           return 1
 
-        self.test_cases.append(TestCase(input_path, self.options.parse_only, self.options.use_dawn))
+        self.test_cases.append(TestCase(input_path, self.options.parse_only,
+            self.options.use_dawn, self.options.use_opencl))
 
     else:
       for file_dir, _, filename_list in os.walk(self.options.test_dir):
@@ -273,7 +281,8 @@ class TestRunner:
             input_path = os.path.join(file_dir, input_filename)
             if os.path.isfile(input_path):
               self.test_cases.append(
-                  TestCase(input_path, self.options.parse_only, self.options.use_dawn))
+                  TestCase(input_path, self.options.parse_only,
+                      self.options.use_dawn, self.options.use_opencl))
 
     self.failures = []
     self.suppressed = []


### PR DESCRIPTION
The buffer type can get changed late in the process (this happens in the
case of OpenCL where we determine the buffer type from binding data that
is seen later). This means, the buffer type can be changed _after_ the
BufferInfo structure is setup.

Make sure we always retrieve the buffer type from the buffer directly
instead of caching.