### PR TITLE
Don't checkout clspv and dxc deps by default

### DIFF
--- a/kokoro/linux-gcc-release-clspv/build.sh
+++ b/kokoro/linux-gcc-release-clspv/build.sh
@@ -17,4 +17,4 @@ set -e  # fail on error
 set -x  # display commands
 
 SCRIPT_DIR=`dirname "$BASH_SOURCE"`
-source $SCRIPT_DIR/../scripts/linux/build.sh RELEASE gcc -DAMBER_USE_CLSPV=ON
+source $SCRIPT_DIR/../scripts/linux/build.sh RELEASE gcc -DAMBER_USE_CLSPV=TRUE

--- a/kokoro/scripts/linux/build.sh
+++ b/kokoro/scripts/linux/build.sh
@@ -61,8 +61,15 @@ wget -q https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linu
 unzip -q ninja-linux.zip
 export PATH="$PWD:$PATH"
 
+DEPS_ARGS=
+if [[ "$EXTRA_CONFIG" =~ "USE_CLSPV=TRUE" ]]; then
+  DEPS_ARGS="--with-clspv"
+elif [[ "$EXTRA_CONFIG" =~ "USE_DXC=TRUE" ]]; then
+  DEPS_ARGS="--use-dxc"
+fi
+
 cd $SRC
-./tools/git-sync-deps
+./tools/git-sync-deps $DEPS_ARGS
 
 mkdir build && cd $SRC/build
 

--- a/tools/git-sync-deps
+++ b/tools/git-sync-deps
@@ -50,6 +50,7 @@ from builtins import bytes
 
 with_clspv = False
 with_dxc = False
+with_swiftshader = False
 
 def git_executable():
   """Find the git executable.
@@ -233,6 +234,9 @@ def git_sync_deps(deps_file_path, command_line_os_requests, verbose):
     if not with_dxc and 'dxc' in directory:
       continue
 
+    if not with_swiftshader and 'swiftshader' in directory:
+      continue
+
     relative_directory = os.path.join(deps_file_directory, directory)
 
     list_of_arg_lists.append(
@@ -271,6 +275,9 @@ def main(argv):
 
   if '--with-dxc' in argv:
     with_dxc = True
+
+  if '--with-swiftshader' in argv:
+    with_swiftshader = True
 
   git_sync_deps(deps_file_path, argv, verbose)
   # subprocess.check_call(

--- a/tools/git-sync-deps
+++ b/tools/git-sync-deps
@@ -18,6 +18,9 @@
 Args:
   An optional list of deps_os values.
 
+  --with-clspv Checkout clspv dependencies
+  --with-dxc   Checkout dxc dependencies
+
 Environment Variables:
   GIT_EXECUTABLE: path to "git" binary; if unset, will look for one of
   ['git', 'git.exe', 'git.bat'] in your default path.
@@ -37,7 +40,6 @@ Git Config:
       git config --unset sync-deps.disable
 """
 
-
 import os
 import re
 import subprocess
@@ -45,6 +47,8 @@ import sys
 import threading
 from builtins import bytes
 
+with_clspv = False
+with_dxc = False
 
 def git_executable():
   """Find the git executable.
@@ -222,6 +226,12 @@ def git_sync_deps(deps_file_path, command_line_os_requests, verbose):
     else:
       raise Exception("please specify commit or tag")
 
+    if not with_clspv and 'clspv' in directory:
+      continue
+
+    if not with_dxc and 'dxc' in directory:
+      continue
+
     relative_directory = os.path.join(deps_file_directory, directory)
 
     list_of_arg_lists.append(
@@ -254,6 +264,12 @@ def main(argv):
   if '--help' in argv or '-h' in argv:
     usage(deps_file_path)
     return 1
+
+  if '--with-clspv' in argv:
+    with_clspv = True
+
+  if '--with-dxc' in argv:
+    with_dxc = True
 
   git_sync_deps(deps_file_path, argv, verbose)
   # subprocess.check_call(

--- a/tools/git-sync-deps
+++ b/tools/git-sync-deps
@@ -228,13 +228,16 @@ def git_sync_deps(deps_file_path, command_line_os_requests, verbose):
     else:
       raise Exception("please specify commit or tag")
 
-    if not with_clspv and directory[12:17] is 'clspv':
+    if not with_clspv and directory is 'third_party/clspv':
       continue
 
-    if not with_dxc and directory[12:15] is 'dxc':
+    if not with_clspv and directory is 'third_party/clspv-llvm':
       continue
 
-    if not with_swiftshader and directory[12:23] is 'swiftshader':
+    if not with_dxc and directory is 'third_party/dxc':
+      continue
+
+    if not with_swiftshader and directory is 'third_party/swiftshader':
       continue
 
     relative_directory = os.path.join(deps_file_directory, directory)

--- a/tools/git-sync-deps
+++ b/tools/git-sync-deps
@@ -18,8 +18,9 @@
 Args:
   An optional list of deps_os values.
 
-  --with-clspv Checkout clspv dependencies
-  --with-dxc   Checkout dxc dependencies
+  --with-swiftshader Checkout Swiftshader dependencies
+  --with-clspv       Checkout clspv dependencies
+  --with-dxc         Checkout dxc dependencies
 
 Environment Variables:
   GIT_EXECUTABLE: path to "git" binary; if unset, will look for one of

--- a/tools/git-sync-deps
+++ b/tools/git-sync-deps
@@ -228,13 +228,13 @@ def git_sync_deps(deps_file_path, command_line_os_requests, verbose):
     else:
       raise Exception("please specify commit or tag")
 
-    if not with_clspv and 'clspv' in directory:
+    if not with_clspv and directory[12:17] is 'clspv':
       continue
 
-    if not with_dxc and 'dxc' in directory:
+    if not with_dxc and directory[12:15] is 'dxc':
       continue
 
-    if not with_swiftshader and 'swiftshader' in directory:
+    if not with_swiftshader and directory[12:23] is 'swiftshader':
       continue
 
     relative_directory = os.path.join(deps_file_directory, directory)


### PR DESCRIPTION
Fixes #707

* Add new arguments to git-sync-deps to control whether dxc and clspv
are checked out
* Update linux build to be able to sync extra deps