### PR TITLE
Rolling 2 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,7 +8,7 @@ vars = {
   'swiftshader_git': 'https://swiftshader.googlesource.com',
   'microsoft_git': 'https://github.com/Microsoft',
 
-  'clspv_llvm_revision': '4becf68c6f17fe143539ceac954b21175914e1c1',
+  'clspv_llvm_revision': '5e5e99c041e48a69615eefd123dac23d9d0c7f73',
   'clspv_revision': 'ae7cff6ee4b5e3048e8cd3d01e499d67cae18d5d',
   'cpplint_revision': '26470f9ccb354ff2f6d098f831271a1833701b28',
   'dxc_revision': '2749458081b6211fde8fc6de5294f1460798b49b',
@@ -18,7 +18,7 @@ vars = {
   'shaderc_revision': '4399459c192085e44270b3dea25c0d3224ad77df',
   'spirv_headers_revision': '204cd131c42b90d129073719f2766293ce35c081',
   'spirv_tools_revision': '38d7fbaad0a376c777fa5ee95338c2c90e02d416',
-  'swiftshader_revision': '24c49ddde89ca50ad656e672973575a528c8ba48',
+  'swiftshader_revision': 'ff3d55c60356103457f626a2f39cbda160e84709',
   'vulkan_headers_revision': '0e57fc1cfa56a203efe43e4dfb9b3c9e9b105593',
   'vulkan_validationlayers_revision': '2b19f3916726243552178be6f8d38454bbb1db63',
   'vulkan_loader_revision': '2069798558ec7eb9b489ffc69fd1d27eebb0c84e',


### PR DESCRIPTION
Roll third_party/clspv-llvm/ 4becf68c6..5e5e99c04 (88 commits)

https://github.com/llvm/llvm-project/compare/4becf68c6f17...5e5e99c041e4

$ git log 4becf68c6..5e5e99c04 --date=short --no-merges --format='%ad %ae %s'
2019-12-18 spatel [AArch64] match fcvtl2 with bitcasted extract
2019-12-17 spatel [InstCombine] add tests for copysign; NFC
2019-12-17 teemperor [lldb][NFC] Add unit test for persistent variable lookup with ClangExpressionDeclMap
2019-12-18 daniel_l_sanders [gicombiner] Add support for arbitrary match data being passed from match to apply
2019-12-18 stephen.tozer Revert "[DebugInfo] Correctly handle salvaged casts and split fragments at ISel"
2019-12-18 llvmgnsyncbot gn build: Merge 7ea2e5195a8
2019-12-18 daniel_l_sanders Revert "Temporarily Revert "[gicombiner] Add the MatchDag structure and parse instruction DAG's from the input""
2019-12-18 llvmgnsyncbot gn build: Merge 1ad15046dcf
2019-12-18 ibiryukov [Syntax] Use a hash table to search for tokens by their location
2019-12-18 ibiryukov [Syntax] Uppercase the first letter of the test name. NFC
2019-12-18 ibiryukov [Syntax] Allow to mutate syntax trees
2019-12-17 stephen.tozer [DebugInfo] Correctly handle salvaged casts and split fragments at ISel
2019-12-04 gabor.marton recommit: [ASTImporter] Friend class decl should not be visible in its context
2019-12-18 sven.vanhaastregt [OpenCL] Add builtin function extension handling
2019-10-28 Victor.Campos [AArch64] Improve codegen of volatile load/store of i128
2019-12-11 jay.foad [AArch64] Enable clustering memory accesses to fixed stack objects
2019-12-18 Milos.Stojanovic [llvm-exegesis][mips] Add lit test
2019-12-18 anna.welker [NFC][TTI] Add Alignment for isLegalMasked[Gather/Scatter]
2019-12-18 david.stenberg [cmake] Add llvm-locstats to LLVM_TEST_DEPENDS
2019-12-18 grimar [llvm-readobj][test] - Move a comment. NFC.
2019-12-17 grimar [llvm-readob] - Refactor printing of sections flags. NFCI.
2019-12-17 grimar [llvm-readobj][test] - Cleanup hash-histogram.test
2019-12-13 grimar [llvm-readelf] - Change letters used for SHF_ARM_PURECODE and SHF_X86_64_LARGE flags.
2019-12-17 maskray [ELF] writePlt, writeIplt: replace parameters gotPltEntryAddr and index with `const Symbol &`. NFC
2019-12-13 grimar [llvm-readelf][llvm-readobj] - Reimplement the logic of section flags dumping.
2019-12-13 pengfei.wang [X86] Add calculation for elements in structures in getting uniform base for the Gather/Scatter intrinsic.
2019-12-17 pengfei.wang [X86] Add strict fma support
2019-12-17 xazax [CFG] Add an option to expand CXXDefaultInitExpr into aggregate initialization
2019-12-17 phosek [unwind] Don't link libpthread and libdl on Fuchsia
2019-12-17 maskray [ELF] Fix a comment. NFC
2019-12-17 mail [docs] Remove `git llvm push` and `git llvm revert` from GettingStarted
2019-12-17 nemanja.i.ibm [PowerPC] Add missing legalization for vector BSWAP
2019-12-18 llvmgnsyncbot gn build: Merge e62e760f295
2019-12-17 echristo Temporarily Revert "[gicombiner] Add the MatchDag structure and parse instruction DAG's from the input" and follow-on patches.
2019-12-17 craig.topper [X86] Manually format some setOperationAction calls to line up arguments to improve readability. NFC
2019-12-17 xiaoqing_wu [AArch64][GlobalISel]: Fix a crash in GlobalIsel in dealing with 16bit uadd.with.overflow.
2019-12-17 craig.topper [FPEnv][LegalizeTypes] Make ScalarizeVecOp_STRICT_FP_ROUND do its own replacements and return SDValue()
2019-12-17 Stanislav.Mekhanoshin [AMDGPU] Fixed cost model for packed 16 bit ops
2019-12-17 tlively [WebAssembly] Implement SIMD {i8x16,i16x8}.avgr_u instructions
2019-12-17 31459023+hctim Revert "[ MC ] Match labels to existing fragments even when switching sections."
2019-12-17 artem.dergachev [analysis] Discard type qualifiers when casting values retrieved from the Store.
2019-12-17 craig.topper [FPEnv][LegalizeTypes][LegalizeDAG][AArch64] Few fixes/improvements for legalizing fp<->int conversion nodes.
2019-12-17 arphaman [driver][darwin] Use explicit -mlinker-version in the -platform_version tests
2019-12-17 whitneyt [LoopFusion] Move instructions from FC0.Latch to FC1.Latch.
2019-12-17 daltenty [AIX] Avoid unset csect assert for functions defined after their use in TOC
2019-12-16 tstellar AMDGPU/SILoadStoreOptimillzer: Refactor CombineInfo struct
2019-12-17 nemanja.i.ibm Fix buildbot failures after removing REQUIRES-ANY
2019-12-17 koraq [IR] Use a reference in a range-based for
2019-12-17 koraq [Driver] Avoid copies in range-based for loops
2019-12-17 koraq [Sema] Fixes -Wrange-loop-analysis warnings
2019-12-17 koraq [Frontend] Fixes -Wrange-loop-analysis warnings
2019-12-04 SourabhSingh.Tomar Recommit "[DebugInfo] Refactored macro related generation, added a test case for macinfo.dwo emission."
2019-12-17 get [perf-training] Change profile file pattern string to use %4m instead of %p
2019-12-17 ulrich.weigand [FPEnv] Remove unnecessary rounding mode argument for constrained intrinsics
2019-12-16 a.bataev [OPENMP50]Add parsing/sema analysis for nontemporal clause.
2019-12-17 a.bataev [LIBOPENMP][NVPTX]Fix the build error in the runtime.
2019-12-17 sstipanovic [Attributor] H2S fix.
2019-12-17 sstipanovic [Attributor][NFC] Add test for sle comparison in h2s.
2019-12-13 sbc [WebAssembly] Convert MC tests to from bitcode to asm
2019-12-12 paulsson [Clang FE, SystemZ]  Recognize -mpacked-stack CL option
2019-12-16 d.c.ddcc llvm-diff: Perform structural comparison on GlobalVariables, if possible
2019-12-17 phabouzit [objc_direct] fix uniquing when re-declaring a readwrite-direct property
2019-12-17 jay.foad [AMDGPU] Fix typo in SIInstrInfo::memOpsHaveSameBasePtr
2019-12-17 spatel [SDAG] adjust isNegatibleForFree calculation to avoid crashing
2019-12-17 spatel Revert "[SDAG] remove use restriction in isNegatibleForFree() when called from getNegatedExpression()"
2019-12-17 spatel [SDAG] remove use restriction in isNegatibleForFree() when called from getNegatedExpression()
2019-12-17 thakis Revert "[ASTImporter] Friend class decl should not be visible in its context"
2019-12-16 arphaman [driver][darwin] Pass -platform_version flag to the linker instead of the -<platform>_version_min flag
2019-12-17 jonathanchesterfield [libomptarget][nfc] Move three files under common, build them for amdgcn
2019-11-28 zakk.chen [RISCV] Add subtargets initialized with target feature
2019-12-17 kevin.neal [FPEnv] IRBuilder support for constrained sitofp/uitofp.
2019-12-02 deadalnix [DAGCombiner] Add node back in the worklist in topological order in CommitTargetLoweringOpt
2019-12-17 ulrich.weigand [SystemZ][FPEnv] Back-end support for STRICT_[SU]INT_TO_FP
2019-12-17 daniel_l_sanders [gicombiner] Process the MatchDag such that every node is reachable from the roots
2019-11-15 Piotr.Sobczak [InstCombine][AMDGPU] Trim more components of *buffer_load
2019-12-11 mtrent [ MC ] Match labels to existing fragments even when switching sections.
2019-12-17 jay.foad [AMDGPU] Update autogenerated checks
2019-12-17 jdenny.ornl [lit] Fix internal diff newlines for -w/-b
2019-12-17 spatel [AArch64] add tests for fcvtl2; NFC
2019-12-17 31459023+hctim Revert "Honor  -fuse-init-array when os is not specified on x86"
2019-12-16 kadircet [clangd] Fix handling of inline/anon namespaces and names of deduced types in hover
2019-12-17 kadircet [clangd][NFC] Make use of TagDecl inside type for hover on auto
2019-12-17 llvmgnsyncbot gn build: Merge 390c8baa544
2019-12-17 daniel_l_sanders [gicombiner] Add the MatchDag structure and parse instruction DAG's from the input
2019-12-17 teemperor [lldb][NFC] Use StringRef in CreateRecordType and CreateObjCClass
2019-10-16 kevin.neal This adds constrained intrinsics for the signed and unsigned conversions of integers to floating point.
2019-12-16 erich.keane Reland [NFC-I] Remove hack for fp-classification builtins
2019-12-17 teemperor [lldb][NFC] Rename ClangASTImporter::InsertRecordDecl to SetRecordLayout and document it

Roll third_party/swiftshader/ 24c49ddde..ff3d55c60 (17 commits)

https://swiftshader.googlesource.com/SwiftShader.git/+log/24c49ddde89c..ff3d55c60356

$ git log 24c49ddde..ff3d55c60 --date=short --no-merges --format='%ad %ae %s'
2019-12-18 swiftshader.regress Regres: Update test lists @ 21be09d8
2019-12-17 sugoi Enable samplerAnisotropy
2019-12-16 chrisforbes Advertise variableMultisampleRate feature
2019-12-17 bclayton clang-format the src/WSI directory
2019-12-17 bclayton clang-format the src/Vulkan directory
2019-12-17 bclayton clang-format the src/System directory
2019-12-17 bclayton clang-format the src/Reactor directory
2019-12-17 bclayton clang-format the src/Pipeline directory
2019-12-17 bclayton clang-format the src/Device directory
2019-02-01 bclayton Start a custom .clang-format rule
2019-12-16 capn Remove spaces after control statements keywords
2019-12-17 sugoi Enable blending for 32FP formats
2019-12-13 capn Make use of vec<T, N> vector broadcasts
2019-12-17 capn Replace vector() and replicate() with float4 constructors
2019-12-13 capn Create a generic vec<T, N> class
2019-12-13 capn Typedef int4/float4 from a vec4<T> template
2019-12-12 capn Prefer alignas() over ALIGN()

Created with:
  roll-dep third_party/clspv third_party/clspv-llvm third_party/dxc third_party/glslang third_party/googletest third_party/lodepng third_party/shaderc third_party/spirv-headers third_party/spirv-tools third_party/swiftshader third_party/vulkan-headers third_party/vulkan-loader third_party/vulkan-validationlayers