### PR TITLE
[run_tests] Only print output if not suppressed.

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -186,8 +186,8 @@ class TestRunner:
         return False
 
     except Exception as e:
-      print e.output
       if not tc.IsExpectedFail() and not tc.IsSuppressed():
+        print e.output
         print e
       return False
 


### PR DESCRIPTION
Currently the test output is always emitted. This is confusing when the
test is suppressed. This CL only outputs the command results if the
script is not suppressed and not expected to fail.