### PR TITLE
Fixup float16 detection

### DIFF
--- a/samples/config_helper_vulkan.cc
+++ b/samples/config_helper_vulkan.cc
@@ -669,8 +669,6 @@ amber::Result ConfigHelperVulkan::CreateVulkanInstance(
   for (auto& ext : required_extensions) {
     if (ext == "VK_KHR_get_physical_device_properties2")
       supports_get_physical_device_properties2_ = true;
-    if (ext == "VK_KHR_shader_float16_int8")
-      supports_shader_float16_int8_ = true;
   }
 
   std::vector<const char*> required_extensions_in_char;
@@ -776,6 +774,10 @@ amber::Result ConfigHelperVulkan::CheckVulkanPhysicalDeviceRequirements(
   if (!AreAllExtensionsSupported(available_device_extensions_,
                                  required_extensions)) {
     return amber::Result("Device does not support all required extensions");
+  }
+  for (const auto& ext : available_device_extensions_) {
+    if (ext == "VK_KHR_shader_float16_int8")
+      supports_shader_float16_int8_ = true;
   }
 
   vulkan_queue_family_index_ = ChooseQueueFamilyIndex(physical_device);


### PR DESCRIPTION
The detection of float16 support was looking at the wrong set of
extensions. This CL updates to use the correct set of device extensions.