### PR TITLE
Add ability to extract shader source.

### DIFF
--- a/include/amber/shader_info.h
+++ b/include/amber/shader_info.h
@@ -54,6 +54,8 @@ struct ShaderInfo {
   std::string shader_source;
   /// A list of SPIR-V optimization passes to execute on the shader.
   std::vector<std::string> optimizations;
+  /// The shader SPIR-V if it was compiled by Amber
+  std::vector<uint32_t> shader_data;
 };
 
 }  // namespace amber

--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -330,7 +330,8 @@ class SampleDelegate : public amber::Delegate {
   bool log_execute_calls_ = false;
 };
 
-std::string disassemble(const std::string& env, const std::vector<uint32_t>& data) {
+std::string disassemble(const std::string& env,
+                        const std::vector<uint32_t>& data) {
 #if AMBER_ENABLE_SPIRV_TOOLS
   std::string spv_errors;
 
@@ -368,8 +369,8 @@ std::string disassemble(const std::string& env, const std::vector<uint32_t>& dat
 
   std::string result;
   tools.Disassemble(data, &result,
-      SPV_BINARY_TO_TEXT_OPTION_INDENT |
-      SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
+                    SPV_BINARY_TO_TEXT_OPTION_INDENT |
+                        SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
   return result;
 #else
   return "";
@@ -550,9 +551,12 @@ int main(int argc, const char** argv) {
       } else {
         auto info = recipe->GetShaderInfo();
         for (const auto& sh : info) {
-          shader_file << ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;" << std::endl;
-          shader_file << "; " << sh.shader_name << std::endl << ";" << std::endl;
-          shader_file << disassemble(options.spv_env, sh.shader_data) << std::endl;
+          shader_file << ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;"
+                      << std::endl;
+          shader_file << "; " << sh.shader_name << std::endl
+                      << ";" << std::endl;
+          shader_file << disassemble(options.spv_env, sh.shader_data)
+                      << std::endl;
         }
         shader_file.close();
       }

--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -31,6 +31,10 @@
 #include "src/build-versions.h"
 #include "src/make_unique.h"
 
+#if AMBER_ENABLE_SPIRV_TOOLS
+#include "spirv-tools/libspirv.hpp"
+#endif
+
 #if AMBER_ENABLE_LODEPNG
 #include "samples/png.h"
 #endif  // AMBER_ENABLE_LODEPNG
@@ -60,6 +64,7 @@ struct Options {
   bool log_graphics_calls_time = false;
   bool log_execute_calls = false;
   bool disable_spirv_validation = false;
+  std::string shader_filename;
   amber::EngineType engine = amber::kEngineTypeVulkan;
   std::string spv_env;
 };
@@ -86,6 +91,7 @@ const char kUsage[] = R"(Usage: amber [options] SCRIPT [SCRIPTS...]
   -b <filename>             -- Write contents of a UBO or SSBO to <filename>.
   -B [<desc set>:]<binding> -- Descriptor set and binding of buffer to write.
                                Default is [0:]0.
+  -w <filename>             -- Write shader assembly to |filename|                               
   -e <engine>               -- Specify graphics engine: vulkan, dawn. Default is vulkan.
   -v <engine version>       -- Engine version (eg, 1.1 for Vulkan). Default 1.0.
   -V, --version             -- Output version information for Amber and libraries.
@@ -131,6 +137,13 @@ bool ParseArgs(const std::vector<std::string>& args, Options* opts) {
       }
       opts->buffer_to_dump.emplace_back();
       opts->buffer_to_dump.back().buffer_name = args[i];
+    } else if (arg == "-w") {
+      ++i;
+      if (i >= args.size()) {
+        std::cerr << "Missing value for -w argument." << std::endl;
+        return false;
+      }
+      opts->shader_filename = args[i];
     } else if (arg == "-e") {
       ++i;
       if (i >= args.size()) {
@@ -317,6 +330,52 @@ class SampleDelegate : public amber::Delegate {
   bool log_execute_calls_ = false;
 };
 
+std::string disassemble(const std::string& env, const std::vector<uint32_t>& data) {
+#if AMBER_ENABLE_SPIRV_TOOLS
+  std::string spv_errors;
+
+  spv_target_env target_env = SPV_ENV_UNIVERSAL_1_0;
+  if (!env.empty()) {
+    if (!spvParseTargetEnv(env.c_str(), &target_env))
+      return "";
+  }
+
+  auto msg_consumer = [&spv_errors](spv_message_level_t level, const char*,
+                                    const spv_position_t& position,
+                                    const char* message) {
+    switch (level) {
+      case SPV_MSG_FATAL:
+      case SPV_MSG_INTERNAL_ERROR:
+      case SPV_MSG_ERROR:
+        spv_errors += "error: line " + std::to_string(position.index) + ": " +
+                      message + "\n";
+        break;
+      case SPV_MSG_WARNING:
+        spv_errors += "warning: line " + std::to_string(position.index) + ": " +
+                      message + "\n";
+        break;
+      case SPV_MSG_INFO:
+        spv_errors += "info: line " + std::to_string(position.index) + ": " +
+                      message + "\n";
+        break;
+      case SPV_MSG_DEBUG:
+        break;
+    }
+  };
+
+  spvtools::SpirvTools tools(target_env);
+  tools.SetMessageConsumer(msg_consumer);
+
+  std::string result;
+  tools.Disassemble(data, &result,
+      SPV_BINARY_TO_TEXT_OPTION_INDENT |
+      SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
+  return result;
+#else
+  return "";
+#endif  // AMBER_ENABLE_SPIRV_TOOLS
+}
+
 }  // namespace
 
 int main(int argc, const char** argv) {
@@ -478,6 +537,26 @@ int main(int argc, const char** argv) {
       failures.push_back(file);
       // Note, we continue after failure to allow dumping the buffers which may
       // give clues as to the failure.
+    }
+
+    // Dump the shader assembly
+    if (!options.shader_filename.empty()) {
+#if AMBER_ENABLE_SPIRV_TOOLS
+      std::ofstream shader_file;
+      shader_file.open(options.shader_filename, std::ios::out);
+      if (!shader_file.is_open()) {
+        std::cerr << "Cannot open file for shader dump: ";
+        std::cerr << options.shader_filename << std::endl;
+      } else {
+        auto info = recipe->GetShaderInfo();
+        for (const auto& sh : info) {
+          shader_file << ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;" << std::endl;
+          shader_file << "; " << sh.shader_name << std::endl << ";" << std::endl;
+          shader_file << disassemble(options.spv_env, sh.shader_data) << std::endl;
+        }
+        shader_file.close();
+      }
+#endif  // AMBER_ENABLE_SPIRV_TOOLS
     }
 
     for (size_t i = 0; i < options.image_filenames.size(); ++i) {

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -182,6 +182,15 @@ class Pipeline {
   /// Returns information on all bound shaders in this pipeline.
   const std::vector<ShaderInfo>& GetShaders() const { return shaders_; }
 
+  /// Returns the ShaderInfo for |shader| or nullptr.
+  const ShaderInfo* GetShader(Shader* shader) const {
+    for (const auto& info : shaders_) {
+      if (info.GetShader() == shader)
+        return &info;
+    }
+    return nullptr;
+  }
+
   /// Sets the |type| of |shader| in the pipeline.
   Result SetShaderType(const Shader* shader, ShaderType type);
   /// Sets the entry point |name| for |shader| in this pipeline.

--- a/src/script.cc
+++ b/src/script.cc
@@ -31,12 +31,10 @@ std::vector<ShaderInfo> Script::GetShaderInfo() const {
     for (const auto& pipeline : pipelines_) {
       auto shader_info = pipeline->GetShader(shader.get());
       if (shader_info) {
-        ret.emplace_back(ShaderInfo{shader->GetFormat(),
-                                  shader->GetType(),
-                                  pipeline->GetName() + "-" + shader->GetName(),
-                                  shader->GetData(),
-                                  shader_info->GetShaderOptimizations(),
-                                  shader_info->GetData()});
+        ret.emplace_back(ShaderInfo{
+            shader->GetFormat(), shader->GetType(),
+            pipeline->GetName() + "-" + shader->GetName(), shader->GetData(),
+            shader_info->GetShaderOptimizations(), shader_info->GetData()});
 
         in_pipeline = true;
       }
@@ -47,7 +45,8 @@ std::vector<ShaderInfo> Script::GetShaderInfo() const {
                                   shader->GetType(),
                                   shader->GetName(),
                                   shader->GetData(),
-                                  {}, {}});
+                                  {},
+                                  {}});
     }
   }
   return ret;

--- a/src/script.cc
+++ b/src/script.cc
@@ -25,17 +25,30 @@ Script::~Script() = default;
 std::vector<ShaderInfo> Script::GetShaderInfo() const {
   std::vector<ShaderInfo> ret;
   for (const auto& shader : shaders_) {
-    // TODO(dsinclair): The name returned should be the
-    // `pipeline_name + shader_name` instead of just shader name when we have
-    // pipelines everywhere
+    bool in_pipeline = false;
+    // A given shader could be in multiple pipelines with different
+    // optimizations so make sure we check and report all pipelines.
+    for (const auto& pipeline : pipelines_) {
+      auto shader_info = pipeline->GetShader(shader.get());
+      if (shader_info) {
+        ret.emplace_back(ShaderInfo{shader->GetFormat(),
+                                  shader->GetType(),
+                                  pipeline->GetName() + "-" + shader->GetName(),
+                                  shader->GetData(),
+                                  shader_info->GetShaderOptimizations(),
+                                  shader_info->GetData()});
 
-    // TODO(dsinclair): The optimization passes should be retrieved from the
-    // pipeline and returned here instead of an empty array.
-    ret.emplace_back(ShaderInfo{shader->GetFormat(),
-                                shader->GetType(),
-                                shader->GetName(),
-                                shader->GetData(),
-                                {}});
+        in_pipeline = true;
+      }
+    }
+
+    if (!in_pipeline) {
+      ret.emplace_back(ShaderInfo{shader->GetFormat(),
+                                  shader->GetType(),
+                                  shader->GetName(),
+                                  shader->GetData(),
+                                  {}, {}});
+    }
   }
   return ret;
 }

--- a/src/shader.h
+++ b/src/shader.h
@@ -36,9 +36,9 @@ class Shader {
   void SetFormat(ShaderFormat fmt) { shader_format_ = fmt; }
   ShaderFormat GetFormat() const { return shader_format_; }
 
-  /// Sets the compiled shader to |data|.
+  /// Sets the source shader to |data|.
   void SetData(const std::string& data) { data_ = data; }
-  /// Returns the compiled shader source.
+  /// Returns the source shader source.
   const std::string& GetData() const { return data_; }
 
  private:


### PR DESCRIPTION
If the shader is compiled by Amber, the compiled shader data will now be
returned when querying for shader information. This allows adding a flag
'-w <filename>' to the amber sample program to dump the SPIR-V
disassembly of the compiled shaders to a file.

This also fixes up the shader name and optimization pass return values
in the shader_info to hold the correct information based on pipeline.