### PR TITLE
Opencl images and samplers

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,10 +8,8 @@ vars = {
   'swiftshader_git': 'https://swiftshader.googlesource.com',
   'microsoft_git': 'https://github.com/Microsoft',
 
-  'clspv_llvm_revision': '97aa42f5dfcd10ca6df230caf9ca7868da5f25af',
-  'clspv_revision': '8132fc9122f7709149dd82b25283e244bbe666a6',
-  'clspv_llvm_revision': '6ba5cbf3ea2315acf1b7f1c39c6fec6cca5560ca',
-  'clspv_revision': 'f26dac9ae5d6fab98ca027a26e375937074770cf',
+  'clspv_llvm_revision': 'e74b326b1f506538f1fce11b7a70bcf7fb9b573c',
+  'clspv_revision': 'f67468c36e682178d1b441e3a65e219f034805ba',
   'cpplint_revision': '26470f9ccb354ff2f6d098f831271a1833701b28',
   'dxc_revision': '815358229dc74a43f57905cbf10fd805ab26c049',
   'glslang_revision': '38b4db48f98c4e3a9cc405de3a76547b857e1c37',

--- a/docs/amber_script.md
+++ b/docs/amber_script.md
@@ -135,7 +135,7 @@ BUFFER {name} DATA_TYPE {type} {STD140 | STD430} SIZE _size_in_items_ \
     {initializer}
 
 # Defines a buffer with width and height and filled by data as specified by the
-`initializer`.
+# `initializer`.
 BUFFER {name} DATA_TYPE {type} {STD140|STD430} WIDTH {w} HEIGHT {h} \
     {initializer}
 

--- a/docs/amber_script.md
+++ b/docs/amber_script.md
@@ -134,6 +134,11 @@ END
 BUFFER {name} DATA_TYPE {type} {STD140 | STD430} SIZE _size_in_items_ \
     {initializer}
 
+# Defines a buffer with width and height and filled by data as specified by the
+`initializer`.
+BUFFER {name} DATA_TYPE {type} {STD140|STD430} WIDTH {w} HEIGHT {h} \
+    {initializer}
+
 # Creates a buffer which will store the given `FORMAT` of data. These
 # buffers are used as image and depth buffers in the `PIPELINE` commands.
 # The buffer will be sized based on the `RENDER_SIZE` of the `PIPELINE`.
@@ -285,6 +290,13 @@ contain image attachment content, depth/stencil content, uniform buffers, etc.
   # type as appropriate for the argument buffer. All uses of the buffer
   # must have a consistent |buffer_type| across all pipelines.
   BIND BUFFER {buffer_name} [AS {buffer_type}] KERNEL ARG_NUMBER _number_
+
+  # Bind OpenCL argument sampler by argument name.
+  BIND SAMPLER {sampler_name} KERNEL ARG_NAME _name_
+
+  # Bind OpenCL argument sampler by argument ordinal. Arguments use 0-based
+  # numbering.
+  BIND SAMPLER {sampler_name} KERNEL ARG_NUMBER _number_
 ```
 
 ```groovy

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -833,9 +833,6 @@ Result Parser::ParsePipelineBind(Pipeline* pipeline) {
       return Result("expected a string token for BIND command");
 
     if (token->AsString() == "DESCRIPTOR_SET") {
-      if (!token->IsString() || token->AsString() != "DESCRIPTOR_SET")
-        return Result("missing DESCRIPTOR_SET for BIND command");
-
       token = tokenizer_->NextToken();
       if (!token->IsInteger())
         return Result("invalid value for DESCRIPTOR_SET in BIND command");

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -20,7 +20,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include <iostream>
 
 #include "src/make_unique.h"
 #include "src/sampler.h"
@@ -1146,8 +1145,6 @@ Result Parser::ParseBuffer() {
   }
   buffer->SetName(name);
 
-  std::cout << "Buffer " << buffer->GetName() << " ele count: " << buffer->ElementCount() << "\n";
-  std::cout << "Buffer " << buffer->GetName() << " value count: " << buffer->ValueCount() << "\n";
   Result r = script_->AddBuffer(std::move(buffer));
   if (!r.IsSuccess())
     return r;

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -1191,6 +1191,35 @@ Result Parser::ParseBufferInitializer(Buffer* buffer) {
 
   if (token->AsString() == "SIZE")
     return ParseBufferInitializerSize(buffer);
+  if (token->AsString() == "WIDTH") {
+    token = tokenizer_->NextToken();
+    if (!token->IsInteger())
+      return Result("expected an integer for WIDTH");
+    const uint32_t width = token->AsUint32();
+    if (width == 0)
+      return Result("expected WIDTH to be positive");
+    buffer->SetWidth(width);
+
+    token = tokenizer_->NextToken();
+    if (token->AsString() != "HEIGHT")
+      return Result("BUFFER HEIGHT missing");
+    token = tokenizer_->NextToken();
+    if (!token->IsInteger())
+      return Result("expected an integer for HEIGHT");
+    const uint32_t height = token->AsUint32();
+    if (height == 0)
+      return Result("expected HEIGHT to be positive");
+    buffer->SetHeight(height);
+
+    token = tokenizer_->NextToken();
+    uint32_t size_in_items = width * height;
+    buffer->SetElementCount(size_in_items);
+    if (token->AsString() == "FILL")
+      return ParseBufferInitializerFill(buffer, size_in_items);
+    if (token->AsString() == "SERIES_FROM")
+      return ParseBufferInitializerSeries(buffer, size_in_items);
+    return {};
+  }
   if (token->AsString() == "DATA")
     return ParseBufferInitializerData(buffer);
 

--- a/src/amberscript/parser_bind_test.cc
+++ b/src/amberscript/parser_bind_test.cc
@@ -1325,6 +1325,139 @@ END)";
   EXPECT_EQ("9: expected argument number", r.Error());
 }
 
+TEST_F(AmberScriptParserTest, BindSamplerOpenCLMissingKernel) {
+  std::string in = R"(
+SHADER compute my_shader OPENCL-C
+#shader
+END
+SAMPLER s
+
+PIPELINE compute my_pipeline
+  ATTACH my_shader
+  BIND SAMPLER s
+END
+)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("10: expected a string token for BIND command", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, BindSamplerOpenCLInvalidKernel) {
+  std::string in = R"(
+SHADER compute my_shader OPENCL-C
+#shader
+END
+SAMPLER s
+
+PIPELINE compute my_pipeline
+  ATTACH my_shader
+  BIND SAMPLER s INVALID
+END
+)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("9: missing DESCRIPTOR_SET or KERNEL for BIND command", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, BindSamplerOpenCLMissingArgument) {
+  std::string in = R"(
+SHADER compute my_shader OPENCL-C
+#shader
+END
+SAMPLER s
+
+PIPELINE compute my_pipeline
+  ATTACH my_shader
+  BIND SAMPLER s KERNEL
+END
+)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("10: missing kernel arg identifier", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, BindSamplerOpenCLMissingArgumentName) {
+  std::string in = R"(
+SHADER compute my_shader OPENCL-C
+#shader
+END
+SAMPLER s
+
+PIPELINE compute my_pipeline
+  ATTACH my_shader
+  BIND SAMPLER s KERNEL ARG_NAME
+END
+)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("10: expected argument identifier", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, BindSamplerOpenCLArgumentNameNotString) {
+  std::string in = R"(
+SHADER compute my_shader OPENCL-C
+#shader
+END
+SAMPLER s
+
+PIPELINE compute my_pipeline
+  ATTACH my_shader
+  BIND SAMPLER s KERNEL ARG_NAME 0
+END
+)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("9: expected argument identifier", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, BindSamplerOpenCLMissingArgumentNumber) {
+  std::string in = R"(
+SHADER compute my_shader OPENCL-C
+#shader
+END
+SAMPLER s
+
+PIPELINE compute my_pipeline
+  ATTACH my_shader
+  BIND SAMPLER s KERNEL ARG_NUMBER
+END
+)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("10: expected argument number", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, BindSamplerOpenCLArgumentNumberNotInteger) {
+  std::string in = R"(
+SHADER compute my_shader OPENCL-C
+#shader
+END
+SAMPLER s
+
+PIPELINE compute my_pipeline
+  ATTACH my_shader
+  BIND SAMPLER s KERNEL ARG_NUMBER a
+END
+)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("9: expected argument number", r.Error());
+}
+
 TEST_F(AmberScriptParserTest, BindBufferStorageImageCompute) {
   std::string in = R"(
 SHADER compute compute_shader GLSL
@@ -1808,7 +1941,7 @@ END)";
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("12: missing DESCRIPTOR_SET for BIND command", r.Error());
+  EXPECT_EQ("12: missing DESCRIPTOR_SET or KERNEL for BIND command", r.Error());
 }
 
 TEST_F(AmberScriptParserTest, BindSamplerMissingBindingValue) {

--- a/src/amberscript/parser_buffer_test.cc
+++ b/src/amberscript/parser_buffer_test.cc
@@ -962,5 +962,81 @@ END)";
   EXPECT_FLOAT_EQ(220, *reinterpret_cast<const float*>(data + 24));
 }
 
+TEST_F(AmberScriptParserTest, InvalidBufferWidth) {
+  std::string in = R"(
+BUFFER buf DATA_TYPE vec4<float> WIDTH a
+)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("2: expected an integer for WIDTH", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, ZeroBufferWidth) {
+  std::string in = R"(
+BUFFER buf DATA_TYPE vec4<float> WIDTH 0
+)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("2: expected WIDTH to be positive", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, MissingBufferHeight) {
+  std::string in = R"(
+BUFFER buf DATA_TYPE vec4<float> WIDTH 1
+)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("3: BUFFER HEIGHT missing", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, InvalidBufferHeight) {
+  std::string in = R"(
+BUFFER buf DATA_TYPE vec4<float> WIDTH 1 HEIGHT 1.0
+)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("2: expected an integer for HEIGHT", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, ZeroBufferHeight) {
+  std::string in = R"(
+BUFFER buf DATA_TYPE vec4<float> WIDTH 1 HEIGHT 0
+)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("2: expected HEIGHT to be positive", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, BufferWidthAndHeight) {
+  std::string in = R"(
+BUFFER buf DATA_TYPE vec4<float> WIDTH 2 HEIGHT 3
+)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_TRUE(r.IsSuccess());
+
+  auto script = parser.GetScript();
+  const auto& buffers = script->GetBuffers();
+  ASSERT_EQ(1U, buffers.size());
+  ASSERT_TRUE(buffers[0] != nullptr);
+  EXPECT_EQ("buf", buffers[0]->GetName());
+
+  auto* buffer = buffers[0].get();
+  EXPECT_EQ(2, buffer->GetWidth());
+  EXPECT_EQ(3, buffer->GetHeight());
+  EXPECT_EQ(6, buffer->ElementCount());
+}
+
 }  // namespace amberscript
 }  // namespace amber

--- a/src/clspv_helper.cc
+++ b/src/clspv_helper.cc
@@ -63,6 +63,18 @@ Result Compile(Pipeline::ShaderInfo* shader_info,
         descriptor_entry.kind =
             Pipeline::ShaderInfo::DescriptorMapEntry::Kind::POD_UBO;
         break;
+      case clspv::ArgKind::ReadOnlyImage:
+        descriptor_entry.kind =
+            Pipeline::ShaderInfo::DescriptorMapEntry::Kind::RO_IMAGE;
+        break;
+      case clspv::ArgKind::WriteOnlyImage:
+        descriptor_entry.kind =
+            Pipeline::ShaderInfo::DescriptorMapEntry::Kind::WO_IMAGE;
+        break;
+      case clspv::ArgKind::Sampler:
+        descriptor_entry.kind =
+            Pipeline::ShaderInfo::DescriptorMapEntry::Kind::SAMPLER;
+        break;
       case clspv::ArgKind::Local:
         // Local arguments are handled via specialization constants.
         break;

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -424,8 +424,7 @@ void Pipeline::AddSampler(Sampler* sampler,
   info.binding = binding;
 }
 
-void Pipeline::AddSampler(Sampler* sampler,
-                          const std::string& arg_name) {
+void Pipeline::AddSampler(Sampler* sampler, const std::string& arg_name) {
   for (auto& info : samplers_) {
     if (info.arg_name == arg_name) {
       info.sampler = sampler;
@@ -442,8 +441,7 @@ void Pipeline::AddSampler(Sampler* sampler,
   info.arg_no = std::numeric_limits<uint32_t>::max();
 }
 
-void Pipeline::AddSampler(Sampler* sampler,
-                          uint32_t arg_no) {
+void Pipeline::AddSampler(Sampler* sampler, uint32_t arg_no) {
   for (auto& info : samplers_) {
     if (info.arg_no == arg_no) {
       info.sampler = sampler;
@@ -481,8 +479,9 @@ Result Pipeline::UpdateOpenCLBufferBindings() {
         if (entry.arg_name == info.arg_name ||
             entry.arg_ordinal == info.arg_no) {
           if (entry.kind !=
-              Pipeline::ShaderInfo::DescriptorMapEntry::Kind::SAMPLER)
+              Pipeline::ShaderInfo::DescriptorMapEntry::Kind::SAMPLER) {
             return Result("Sampler bound to non-sampler kernel arg");
+          }
           info.descriptor_set = entry.descriptor_set;
           info.binding = entry.binding;
         }
@@ -535,14 +534,16 @@ Result Pipeline::UpdateOpenCLBufferBindings() {
             }
           } else if (info.type == BufferType::kSampledImage) {
             if (entry.kind !=
-                Pipeline::ShaderInfo::DescriptorMapEntry::Kind::RO_IMAGE)
+                Pipeline::ShaderInfo::DescriptorMapEntry::Kind::RO_IMAGE) {
               return Result("Buffer " + info.buffer->GetName() +
                             " must be a read-only image binding");
+            }
           } else if (info.type == BufferType::kStorageImage) {
             if (entry.kind !=
-                Pipeline::ShaderInfo::DescriptorMapEntry::Kind::WO_IMAGE)
+                Pipeline::ShaderInfo::DescriptorMapEntry::Kind::WO_IMAGE) {
               return Result("Buffer " + info.buffer->GetName() +
                             " must be a write-only image binding");
+            }
           } else {
             return Result("Unhandled buffer type for OPENCL-C shader");
           }

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -90,6 +90,9 @@ class Pipeline {
         UBO,
         POD,
         POD_UBO,
+        RO_IMAGE,
+        WO_IMAGE,
+        SAMPLER,
       } kind;
 
       uint32_t descriptor_set = 0;
@@ -145,6 +148,8 @@ class Pipeline {
     Sampler* sampler = nullptr;
     uint32_t descriptor_set = 0;
     uint32_t binding = 0;
+    std::string arg_name = "";
+    uint32_t arg_no = 0;
   };
 
   static const char* kGeneratedColorBuffer;
@@ -248,6 +253,11 @@ class Pipeline {
   /// Adds |sampler| to the pipeline at the given |descriptor_set| and
   /// |binding|.
   void AddSampler(Sampler* sampler, uint32_t descriptor_set, uint32_t binding);
+  /// Adds |sampler| to the pipeline at the given |arg_name|.
+  void AddSampler(Sampler* sampler, const std::string& arg_name);
+  /// Adds |sampler| to the pieline at the given |arg_no|.
+  void AddSampler(Sampler* sampler, uint32_t arg_no);
+
   /// Returns information on all samplers in this pipeline.
   const std::vector<SamplerInfo>& GetSamplers() const { return samplers_; }
 

--- a/src/pipeline_test.cc
+++ b/src/pipeline_test.cc
@@ -481,6 +481,56 @@ TEST_F(PipelineTest, OpenCLUpdateBindingTypeMismatch) {
   EXPECT_EQ("Buffer buf2 must be a uniform binding", r.Error());
 }
 
+TEST_F(PipelineTest, OpenCLUpdateBindingImagesAndSamplers) {
+  Pipeline p(PipelineType::kCompute);
+  p.SetName("my_pipeline");
+
+  Shader cs(kShaderTypeCompute);
+  cs.SetFormat(kShaderFormatOpenCLC);
+  p.AddShader(&cs, kShaderTypeCompute);
+  p.SetShaderEntryPoint(&cs, "my_main");
+
+  Pipeline::ShaderInfo::DescriptorMapEntry entry1;
+  entry1.kind = Pipeline::ShaderInfo::DescriptorMapEntry::Kind::RO_IMAGE;
+  entry1.descriptor_set = 4;
+  entry1.binding = 5;
+  entry1.arg_name = "arg_a";
+  entry1.arg_ordinal = 0;
+  p.GetShaders()[0].AddDescriptorEntry("my_main", std::move(entry1));
+
+  Pipeline::ShaderInfo::DescriptorMapEntry entry2;
+  entry2.kind = Pipeline::ShaderInfo::DescriptorMapEntry::Kind::WO_IMAGE;
+  entry2.descriptor_set = 3;
+  entry2.binding = 1;
+  entry2.arg_name = "arg_b";
+  entry2.arg_ordinal = 1;
+  p.GetShaders()[0].AddDescriptorEntry("my_main", std::move(entry2));
+
+  Pipeline::ShaderInfo::DescriptorMapEntry entry3;
+  entry2.kind = Pipeline::ShaderInfo::DescriptorMapEntry::Kind::SAMPLER;
+  entry2.descriptor_set = 3;
+  entry2.binding = 2;
+  entry2.arg_name = "arg_c";
+  entry2.arg_ordinal = 2;
+  p.GetShaders()[0].AddDescriptorEntry("my_main", std::move(entry2));
+
+  auto a_buf = MakeUnique<Buffer>();
+  a_buf->SetName("buf1");
+  p.AddBuffer(a_buf.get(), BufferType::kSampledImage, "arg_a");
+
+  auto b_buf = MakeUnique<Buffer>();
+  b_buf->SetName("buf2");
+  p.AddBuffer(b_buf.get(), BufferType::kStorageImage, 1);
+
+  auto s = MakeUnique<Sampler>();
+  s->SetName("samp");
+  p.AddSampler(s.get(), "arg_c");
+
+  auto r = p.UpdateOpenCLBufferBindings();
+
+  ASSERT_TRUE(r.IsSuccess());
+}
+
 TEST_F(PipelineTest, OpenCLGeneratePodBuffers) {
   Pipeline p(PipelineType::kCompute);
   p.SetName("my_pipeline");

--- a/src/shader_compiler_test.cc
+++ b/src/shader_compiler_test.cc
@@ -404,11 +404,14 @@ kernel void TestShader(read_only image2d_t ro_image, write_only image2d_t wo_ima
   auto iter = shader_info1.GetDescriptorMap().find("TestShader");
   for (const auto& entry : iter->second) {
     if (entry.binding == 0) {
-      EXPECT_EQ(entry.kind, Pipeline::ShaderInfo::DescriptorMapEntry::Kind::RO_IMAGE);
+      EXPECT_EQ(entry.kind,
+                Pipeline::ShaderInfo::DescriptorMapEntry::Kind::RO_IMAGE);
     } else if (entry.binding == 1) {
-      EXPECT_EQ(entry.kind, Pipeline::ShaderInfo::DescriptorMapEntry::Kind::WO_IMAGE);
+      EXPECT_EQ(entry.kind,
+                Pipeline::ShaderInfo::DescriptorMapEntry::Kind::WO_IMAGE);
     } else if (entry.binding == 2) {
-      EXPECT_EQ(entry.kind, Pipeline::ShaderInfo::DescriptorMapEntry::Kind::SAMPLER);
+      EXPECT_EQ(entry.kind,
+                Pipeline::ShaderInfo::DescriptorMapEntry::Kind::SAMPLER);
     } else {
       ASSERT_TRUE(false);
     }

--- a/src/shader_compiler_test.cc
+++ b/src/shader_compiler_test.cc
@@ -378,6 +378,42 @@ kernel void TestShader(global int* in, global int* out, int m, int b) {
   EXPECT_EQ(2U, max_binding);
   EXPECT_TRUE(has_pod_ubo);
 }
+
+TEST_F(ShaderCompilerTest, ClspvImagesAndSamplers) {
+  std::string data = R"(
+kernel void TestShader(read_only image2d_t ro_image, write_only image2d_t wo_image, sampler_t sampler) {
+  int2 coord = (int2)(0, 0);
+  float4 texel = read_imagef(ro_image, sampler, coord);
+  write_imagef(wo_image, coord, texel);
+}
+)";
+
+  Shader shader(kShaderTypeCompute);
+  shader.SetName("TestShader");
+  shader.SetFormat(kShaderFormatOpenCLC);
+  shader.SetData(data);
+
+  ShaderCompiler sc;
+  Result r;
+  std::vector<uint32_t> binary;
+  Pipeline::ShaderInfo shader_info1(&shader, kShaderTypeCompute);
+  std::tie(r, binary) = sc.Compile(&shader_info1, ShaderMap());
+  ASSERT_TRUE(r.IsSuccess());
+  EXPECT_FALSE(binary.empty());
+  EXPECT_EQ(0x07230203, binary[0]);  // Verify SPIR-V header present.
+  auto iter = shader_info1.GetDescriptorMap().find("TestShader");
+  for (const auto& entry : iter->second) {
+    if (entry.binding == 0) {
+      EXPECT_EQ(entry.kind, Pipeline::ShaderInfo::DescriptorMapEntry::Kind::RO_IMAGE);
+    } else if (entry.binding == 1) {
+      EXPECT_EQ(entry.kind, Pipeline::ShaderInfo::DescriptorMapEntry::Kind::WO_IMAGE);
+    } else if (entry.binding == 2) {
+      EXPECT_EQ(entry.kind, Pipeline::ShaderInfo::DescriptorMapEntry::Kind::SAMPLER);
+    } else {
+      ASSERT_TRUE(false);
+    }
+  }
+}
 #endif  // AMBER_ENABLE_CLSPV
 
 struct ParseSpvEnvCase {

--- a/src/vulkan/resource.cc
+++ b/src/vulkan/resource.cc
@@ -16,6 +16,7 @@
 
 #include <cstring>
 #include <limits>
+#include <iostream>
 
 #include "src/vulkan/command_buffer.h"
 #include "src/vulkan/device.h"
@@ -61,6 +62,7 @@ Result Resource::CreateVkBuffer(VkBuffer* buffer, VkBufferUsageFlags usage) {
   buffer_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
   buffer_info.size = size_in_bytes_;
   buffer_info.usage = usage;
+  std::cout << "Creating buffer with " << size_in_bytes_ << " bytes\n";
 
   if (device_->GetPtrs()->vkCreateBuffer(device_->GetVkDevice(), &buffer_info,
                                          nullptr, buffer) != VK_SUCCESS) {

--- a/src/vulkan/resource.cc
+++ b/src/vulkan/resource.cc
@@ -16,7 +16,6 @@
 
 #include <cstring>
 #include <limits>
-#include <iostream>
 
 #include "src/vulkan/command_buffer.h"
 #include "src/vulkan/device.h"
@@ -62,7 +61,6 @@ Result Resource::CreateVkBuffer(VkBuffer* buffer, VkBufferUsageFlags usage) {
   buffer_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
   buffer_info.size = size_in_bytes_;
   buffer_info.usage = usage;
-  std::cout << "Creating buffer with " << size_in_bytes_ << " bytes\n";
 
   if (device_->GetPtrs()->vkCreateBuffer(device_->GetVkDevice(), &buffer_info,
                                          nullptr, buffer) != VK_SUCCESS) {

--- a/tests/cases/opencl_read_image.amber
+++ b/tests/cases/opencl_read_image.amber
@@ -1,0 +1,68 @@
+#!amber
+# Copyright 2019 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHADER vertex vs PASSTHROUGH
+
+SHADER fragment fs GLSL
+#version 430
+layout(location = 0) out vec4 color_out;
+void main() {
+  color_out = vec4(1.0, 0.0, 0.0, 1.0);
+}
+END
+
+SHADER compute read_imagef OPENCL-C
+kernel void foo(read_only image2d_t image, sampler_t sampler, global float4* out) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  float2 coord = (float2)(gid_x, gid_y);
+  out[linear] = read_imagef(image, sampler, coord);
+}
+END
+
+BUFFER texture DATA_TYPE vec4<float> SIZE 4 FILL 0.0
+BUFFER out_buf DATA_TYPE vec4<float> DATA
+2.0 2.0 2.0 2.0
+2.0 2.0 2.0 2.0
+2.0 2.0 2.0 2.0
+2.0 2.0 2.0 2.0
+END
+SAMPLER sampler
+
+PIPELINE compute read_pipe
+  ATTACH read_imagef ENTRY_POINT foo
+  BIND BUFFER out_buf KERNEL ARG_NAME out
+  BIND BUFFER texture KERNEL ARG_NAME image
+  BIND SAMPLER sampler KERNEL ARG_NAME sampler
+END
+
+PIPELINE graphics fill_red
+  ATTACH vs
+  ATTACH fs
+  FRAMEBUFFER_SIZE 2 2
+  BIND BUFFER texture AS color LOCATION 0
+END
+
+CLEAR_COLOR fill_red 0 0 3 3
+CLEAR fill_red
+RUN fill_red DRAW_RECT POS 0 0 SIZE 2 2
+
+RUN read_pipe 2 2 1
+
+EXPECT out_buf IDX 0  EQ 1.0 0.0 0.0 1.0
+EXPECT out_buf IDX 16 EQ 1.0 0.0 0.0 1.0
+EXPECT out_buf IDX 32 EQ 1.0 0.0 0.0 1.0
+EXPECT out_buf IDX 48 EQ 1.0 0.0 0.0 1.0

--- a/tests/cases/opencl_write_image.amber
+++ b/tests/cases/opencl_write_image.amber
@@ -1,0 +1,45 @@
+#!amber
+# Copyright 2019 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHADER compute write_imagef OPENCL-C
+kernel void foo(write_only image2d_t image, global float4* data) {
+  int gid_x = get_global_id(0);
+  int gid_y = get_global_id(1);
+  int linear = 2 * gid_y + gid_x;
+  int2 coord = (int2)(gid_x, gid_y);
+  write_imagef(image, coord, data[linear]);
+}
+END
+
+BUFFER texture DATA_TYPE vec4<float> WIDTH 2 HEIGHT 2 FILL 0.0
+BUFFER data DATA_TYPE vec4<float> DATA
+1.0 2.0 3.0 4.0
+2.0 3.0 4.0 1.0
+3.0 4.0 1.0 2.0
+4.0 1.0 2.0 3.0
+END
+
+PIPELINE compute read_pipe
+  ATTACH write_imagef ENTRY_POINT foo
+  BIND BUFFER data KERNEL ARG_NAME data
+  BIND BUFFER texture KERNEL ARG_NAME image
+END
+
+RUN read_pipe 2 2 1
+
+EXPECT texture IDX 0  EQ 1.0 2.0 3.0 4.0
+EXPECT texture IDX 16 EQ 2.0 3.0 4.0 1.0
+EXPECT texture IDX 32 EQ 3.0 4.0 1.0 2.0
+EXPECT texture IDX 48 EQ 4.0 1.0 2.0 3.0

--- a/tools/roll-all
+++ b/tools/roll-all
@@ -45,9 +45,6 @@ def roll_all_deps(deps_file_path):
 
   list_of_deps = ['roll-dep', '--ignore-dirty-tree']
   for directory in sorted(deps_file['deps']):
-    # Leave CLSPV to be rolled individually.
-    if directory == "third_party/clspv" or directory == "third_party/clspv-llvm":
-      continue
     # cpplint uses gh-pages as the main branch, not master which doesn't work
     # with roll-dep
     if directory == "third_party/cpplint":


### PR DESCRIPTION
Add support for images and samplers in OPENCL-C shaders. Also adds the ability to specify the buffer size in terms of width and height. Hooks up binding similarly to other buffers.

Updated docs.

Note: Swiftshader currently cannot support the opencl_write_image.amber test as it is missing a required capability.