### PR TITLE
Prefix pipeline name to shader name when searching shader map.

### DIFF
--- a/src/executor.cc
+++ b/src/executor.cc
@@ -39,7 +39,8 @@ Result Executor::CompileShaders(const amber::Script* script,
 
       Result r;
       std::vector<uint32_t> data;
-      std::tie(r, data) = sc.Compile(&shader_info, shader_map);
+      std::tie(r, data) =
+          sc.Compile(pipeline->GetName(), &shader_info, shader_map);
       if (!r.IsSuccess())
         return r;
 

--- a/src/shader_compiler.cc
+++ b/src/shader_compiler.cc
@@ -58,7 +58,11 @@ std::pair<Result, std::vector<uint32_t>> ShaderCompiler::Compile(
     Pipeline::ShaderInfo* shader_info,
     const ShaderMap& shader_map) const {
   const auto shader = shader_info->GetShader();
-  auto it = shader_map.find(pipeline_name + "-" + shader->GetName());
+  std::string key = shader->GetName();
+  if (pipeline_name != "") {
+    key = pipeline_name + "-" + key;
+  }
+  auto it = shader_map.find(key);
   if (it != shader_map.end()) {
 #if AMBER_ENABLE_CLSPV
     if (shader->GetFormat() == kShaderFormatOpenCLC) {

--- a/src/shader_compiler.cc
+++ b/src/shader_compiler.cc
@@ -54,10 +54,11 @@ ShaderCompiler::ShaderCompiler(const std::string& env,
 ShaderCompiler::~ShaderCompiler() = default;
 
 std::pair<Result, std::vector<uint32_t>> ShaderCompiler::Compile(
+    std::string pipeline_name,
     Pipeline::ShaderInfo* shader_info,
     const ShaderMap& shader_map) const {
   const auto shader = shader_info->GetShader();
-  auto it = shader_map.find(shader->GetName());
+  auto it = shader_map.find(pipeline_name + "-" + shader->GetName());
   if (it != shader_map.end()) {
 #if AMBER_ENABLE_CLSPV
     if (shader->GetFormat() == kShaderFormatOpenCLC) {

--- a/src/shader_compiler.h
+++ b/src/shader_compiler.h
@@ -41,7 +41,12 @@ class ShaderCompiler {
   /// If |shader_info| specifies shader optimizations to run and there is no
   /// entry in |shader_map| for that shader, then the SPIRV-Tools optimizer will
   /// be invoked to produce the shader binary.
+  ///
+  /// |pipeline_name| is prefixed to shader name to distinguish between
+  /// shaders used in multiple pipelines with different optimization
+  /// flags.
   std::pair<Result, std::vector<uint32_t>> Compile(
+      std::string pipeline_name,
       Pipeline::ShaderInfo* shader_info,
       const ShaderMap& shader_map) const;
 

--- a/src/shader_compiler_test.cc
+++ b/src/shader_compiler_test.cc
@@ -107,7 +107,7 @@ void main() {
   Result r;
   std::vector<uint32_t> binary;
   Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
-  std::tie(r, binary) = sc.Compile(&shader_info, ShaderMap());
+  std::tie(r, binary) = sc.Compile("", &shader_info, ShaderMap());
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
   EXPECT_FALSE(binary.empty());
   EXPECT_EQ(0x07230203, binary[0]);  // Verify SPIR-V header present.
@@ -125,7 +125,7 @@ TEST_F(ShaderCompilerTest, CompilesSpirvAsm) {
   Result r;
   std::vector<uint32_t> binary;
   Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
-  std::tie(r, binary) = sc.Compile(&shader_info, ShaderMap());
+  std::tie(r, binary) = sc.Compile("", &shader_info, ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   EXPECT_FALSE(binary.empty());
   EXPECT_EQ(0x07230203, binary[0]);  // Verify SPIR-V header present.
@@ -144,7 +144,7 @@ TEST_F(ShaderCompilerTest, InvalidSpirvHex) {
   Result r;
   std::vector<uint32_t> binary;
   Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
-  std::tie(r, binary) = sc.Compile(&shader_info, ShaderMap());
+  std::tie(r, binary) = sc.Compile("", &shader_info, ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("Invalid shader: error: line 0: Invalid SPIR-V magic number.\n",
             r.Error());
@@ -160,7 +160,7 @@ TEST_F(ShaderCompilerTest, InvalidHex) {
   Result r;
   std::vector<uint32_t> binary;
   Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
-  std::tie(r, binary) = sc.Compile(&shader_info, ShaderMap());
+  std::tie(r, binary) = sc.Compile("", &shader_info, ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("Invalid shader: error: line 0: Invalid SPIR-V magic number.\n",
             r.Error());
@@ -211,11 +211,11 @@ OpFunctionEnd
   ShaderCompiler sc;
   Result r;
   std::vector<uint32_t> unopt_binary;
-  std::tie(r, unopt_binary) = sc.Compile(&unoptimized, ShaderMap());
+  std::tie(r, unopt_binary) = sc.Compile("", &unoptimized, ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
 
   std::vector<uint32_t> opt_binary;
-  std::tie(r, opt_binary) = sc.Compile(&optimized, ShaderMap());
+  std::tie(r, opt_binary) = sc.Compile("", &optimized, ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   EXPECT_NE(opt_binary.size(), unopt_binary.size());
 }
@@ -231,7 +231,7 @@ TEST_F(ShaderCompilerTest, CompilesSpirvHex) {
   Result r;
   std::vector<uint32_t> binary;
   Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
-  std::tie(r, binary) = sc.Compile(&shader_info, ShaderMap());
+  std::tie(r, binary) = sc.Compile("", &shader_info, ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   EXPECT_FALSE(binary.empty());
   EXPECT_EQ(0x07230203, binary[0]);  // Verify SPIR-V header present.
@@ -249,7 +249,7 @@ TEST_F(ShaderCompilerTest, FailsOnInvalidShader) {
   Result r;
   std::vector<uint32_t> binary;
   Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
-  std::tie(r, binary) = sc.Compile(&shader_info, ShaderMap());
+  std::tie(r, binary) = sc.Compile("", &shader_info, ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
 }
 
@@ -259,6 +259,7 @@ TEST_F(ShaderCompilerTest, ReturnsCachedShader) {
   std::string contents = "Just Random\nText()\nThat doesn't work.";
 
   static const char kShaderName[] = "CachedShader";
+  static const char kShaderNameWithPipeline[] = "pipeline-CachedShader";
   Shader shader(kShaderTypeVertex);
   shader.SetName(kShaderName);
   shader.SetFormat(kShaderFormatGlsl);
@@ -267,13 +268,13 @@ TEST_F(ShaderCompilerTest, ReturnsCachedShader) {
   std::vector<uint32_t> src_bytes = {1, 2, 3, 4, 5};
 
   ShaderMap map;
-  map[kShaderName] = src_bytes;
+  map[kShaderNameWithPipeline] = src_bytes;
 
   ShaderCompiler sc;
   Result r;
   std::vector<uint32_t> binary;
   Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
-  std::tie(r, binary) = sc.Compile(&shader_info, map);
+  std::tie(r, binary) = sc.Compile("pipeline", &shader_info, map);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
   ASSERT_EQ(binary.size(), src_bytes.size());
@@ -297,7 +298,7 @@ kernel void TestShader(global int* in, global int* out) {
   Result r;
   std::vector<uint32_t> binary;
   Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
-  std::tie(r, binary) = sc.Compile(&shader_info, ShaderMap());
+  std::tie(r, binary) = sc.Compile("", &shader_info, ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   EXPECT_FALSE(binary.empty());
   EXPECT_EQ(0x07230203, binary[0]);  // Verify SPIR-V header present.
@@ -323,7 +324,7 @@ kernel void TestShader(global int* in, global int* out) {
   Result r;
   std::vector<uint32_t> binary;
   Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
-  std::tie(r, binary) = sc.Compile(&shader_info, map);
+  std::tie(r, binary) = sc.Compile("", &shader_info, map);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_TRUE(binary.empty());
 }
@@ -343,7 +344,7 @@ kernel void TestShader(global int* in, global int* out, int m, int b) {
   Result r;
   std::vector<uint32_t> binary;
   Pipeline::ShaderInfo shader_info1(&shader, kShaderTypeCompute);
-  std::tie(r, binary) = sc.Compile(&shader_info1, ShaderMap());
+  std::tie(r, binary) = sc.Compile("", &shader_info1, ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   EXPECT_FALSE(binary.empty());
   EXPECT_EQ(0x07230203, binary[0]);  // Verify SPIR-V header present.
@@ -362,7 +363,7 @@ kernel void TestShader(global int* in, global int* out, int m, int b) {
   binary.clear();
   Pipeline::ShaderInfo shader_info2(&shader, kShaderTypeCompute);
   shader_info2.SetCompileOptions({"-cluster-pod-kernel-args", "-pod-ubo"});
-  std::tie(r, binary) = sc.Compile(&shader_info2, ShaderMap());
+  std::tie(r, binary) = sc.Compile("", &shader_info2, ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   EXPECT_FALSE(binary.empty());
   EXPECT_EQ(0x07230203, binary[0]);  // Verify SPIR-V header present.
@@ -397,7 +398,7 @@ kernel void TestShader(read_only image2d_t ro_image, write_only image2d_t wo_ima
   Result r;
   std::vector<uint32_t> binary;
   Pipeline::ShaderInfo shader_info1(&shader, kShaderTypeCompute);
-  std::tie(r, binary) = sc.Compile(&shader_info1, ShaderMap());
+  std::tie(r, binary) = sc.Compile("", &shader_info1, ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   EXPECT_FALSE(binary.empty());
   EXPECT_EQ(0x07230203, binary[0]);  // Verify SPIR-V header present.


### PR DESCRIPTION
CTS amber integration was broken because of recent changes where shader names got pipeline name as prefix. Now the shader map is searched with that same prefix.