### PR TITLE
Remove redundant return

### DIFF
--- a/src/executor_test.cc
+++ b/src/executor_test.cc
@@ -202,7 +202,7 @@ class VkScriptExecutorTest : public testing::Test {
     auto engine = MakeUnique<EngineStub>();
     engine->Initialize(nullptr, nullptr, features, instance_extensions,
                        device_extensions);
-    return std::move(engine);
+    return engine;
   }
   EngineStub* ToStub(Engine* engine) {
     return static_cast<EngineStub*>(engine);

--- a/src/executor_test.cc
+++ b/src/executor_test.cc
@@ -199,7 +199,7 @@ class VkScriptExecutorTest : public testing::Test {
       const std::vector<std::string>& features,
       const std::vector<std::string>& instance_extensions,
       const std::vector<std::string>& device_extensions) {
-    auto engine = MakeUnique<EngineStub>();
+    std::unique_ptr<Engine> engine = MakeUnique<EngineStub>();
     engine->Initialize(nullptr, nullptr, features, instance_extensions,
                        device_extensions);
     return engine;


### PR DESCRIPTION
This is being picked up by newer GCC and isn't required.

Fixes #737