### PR TITLE
Fix -V driver version info

### DIFF
--- a/samples/config_helper_vulkan.h
+++ b/samples/config_helper_vulkan.h
@@ -58,7 +58,8 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
       uint32_t engine_major,
       uint32_t engine_minor,
       std::vector<std::string> required_instance_extensions,
-      bool disable_validation_layer);
+      bool disable_validation_layer,
+      bool show_version_info);
 
   /// Create |vulkan_callback_| that reports validation layer errors
   /// via debugCallback() function in config_helper_vulkan.cc.
@@ -108,7 +109,7 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
   VkQueue vulkan_queue_ = VK_NULL_HANDLE;
   VkDevice vulkan_device_ = VK_NULL_HANDLE;
 
-  bool use_physical_device_features2_ = false;
+  bool supports_get_physical_device_properties2_ = false;
   VkPhysicalDeviceFeatures available_features_;
   VkPhysicalDeviceFeatures2KHR available_features2_;
   VkPhysicalDeviceVariablePointerFeaturesKHR variable_pointers_feature_;


### PR DESCRIPTION
We now request "VK_KHR_get_physical_device_properties2" when creating the Vulkan instance, if it is available and if "-V" is passed. We also now correctly get the address of the "vkGetPhysicalDeviceProperties2KHR" function (*with* the KHR suffix), as opposed to "vkGetPhysicalDeviceProperties2", which is only available in Vulkan 1.1.

Fix #735