### PR TITLE
Add Float 16 Support

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -30,6 +30,7 @@ LOCAL_SRC_FILES:= \
     src/descriptor_set_and_binding_parser.cc \
     src/engine.cc \
     src/executor.cc \
+    src/float16_helper.cc \
     src/format.cc \
     src/parser.cc \
     src/pipeline.cc \

--- a/docs/amber_script.md
+++ b/docs/amber_script.md
@@ -34,8 +34,10 @@ DEVICE_FEATURE VariablePointerFeatures.variablePointersStorageBuffer
 ```
 
 Currently each of the items in `VkPhysicalDeviceFeatures` are recognized along
-with `VariablePointerFeatures.variablePointers` and
-`VariablePointerFeatures.variablePointersStorageBuffer`.
+with:
+ * `VariablePointerFeatures.variablePointers`
+ * `VariablePointerFeatures.variablePointersStorageBuffer`
+ * `Float16Int8Features.shaderFloat16`
 
 Extensions can be enabled with the `DEVICE_EXTENSION` and `INSTANCE_EXTENSION`
 commands.

--- a/docs/amber_script.md
+++ b/docs/amber_script.md
@@ -114,6 +114,7 @@ either image buffers or, what the target API would refer to as a buffer.
  * `uint16`
  * `uint32`
  * `uint64`
+ * `float16`
  * `float`
  * `double`
  * vec[2,3,4]{type}

--- a/samples/config_helper_vulkan.cc
+++ b/samples/config_helper_vulkan.cc
@@ -46,6 +46,7 @@ const size_t kNumberOfRequiredValidationLayers =
 const char kVariablePointers[] = "VariablePointerFeatures.variablePointers";
 const char kVariablePointersStorageBuffer[] =
     "VariablePointerFeatures.variablePointersStorageBuffer";
+const char kShaderFloat16[] = "Float16Int8Features.shaderFloat16";
 
 const char kExtensionForValidationLayer[] = "VK_EXT_debug_report";
 
@@ -598,7 +599,8 @@ std::string deviceTypeToName(VkPhysicalDeviceType type) {
 ConfigHelperVulkan::ConfigHelperVulkan()
     : available_features_(VkPhysicalDeviceFeatures()),
       available_features2_(VkPhysicalDeviceFeatures2KHR()),
-      variable_pointers_feature_(VkPhysicalDeviceVariablePointerFeaturesKHR()) {
+      variable_pointers_feature_(VkPhysicalDeviceVariablePointerFeaturesKHR()),
+      float16_int8_feature_(VkPhysicalDeviceShaderFloat16Int8FeaturesKHR()) {
 }
 
 ConfigHelperVulkan::~ConfigHelperVulkan() {
@@ -882,9 +884,13 @@ amber::Result ConfigHelperVulkan::CreateDeviceWithFeatures1(
 amber::Result ConfigHelperVulkan::CreateDeviceWithFeatures2(
     const std::vector<std::string>& required_features,
     VkDeviceCreateInfo* info) {
+  float16_int8_feature_.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR;
+  float16_int8_feature_.pNext = nullptr;
+
   variable_pointers_feature_.sType =
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES_KHR;
-  variable_pointers_feature_.pNext = nullptr;
+  variable_pointers_feature_.pNext = &float16_int8_feature_;
 
   available_features2_.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR;
   available_features2_.pNext = &variable_pointers_feature_;
@@ -901,6 +907,8 @@ amber::Result ConfigHelperVulkan::CreateDeviceWithFeatures2(
       variable_pointers_feature_.variablePointers = VK_TRUE;
     else if (feature == kVariablePointersStorageBuffer)
       variable_pointers_feature_.variablePointersStorageBuffer = VK_TRUE;
+    else if (feature == kShaderFloat16)
+      float16_int8_feature_.shaderFloat16 = VK_TRUE;
   }
 
   VkPhysicalDeviceFeatures required_vulkan_features =

--- a/samples/config_helper_vulkan.cc
+++ b/samples/config_helper_vulkan.cc
@@ -46,7 +46,7 @@ const size_t kNumberOfRequiredValidationLayers =
 const char kVariablePointers[] = "VariablePointerFeatures.variablePointers";
 const char kVariablePointersStorageBuffer[] =
     "VariablePointerFeatures.variablePointersStorageBuffer";
-const char kShaderFloat16[] = "Float16Int8Features.shaderFloat16";
+const char kFloat16Int8[] = "Float16Int8Features.shaderFloat16";
 
 const char kExtensionForValidationLayer[] = "VK_EXT_debug_report";
 
@@ -600,8 +600,7 @@ ConfigHelperVulkan::ConfigHelperVulkan()
     : available_features_(VkPhysicalDeviceFeatures()),
       available_features2_(VkPhysicalDeviceFeatures2KHR()),
       variable_pointers_feature_(VkPhysicalDeviceVariablePointerFeaturesKHR()),
-      float16_int8_feature_(VkPhysicalDeviceShaderFloat16Int8FeaturesKHR()) {
-}
+      float16_int8_feature_(VkPhysicalDeviceFloat16Int8FeaturesKHR()) {}
 
 ConfigHelperVulkan::~ConfigHelperVulkan() {
   if (vulkan_device_)
@@ -885,7 +884,7 @@ amber::Result ConfigHelperVulkan::CreateDeviceWithFeatures2(
     const std::vector<std::string>& required_features,
     VkDeviceCreateInfo* info) {
   float16_int8_feature_.sType =
-      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR;
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR;
   float16_int8_feature_.pNext = nullptr;
 
   variable_pointers_feature_.sType =
@@ -907,7 +906,7 @@ amber::Result ConfigHelperVulkan::CreateDeviceWithFeatures2(
       variable_pointers_feature_.variablePointers = VK_TRUE;
     else if (feature == kVariablePointersStorageBuffer)
       variable_pointers_feature_.variablePointersStorageBuffer = VK_TRUE;
-    else if (feature == kShaderFloat16)
+    else if (feature == kFloat16Int8)
       float16_int8_feature_.shaderFloat16 = VK_TRUE;
   }
 

--- a/samples/config_helper_vulkan.cc
+++ b/samples/config_helper_vulkan.cc
@@ -667,9 +667,10 @@ amber::Result ConfigHelperVulkan::CreateVulkanInstance(
 
   // Determine if VkPhysicalDeviceProperties2KHR should be used
   for (auto& ext : required_extensions) {
-    if (ext == "VK_KHR_get_physical_device_properties2") {
+    if (ext == "VK_KHR_get_physical_device_properties2")
       supports_get_physical_device_properties2_ = true;
-    }
+    if (ext == "VK_KHR_shader_float16_int8")
+      supports_shader_float16_int8_ = true;
   }
 
   std::vector<const char*> required_extensions_in_char;
@@ -889,7 +890,11 @@ amber::Result ConfigHelperVulkan::CreateDeviceWithFeatures2(
 
   variable_pointers_feature_.sType =
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES_KHR;
-  variable_pointers_feature_.pNext = &float16_int8_feature_;
+
+  if (supports_shader_float16_int8_)
+    variable_pointers_feature_.pNext = &float16_int8_feature_;
+  else
+    variable_pointers_feature_.pNext = nullptr;
 
   available_features2_.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR;
   available_features2_.pNext = &variable_pointers_feature_;

--- a/samples/config_helper_vulkan.cc
+++ b/samples/config_helper_vulkan.cc
@@ -46,7 +46,7 @@ const size_t kNumberOfRequiredValidationLayers =
 const char kVariablePointers[] = "VariablePointerFeatures.variablePointers";
 const char kVariablePointersStorageBuffer[] =
     "VariablePointerFeatures.variablePointersStorageBuffer";
-const char kFloat16Int8[] = "Float16Int8Features.shaderFloat16";
+const char kFloat16Int8_Float16[] = "Float16Int8Features.shaderFloat16";
 
 const char kExtensionForValidationLayer[] = "VK_EXT_debug_report";
 
@@ -906,7 +906,7 @@ amber::Result ConfigHelperVulkan::CreateDeviceWithFeatures2(
       variable_pointers_feature_.variablePointers = VK_TRUE;
     else if (feature == kVariablePointersStorageBuffer)
       variable_pointers_feature_.variablePointersStorageBuffer = VK_TRUE;
-    else if (feature == kFloat16Int8)
+    else if (feature == kFloat16Int8_Float16)
       float16_int8_feature_.shaderFloat16 = VK_TRUE;
   }
 

--- a/samples/config_helper_vulkan.h
+++ b/samples/config_helper_vulkan.h
@@ -110,6 +110,7 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
   VkDevice vulkan_device_ = VK_NULL_HANDLE;
 
   bool supports_get_physical_device_properties2_ = false;
+  bool supports_shader_float16_int8_ = false;
   VkPhysicalDeviceFeatures available_features_;
   VkPhysicalDeviceFeatures2KHR available_features2_;
   VkPhysicalDeviceVariablePointerFeaturesKHR variable_pointers_feature_;

--- a/samples/config_helper_vulkan.h
+++ b/samples/config_helper_vulkan.h
@@ -113,6 +113,7 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
   VkPhysicalDeviceFeatures available_features_;
   VkPhysicalDeviceFeatures2KHR available_features2_;
   VkPhysicalDeviceVariablePointerFeaturesKHR variable_pointers_feature_;
+  VkPhysicalDeviceShaderFloat16Int8FeaturesKHR float16_int8_feature_;
 };
 
 }  // namespace sample

--- a/samples/config_helper_vulkan.h
+++ b/samples/config_helper_vulkan.h
@@ -113,7 +113,7 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
   VkPhysicalDeviceFeatures available_features_;
   VkPhysicalDeviceFeatures2KHR available_features2_;
   VkPhysicalDeviceVariablePointerFeaturesKHR variable_pointers_feature_;
-  VkPhysicalDeviceShaderFloat16Int8FeaturesKHR float16_int8_feature_;
+  VkPhysicalDeviceFloat16Int8FeaturesKHR float16_int8_feature_;
 };
 
 }  // namespace sample

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ set(AMBER_SOURCES
     descriptor_set_and_binding_parser.cc
     engine.cc
     executor.cc
+    float16_helper.cc
     format.cc
     parser.cc
     pipeline.cc
@@ -138,6 +139,7 @@ if (${AMBER_ENABLE_TESTS})
     command_data_test.cc
     descriptor_set_and_binding_parser_test.cc
     executor_test.cc
+    float16_helper_test.cc
     format_test.cc
     pipeline_test.cc
     result_test.cc

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -70,6 +70,8 @@ std::unique_ptr<type::Type> ToType(const std::string& str) {
     return parser.Parse("R32_UINT");
   if (str == "uint64")
     return parser.Parse("R64_UINT");
+  if (str == "float16")
+    return parser.Parse("R16_SFLOAT");
   if (str == "float")
     return parser.Parse("R32_SFLOAT");
   if (str == "double")

--- a/src/amberscript/parser_device_feature_test.cc
+++ b/src/amberscript/parser_device_feature_test.cc
@@ -23,7 +23,8 @@ using AmberScriptParserTest = testing::Test;
 TEST_F(AmberScriptParserTest, DeviceFeature) {
   std::string in = R"(
 DEVICE_FEATURE vertexPipelineStoresAndAtomics
-DEVICE_FEATURE VariablePointerFeatures.variablePointersStorageBuffer)";
+DEVICE_FEATURE VariablePointerFeatures.variablePointersStorageBuffer
+DEVICE_FEATURE Float16Int8Features.shaderFloat16)";
 
   Parser parser;
   Result r = parser.Parse(in);
@@ -31,10 +32,12 @@ DEVICE_FEATURE VariablePointerFeatures.variablePointersStorageBuffer)";
 
   auto script = parser.GetScript();
   const auto& features = script->GetRequiredFeatures();
-  ASSERT_EQ(2U, features.size());
+  ASSERT_EQ(3U, features.size());
   EXPECT_EQ("vertexPipelineStoresAndAtomics", features[0]);
   EXPECT_EQ("VariablePointerFeatures.variablePointersStorageBuffer",
             features[1]);
+  EXPECT_EQ("Float16Int8Features.shaderFloat16",
+            features[2]);
 }
 
 TEST_F(AmberScriptParserTest, DeviceFeatureMissingFeature) {

--- a/src/amberscript/parser_device_feature_test.cc
+++ b/src/amberscript/parser_device_feature_test.cc
@@ -36,8 +36,7 @@ DEVICE_FEATURE Float16Int8Features.shaderFloat16)";
   EXPECT_EQ("vertexPipelineStoresAndAtomics", features[0]);
   EXPECT_EQ("VariablePointerFeatures.variablePointersStorageBuffer",
             features[1]);
-  EXPECT_EQ("Float16Int8Features.shaderFloat16",
-            features[2]);
+  EXPECT_EQ("Float16Int8Features.shaderFloat16", features[2]);
 }
 
 TEST_F(AmberScriptParserTest, DeviceFeatureMissingFeature) {

--- a/src/buffer_test.cc
+++ b/src/buffer_test.cc
@@ -305,7 +305,7 @@ TEST_F(BufferTest, SetFloat16) {
   auto type = parser.Parse("R16_SFLOAT");
 
   Format fmt(type.get());
-  Buffer b(BufferType::kColor);
+  Buffer b;
   b.SetFormat(&fmt);
   b.SetData(std::move(values));
 

--- a/src/buffer_test.cc
+++ b/src/buffer_test.cc
@@ -18,8 +18,8 @@
 
 #include <limits>
 #include "gtest/gtest.h"
-#include "src/type_parser.h"
 #include "src/float16_helper.h"
+#include "src/type_parser.h"
 
 namespace amber {
 

--- a/src/buffer_test.cc
+++ b/src/buffer_test.cc
@@ -19,6 +19,7 @@
 #include <limits>
 #include "gtest/gtest.h"
 #include "src/type_parser.h"
+#include "src/float16_helper.h"
 
 namespace amber {
 
@@ -292,6 +293,29 @@ TEST_F(BufferTest, CompareHistogramEMDToleranceAllWhite) {
   b2.SetData(values2);
 
   EXPECT_TRUE(b1.CompareHistogramEMD(&b2, 0.0f).IsSuccess());
+}
+
+TEST_F(BufferTest, SetFloat16) {
+  std::vector<Value> values;
+  values.resize(2);
+  values[0].SetDoubleValue(2.8);
+  values[1].SetDoubleValue(1234.567);
+
+  TypeParser parser;
+  auto type = parser.Parse("R16_SFLOAT");
+
+  Format fmt(type.get());
+  Buffer b(BufferType::kColor);
+  b.SetFormat(&fmt);
+  b.SetData(std::move(values));
+
+  EXPECT_EQ(2, b.ElementCount());
+  EXPECT_EQ(2, b.ValueCount());
+  EXPECT_EQ(4, b.GetSizeInBytes());
+
+  auto v = b.GetValues<uint16_t>();
+  EXPECT_EQ(float16::FloatToHexFloat16(2.8f), v[0]);
+  EXPECT_EQ(float16::FloatToHexFloat16(1234.567f), v[1]);
 }
 
 }  // namespace amber

--- a/src/float16_helper.cc
+++ b/src/float16_helper.cc
@@ -1,0 +1,127 @@
+// Copyright 2019 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/float16_helper.h"
+
+#include <cassert>
+#include <iostream>
+
+// Float10
+// | 9 8 7 6 5 | 4 3 2 1 0 |
+// | exponent  | mantissa  |
+//
+// Float11
+// | 10 9 8 7 6 | 5 4 3 2 1 0 |
+// | exponent   |  mantissa   |
+//
+// Float16
+// | 15 | 14 13 12 11 10 | 9 8 7 6 5 4 3 2 1 0 |
+// | s  |     exponent   |  mantissa           |
+//
+// Float32
+// | 31 | 30 ... 23 | 22 ... 0 |
+// | s  |  exponent | mantissa |
+
+namespace amber {
+namespace float16 {
+namespace {
+
+// Return sign value of 32 bits float.
+uint16_t FloatSign(const uint32_t hex_float) {
+  return static_cast<uint16_t>(hex_float >> 31U);
+}
+
+// Return exponent value of 32 bits float.
+uint16_t FloatExponent(const uint32_t hex_float) {
+  uint32_t exponent = ((hex_float >> 23U) & ((1U << 8U) - 1U)) - 112U;
+  const uint32_t half_exponent_mask = (1U << 5U) - 1U;
+  assert(((exponent & ~half_exponent_mask) == 0U) && "Float exponent overflow");
+  return static_cast<uint16_t>(exponent & half_exponent_mask);
+}
+
+// Return mantissa value of 32 bits float. Note that mantissa for 32
+// bits float is 23 bits and this method must return uint32_t.
+uint32_t FloatMantissa(const uint32_t hex_float) {
+  return static_cast<uint32_t>(hex_float & ((1U << 23U) - 1U));
+}
+
+// Convert float |value| whose size is 16 bits to 32 bits float
+// based on IEEE-754.
+float HexFloat16ToFloat(const uint8_t* value) {
+  uint32_t sign = (static_cast<uint32_t>(value[1]) & 0x80) << 24U;
+  uint32_t exponent = (((static_cast<uint32_t>(value[1]) & 0x7c) >> 2U) + 112U)
+                      << 23U;
+  uint32_t mantissa = ((static_cast<uint32_t>(value[1]) & 0x3) << 8U |
+                       static_cast<uint32_t>(value[0]))
+                      << 13U;
+
+  uint32_t hex = sign | exponent | mantissa;
+  float* hex_float = reinterpret_cast<float*>(&hex);
+  return *hex_float;
+}
+
+// Convert float |value| whose size is 11 bits to 32 bits float
+// based on IEEE-754.
+float HexFloat11ToFloat(const uint8_t* value) {
+  uint32_t exponent = (((static_cast<uint32_t>(value[1]) << 2U) |
+                        ((static_cast<uint32_t>(value[0]) & 0xc0) >> 6U)) +
+                       112U)
+                      << 23U;
+  uint32_t mantissa = (static_cast<uint32_t>(value[0]) & 0x3f) << 17U;
+
+  uint32_t hex = exponent | mantissa;
+  float* hex_float = reinterpret_cast<float*>(&hex);
+  return *hex_float;
+}
+
+// Convert float |value| whose size is 10 bits to 32 bits float
+// based on IEEE-754.
+float HexFloat10ToFloat(const uint8_t* value) {
+  uint32_t exponent = (((static_cast<uint32_t>(value[1]) << 3U) |
+                        ((static_cast<uint32_t>(value[0]) & 0xe0) >> 5U)) +
+                       112U)
+                      << 23U;
+  uint32_t mantissa = (static_cast<uint32_t>(value[0]) & 0x1f) << 18U;
+
+  uint32_t hex = exponent | mantissa;
+  float* hex_float = reinterpret_cast<float*>(&hex);
+  return *hex_float;
+}
+
+}  // namespace
+
+float HexFloatToFloat(const uint8_t* value, uint8_t bits) {
+  switch (bits) {
+    case 10:
+      return HexFloat10ToFloat(value);
+    case 11:
+      return HexFloat11ToFloat(value);
+    case 16:
+      return HexFloat16ToFloat(value);
+  }
+
+  assert(false && "Invalid bits");
+  return 0;
+}
+
+uint16_t FloatToHexFloat16(const float value) {
+  const uint32_t* hex = reinterpret_cast<const uint32_t*>(&value);
+  return static_cast<uint16_t>(
+      static_cast<uint16_t>(FloatSign(*hex) << 15U) |
+      static_cast<uint16_t>(FloatExponent(*hex) << 10U) |
+      static_cast<uint16_t>(FloatMantissa(*hex) >> 13U));
+}
+
+}  // namespace float16
+}  // namespace amber

--- a/src/float16_helper.cc
+++ b/src/float16_helper.cc
@@ -15,7 +15,6 @@
 #include "src/float16_helper.h"
 
 #include <cassert>
-#include <iostream>
 
 // Float10
 // | 9 8 7 6 5 | 4 3 2 1 0 |

--- a/src/float16_helper.h
+++ b/src/float16_helper.h
@@ -1,0 +1,45 @@
+// Copyright 2019 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SRC_FLOAT16_HELPER_H_
+#define SRC_FLOAT16_HELPER_H_
+
+#include <cstdint>
+
+namespace amber {
+namespace float16 {
+
+// Convert float |value| whose size is |bits| bits to 32 bits float
+// based on IEEE-754.
+//
+// See https://www.khronos.org/opengl/wiki/Small_Float_Formats
+// and https://en.wikipedia.org/wiki/IEEE_754.
+//
+//    Sign Exponent Mantissa Exponent-Bias
+// 16    1        5       10            15
+// 11    0        5        6            15
+// 10    0        5        5            15
+// 32    1        8       23           127
+// 64    1       11       52          1023
+//
+// 11 and 10 bits floats are always positive.
+float HexFloatToFloat(const uint8_t* value, uint8_t bits);
+
+// Convert 32 bits float |value| to 16 bits float based on IEEE-754.
+uint16_t FloatToHexFloat16(const float value);
+
+}  // namespace float16
+}  // namespace amber
+
+#endif  // SRC_FLOAT16_HELPER_H_

--- a/src/float16_helper_test.cc
+++ b/src/float16_helper_test.cc
@@ -1,0 +1,32 @@
+// Copyright 2019 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/float16_helper.h"
+#include "gtest/gtest.h"
+
+namespace amber {
+namespace float16 {
+
+using Float16HelperTest = testing::Test;
+
+TEST_F(Float16HelperTest, F32ToF16AndBack) {
+  float a = 2.5;
+
+  uint16_t half = float16::FloatToHexFloat16(a);
+  float b = float16::HexFloatToFloat(reinterpret_cast<uint8_t*>(&half), 16);
+  EXPECT_FLOAT_EQ(a, b);
+}
+
+}  // namespace float16
+}  // namespace amber

--- a/src/script.cc
+++ b/src/script.cc
@@ -100,7 +100,8 @@ bool Script::IsKnownFeature(const std::string& name) const {
          name == "sparseResidencyAliased" ||
          name == "variableMultisampleRate" || name == "inheritedQueries" ||
          name == "VariablePointerFeatures.variablePointers" ||
-         name == "VariablePointerFeatures.variablePointersStorageBuffer";
+         name == "VariablePointerFeatures.variablePointersStorageBuffer" ||
+         name == "Float16Int8Features.shaderFloat16";
 }
 
 type::Type* Script::ParseType(const std::string& str) {

--- a/src/vulkan/device.cc
+++ b/src/vulkan/device.cc
@@ -32,7 +32,7 @@ namespace {
 const char kVariablePointers[] = "VariablePointerFeatures.variablePointers";
 const char kVariablePointersStorageBuffer[] =
     "VariablePointerFeatures.variablePointersStorageBuffer";
-const char kFloat16Int8[] = "Float16Int8Features.shaderFloat16";
+const char kFloat16Int8_Float16[] = "Float16Int8Features.shaderFloat16";
 
 struct BaseOutStructure {
   VkStructureType sType;
@@ -436,7 +436,7 @@ Result Device::Initialize(
             "Missing variable pointers storage buffer feature");
       }
 
-      if (feature == kFloat16Int8) {
+      if (feature == kFloat16Int8_Float16) {
         if (float16_ptrs == nullptr) {
           return amber::Result(
               "Shader float 16 requested but feature not returned");

--- a/src/vulkan/device.cc
+++ b/src/vulkan/device.cc
@@ -32,7 +32,7 @@ namespace {
 const char kVariablePointers[] = "VariablePointerFeatures.variablePointers";
 const char kVariablePointersStorageBuffer[] =
     "VariablePointerFeatures.variablePointersStorageBuffer";
-const char kShaderFloat16[] = "Float16Int8Features.shaderFloat16";
+const char kFloat16Int8[] = "Float16Int8Features.shaderFloat16";
 
 struct BaseOutStructure {
   VkStructureType sType;
@@ -395,7 +395,7 @@ Result Device::Initialize(
     available_vulkan_features = available_features2.features;
 
     VkPhysicalDeviceVariablePointerFeaturesKHR* var_ptrs = nullptr;
-    VkPhysicalDeviceShaderFloat16Int8FeaturesKHR* float16_ptrs = nullptr;
+    VkPhysicalDeviceFloat16Int8FeaturesKHR* float16_ptrs = nullptr;
     void* ptr = available_features2.pNext;
     while (ptr != nullptr) {
       BaseOutStructure* s = static_cast<BaseOutStructure*>(ptr);
@@ -404,9 +404,9 @@ Result Device::Initialize(
         var_ptrs =
             static_cast<VkPhysicalDeviceVariablePointerFeaturesKHR*>(ptr);
       } else if (s->sType ==
-          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR) {
+                 VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR) {
         float16_ptrs =
-            static_cast<VkPhysicalDeviceShaderFloat16Int8FeaturesKHR*>(ptr);
+            static_cast<VkPhysicalDeviceFloat16Int8FeaturesKHR*>(ptr);
       }
       ptr = s->pNext;
     }
@@ -436,7 +436,7 @@ Result Device::Initialize(
             "Missing variable pointers storage buffer feature");
       }
 
-      if (feature == kShaderFloat16) {
+      if (feature == kFloat16Int8) {
         if (float16_ptrs == nullptr) {
           return amber::Result(
               "Shader float 16 requested but feature not returned");

--- a/tests/cases/float16.amber
+++ b/tests/cases/float16.amber
@@ -1,0 +1,41 @@
+#!amber
+# Copyright 2019 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHADER compute f16 GLSL
+#version 450
+#extension GL_AMD_gpu_shader_half_float : enable
+
+layout(set=0, binding=0) buffer Buf {
+  float16_t h;
+} data;
+
+void main() {
+  data.h = data.h * 2.0hf;
+}
+END
+
+BUFFER buf DATA_TYPE float16 DATA
+2.4
+END
+
+PIPELINE compute pipeline
+  ATTACH f16
+
+  BIND BUFFER buf AS storage DESCRIPTOR_SET 0 BINDING 0
+END
+
+RUN pipeline 1 1 1
+
+EXPECT buf IDX 0 EQ 4.8

--- a/tests/cases/float16.amber
+++ b/tests/cases/float16.amber
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+INSTANCE_EXTENSION VK_KHR_get_physical_device_properties2
+DEVICE_EXTENSION VK_KHR_shader_float16_int8
+DEVICE_FEATURE Float16Int8Features.shaderFloat16
+
 SHADER compute f16 GLSL
 #version 450
 #extension GL_AMD_gpu_shader_half_float : enable
@@ -38,4 +42,4 @@ END
 
 RUN pipeline 1 1 1
 
-EXPECT buf IDX 0 EQ 4.8
+EXPECT buf IDX 0 TOLERANCE 0.1 EQ 4.8

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -36,8 +36,6 @@ SUPPRESSIONS = {
     "compute_mat3x2.vkscript",
     "compute_mat3x2float.vkscript",
     "compute_mat3x2.amber",
-    # https://github.com/KhronosGroup/SPIRV-Tools/issues/3072
-    "compute_robust_buffer_access_ssbo.amber",
     # Metal vertex shaders cannot simultaneously write to a buffer and return
     # a value to the rasterizer rdar://48348476
     # https://github.com/KhronosGroup/MoltenVK/issues/527
@@ -47,14 +45,10 @@ SUPPRESSIONS = {
     "draw_triangle_list_hlsl.amber",
   ],
   "Linux": [
-    # https://github.com/KhronosGroup/SPIRV-Tools/issues/3072
-    "compute_robust_buffer_access_ssbo.amber",
     # DXC not currently building on bot
     "draw_triangle_list_hlsl.amber",
   ],
   "Win": [
-    # https://github.com/KhronosGroup/SPIRV-Tools/issues/3072
-    "compute_robust_buffer_access_ssbo.amber",
     # DXC not currently building on bot
     "draw_triangle_list_hlsl.amber",
    ]
@@ -76,6 +70,8 @@ SUPPRESSIONS_SWIFTSHADER = [
   # Color attachment format is not supported
   "draw_triangle_list_in_r16g16b16a16_snorm_color_frame.vkscript",
   "draw_triangle_list_in_r8g8b8a8_snorm_color_frame.vkscript",
+  # No supporting device for Float16Int8Features
+  "float16.amber",
   # SEGV: github.com/google/amber/issues/726
   "matrices_uniform_draw.amber",
   # SEGV: github.com/google/amber/issues/725


### PR DESCRIPTION
This CL adds the `float16` data type into amber_script and the required plumbing to enable the feature.

Fixes #485 