### PR TITLE
Rolling 6 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -15,15 +15,15 @@ vars = {
   'cpplint_revision': '26470f9ccb354ff2f6d098f831271a1833701b28',
   'dxc_revision': '815358229dc74a43f57905cbf10fd805ab26c049',
   'glslang_revision': '38b4db48f98c4e3a9cc405de3a76547b857e1c37',
-  'googletest_revision': '679bfec6db73c021b0226e386c65ec1baee7a09f',
+  'googletest_revision': '34e92be31cf457ad4054b7908ee5e0e214dbcddc',
   'lodepng_revision': 'dc3f19b5aeaa26ff94f48f52a1c7cb5b1ef4ed3c',
-  'shaderc_revision': 'ff260580c07e8f9eae471b3d02dd2fe589c73198',
+  'shaderc_revision': '1d6155d8679a7775f7323cbb356cfd9e63400256',
   'spirv_headers_revision': '204cd131c42b90d129073719f2766293ce35c081',
-  'spirv_tools_revision': '85f3e93d13f32d45bd7f9999aa51baddf2452aae',
-  'swiftshader_revision': '663dcefa22ea5eec1b108feebaf40a683fb104ff',
+  'spirv_tools_revision': '52e9cc93016445b6e6b567d7cd696b23570b2513',
+  'swiftshader_revision': '8a6dcf76315ca1bd7268cbdb82124dfae90b8237',
   'vulkan_headers_revision': '2b89fd4e2734b728ca0be72a13f2265c5f5aa88e',
-  'vulkan_validationlayers_revision': '8c954d5a413d4fa724c0c3a6c8e37a7132c68e72',
-  'vulkan_loader_revision': 'fc962d08075e295cb563ce586f0c94c815c4e847',
+  'vulkan_validationlayers_revision': '567954684ca522ced3cae4c1ef03f1e5281238c3',
+  'vulkan_loader_revision': '2d6f74c6d4319e94cf1fa33954c619ab4428f2b8',
 }
 
 deps = {


### PR DESCRIPTION
Roll third_party/googletest/ 679bfec6d..34e92be31 (10 commits)

https://github.com/google/googletest/compare/679bfec6db73...34e92be31cf4

$ git log 679bfec6d..34e92be31 --date=short --no-merges --format='%ad %ae %s'
2019-11-26 absl-team Googletest export
2019-11-25 absl-team Googletest export
2019-11-25 mate.pek README.md: added Catch2 and Google Test Explorer
2019-11-17 krystian.kuzniarek unify googletest and googlemock main functions
2019-11-17 krystian.kuzniarek remove MSVC workaround: wmain link error in the static library
2019-11-22 krystian.kuzniarek remove Nokia's Symbian compiler workaround: SafeMatcherCastImpl
2019-11-22 krystian.kuzniarek consistency fix for SafeMatcherCastImpl member functions
2019-11-14 krystian.kuzniarek remove MSVC workaround: accessing namespace scope from within nested classes
2019-11-22 krystian.kuzniarek remove g++ 3.3 workaround: using on operator<<
2019-11-05 krystian.kuzniarek change incorrect comments

Roll third_party/shaderc/ ff260580c..1d6155d86 (4 commits)

https://github.com/google/shaderc/compare/ff260580c07e...1d6155d8679a

$ git log ff260580c..1d6155d86 --date=short --no-merges --format='%ad %ae %s'
2019-11-27 rharrison Moving spirv-cross dep from Dawn into shaderc (#911)
2019-11-26 rharrison Disable shaderc library target in BUILD.gn (#910)
2019-11-26 9856269+sarahM0 spvc: Fix spvc_spirv_cross_spvc_parser_tests failure by updating known_spvc_filures (#909)
2019-11-26 rharrison Rolling 5 dependencies (#908)

Roll third_party/spirv-tools/ 85f3e93d1..52e9cc930 (7 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/85f3e93d13f3...52e9cc930164

$ git log 85f3e93d1..52e9cc930 --date=short --no-merges --format='%ad %ae %s'
2019-11-27 afdx spirv-fuzz: Improve debugging facilities (#3074)
2019-11-27 stevenperron Handle unreachable block when computing register pressure (#3070)
2019-11-27 greg Improve RegisterSizePasses (#3059)
2019-11-26 headlessclayton utils/vscode: Add install.bat (#3071)
2019-11-26 52076061+digit-google build: cmake: Add support for Fuchsia. (#3062)
2019-11-26 dneto Add test with explicit example of stripping reflection info (#3064)
2019-11-26 9856269+sarahM0 Permit the debug instructions in WebGPU SPIR-V (#3063)

Roll third_party/swiftshader/ 663dcefa2..8a6dcf763 (3 commits)

https://swiftshader.googlesource.com/SwiftShader.git/+log/663dcefa22ea..8a6dcf76315c

$ git log 663dcefa2..8a6dcf763 --date=short --no-merges --format='%ad %ae %s'
2019-11-26 sugoi Support sample image instruction operand
2019-11-27 jmadill Fix ICD build when using multiple toolchains.
2019-11-26 chrisforbes gles: Only clamp default block uniform indexes

Roll third_party/vulkan-loader/ fc962d080..2d6f74c6d (2 commits)

https://github.com/KhronosGroup/Vulkan-Loader/compare/fc962d08075e...2d6f74c6d431

$ git log fc962d080..2d6f74c6d --date=short --no-merges --format='%ad %ae %s'
2019-11-27 tobine build:Add def file for Windows GN build
2019-11-26 shannon build: Update known-good for 1.1.129 header

Roll third_party/vulkan-validationlayers/ 8c954d5a4..567954684 (2 commits)

https://github.com/KhronosGroup/Vulkan-ValidationLayers/compare/8c954d5a413d...567954684ca5

$ git log 8c954d5a4..567954684 --date=short --no-merges --format='%ad %ae %s'
2019-11-22 digit+github build: Fix Vulkan headers detection with CMake
2019-11-25 jbolz layers: Remove MemTrack-FreedMemRef that has moved to best_practices

Created with:
  roll-dep third_party/dxc third_party/glslang third_party/googletest third_party/lodepng third_party/shaderc third_party/spirv-headers third_party/spirv-tools third_party/swiftshader third_party/vulkan-headers third_party/vulkan-loader third_party/vulkan-validationlayers