### PR TITLE
Rolling 7 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,20 +8,20 @@ vars = {
   'swiftshader_git': 'https://swiftshader.googlesource.com',
   'microsoft_git': 'https://github.com/Microsoft',
 
-  'clspv_llvm_revision': '252c4dce618926311bcb4715eae6955f1bc71f13',
-  'clspv_revision': '242e3b6cbea0628c94453d24802bae55864a9b64',
+  'clspv_llvm_revision': 'c24cf97960827fa4993c399dc3f0be5a5376d9e7',
+  'clspv_revision': '4092cc5b82eeae2326d3e69697337a705137f718',
   'cpplint_revision': '26470f9ccb354ff2f6d098f831271a1833701b28',
   'dxc_revision': '80ec7c6bc7e3c40da52110dd2eb9b85192153775',
-  'glslang_revision': 'd203754bc1160cbb14e80de238042a2b9b439917',
+  'glslang_revision': '3ed344dd784ecbbc5855e613786f3a1238823e56',
   'googletest_revision': 'd854bd6acc47f7f6e168007d58b5f509e4981b36',
   'lodepng_revision': '2febfe0d105822575328759dd950c8a24b0ad6b3',
-  'shaderc_revision': '99ca03e1ac3a78c7d0e1ca7b3a1f6d973e0c1fc7',
+  'shaderc_revision': 'f53792645f0696b8954cfdb3c213f96799dd89b2',
   'spirv_headers_revision': '204cd131c42b90d129073719f2766293ce35c081',
-  'spirv_tools_revision': 'f8d7df760c81604ddc4ae3dac7f19333336f64c3',
+  'spirv_tools_revision': '323a81fc5e30e43a04e5e22af4cba98ca2a161e6',
   'swiftshader_revision': '4fd7fccd6db5ebb7a1f9cc7853afc2b6fea16b97',
   'vulkan_headers_revision': '881bbb347a08d1b5aa77f61a52a30b506de9f2bf',
-  'vulkan_validationlayers_revision': 'e91181dfeb79db57687121a06369f7af599934d5',
-  'vulkan_loader_revision': 'a0099c50284635fd7242541b6d335d01a90dcc26',
+  'vulkan_validationlayers_revision': 'ab883b9d257e234c1952f45d38fe3e25a5c87eb1',
+  'vulkan_loader_revision': '20f2d901c085c546e5c732084546e92d3d99cdee',
 }
 
 deps = {


### PR DESCRIPTION
Roll third_party/clspv/ 242e3b6cb..4092cc5b8 (2 commits)

https://github.com/google/clspv/compare/242e3b6cbea0...4092cc5b82ee

$ git log 242e3b6cb..4092cc5b8 --date=short --no-merges --format='%ad %ae %s'
2020-01-15 alanbaker Support convert_half* variants (#496)
2020-01-15 alanbaker Support half variants of mad (#495)

Roll third_party/clspv-llvm/ 252c4dce6..c24cf9796 (105 commits)

https://github.com/llvm/llvm-project/compare/252c4dce6189...c24cf9796082

$ git log 252c4dce6..c24cf9796 --date=short --no-merges --format='%ad %ae %s'
2020-01-16 anna.welker [ARM][MVE] Enable extending gathers
2020-01-16 ntv [mlir][Linalg] Fix Linalg EDSC builders
2020-01-16 thakis try to unbreak build after 4b6d9ac392613
2019-12-13 francesco.petrogalli [VectorUtils] Rework the Vector Function Database (VFDatabase).
2020-01-16 gribozavr Removed an unused include from TypeLocVisitor.h
2020-01-16 thakis Make lld cmake not compute commit revision twice
2020-01-16 jeremy.morse Revert "[PHIEliminate] Move dbg values after phi and label"
2020-01-15 andrew.ng [ELF] Optimization to LinkerScript::computeInputSections NFC
2020-01-16 kadircet [clangd] Make output order of allTargetDecls deterministic
2020-01-16 llvm-dev Fix unused variable warning. NFCI.
2020-01-15 llvm-dev Fix "pointer is null" static analyzer warnings. NFCI.
2020-01-15 teemperor [lldb][NFC] Migrate several tests to expect_expr
2020-01-16 hans Remove release note about in-process-cc1
2020-01-16 yechunliang [PHIEliminate] Move dbg values after phi and label
2020-01-16 saar [Concepts] Fix ConceptSpecializationExpr profiling crash
2020-01-15 kadircet [clangd] Dont display `<unknown>` kinds in hover board
2020-01-16 flo [IR] Mark memset.* intrinsics as IntrWriteMem.
2019-11-18 martin clang-format: [JS] tests for async wrapping.
2020-01-16 flo [LV] Allow assume calls in predicated blocks.
2020-01-16 flo [LV] Make X86/assume.ll X86 independent (NFC).
2020-01-16 llvmgnsyncbot [gn build] Port ed181efa175
2019-08-22 sameer.sahasrabuddhe [HIP][AMDGPU] expand printf when compiling HIP to AMDGPU
2020-01-16 marukawa [VE] i64 arguments, return values and constants
2020-01-16 teemperor [lldb] Fix asan failures in data-formatter-objc tests
2020-01-15 ikudrin [DebugInfo] Simplify the constructor of DWARFDebugAranges::Range. NFC.
2020-01-15 craig.topper [LegalizeDAG][TargetLowering] Move vXi64/i64->vXf32/f32 uint_to_fp legalizing code from TargetLowering::expandUINT_TO_FP back to LegalizeDAG.
2020-01-16 inouehrs [mlir] fix broken links to Glossary
2020-01-15 jonas [lldb/Reproducers] Print more info for reproducer status
2020-01-16 llvmgnsyncbot [gn build] Port 8fdafb7dced
2020-01-16 chen3.liu Insert wait instruction after X87 instructions which could raise float-point exception.
2020-01-15 jonas [lldb/Reproducers] Add a flag to always generating a reproducer
2019-12-05 Matthew.Arsenault Set some fast math attributes in setFunctionAttributes
2020-01-15 jonas [lldb/Reproducers] Extract function for reading environment override (NFC)
2020-01-15 richard PR42694 Support explicit(bool) in older language modes as an extension.
2020-01-15 wmi [SampleFDO] Fix invalid branch profile generated by indirect call promotion.
2020-01-15 craig.topper [X86] When handling i64->f32 sint_to_fp on 32-bit targets only bitcast to f64 if sse2 is enabled.
2020-01-15 craig.topper [X86] Add 32-bit mode sse1 command line to scalar-int-to-fp.ll. NFC
2020-01-15 jingham Fix the macos build after D71575.
2019-12-09 Matthew.Arsenault llc: Don't overwrite frame-pointer attribute
2020-01-15 yuanfang.chen Revert "[Support] make report_fatal_error `abort` instead of `exit`"
2020-01-15 vsk debugserver: Cut dependency on intrinsics_gen
2020-01-14 yuanfang.chen [Support] make report_fatal_error `abort` instead of `exit`
2020-01-15 jonas [lldb/Tools] Remove lldb-mi.exports
2019-12-09 Matthew.Arsenault llc: Change behavior of -mattr with existing attribute
2020-01-15 paolosev [LLDB] Add ObjectFileWasm plugin for WebAssembly debugging
2020-01-15 richard Fix pack deduction to only deduce the arity of packs that are actually expanded by the deduced pack.
2020-01-15 jonas [lldb/Utils] Patch all variables used by lit (3/3)
2020-01-15 jonas [lldb/Utils] Patch all variables used by lldb-dotest (2/2)
2020-01-15 Stanislav.Mekhanoshin Process BUNDLE in tail duplication
2020-01-15 akhuang Revert "Further implement CWG 2292"
(...)
2020-01-15 modocache [IR] Module's NamedMD table needn't be 'void *'
2020-01-15 jonas [lldb/Utils] Patch all variables used by lldb-dotest
2020-01-15 phosek [libcxx] Use mtx_plain | mtx_recursive following C11 API
2020-01-15 rnk [COFF] Warn that LLD does not support /PDBSTRIPPED:
2020-01-15 akhuang Revert "Allow system header to provide their own implementation of some builtin"
2020-01-15 jonas [lldb/Debugger] Rename IO handler methods to be more meaningful (NFC)
2020-01-15 a.bataev Revert "[OPENMP]Do not use RTTI by default for NVPTX devices."
2020-01-15 eric [libc++] Fix parsing <string> in C++03.
2020-01-15 eric [libc++] Optimize basic_string::operator=(const basic_string&) for SSO assignments
2020-01-15 vsk [test] Move call-site-entry-linking.test into test/tools/dsymutil/X86
2020-01-15 vsk DWARF: Simplify the way the return PC is attached to call site tags, NFC
2020-01-16 fedor.sergeev [BasicBlock] add helper getPostdominatingDeoptimizeCall
2020-01-15 eric [libc++] Explicitly enumerate std::string external instantiations - Attempt 2
2020-01-15 eric [libc++] Explicitly mark basic_string<...>::npos with default visibility.
2020-01-15 eric [libc++] Make SFINAE'd member functions in string mutually exclusive.
2020-01-15 vsk lldb: Run TestCrossDSOTailCalls.py and TestCrossObjectTailCalls.py on Darwin only
2020-01-15 jji [MachineScheduler][NFC] Don't swap when we can't cluster
2020-01-15 mtrofin [NFC] Refactor InlineResult for readability
2020-01-08 jpienaar [mlir] Add shaped container component type interface
2020-01-15 jimmy.zhongduo.lin [NFC][IndVarSimplify] remove duplicate code in widenWithVariantLoadUseCodegen.
2019-05-08 richard-llvm PR17164: Change clang's default behavior from -flax-vector-conversions=all to -flax-vector-conversions=integer.
2019-09-16 richard-llvm Work around PR43337: don't try to use the vec_sel overloads for vector long long, since clang's <altivec.h> doesn't provide it yet!
2020-01-15 vsk DebugInfo: Factor out logic to update locations in MD_loop metadata, NFC
2020-01-09 vsk [DWARF] Emit DW_AT_call_return_pc as an address
2020-01-15 lhames [docs][ORC] Update the laziness section of the ORCv2 design doc.
2020-01-15 thakis [gn build] re-run "gn format" with trunk gn
2020-01-15 thakis [gn build] add multi-line forcing comments in more places
2020-01-15 thakis [gn build] make "gn format" comment slightly more concise
2020-01-14 craig.topper [Mips] Add FileCheck to a test that just tested for a crash.
2020-01-15 lhames [ORC] Set setCloneToNewContextOnEmit on LLJIT's transform layer when needed.
2020-01-15 aemerson Revert "Revert rG6078f2fedcac5797ac39ee5ef3fd7a35ef1202d5 - "[AArch64][GlobalISel]: Support @llvm.{return,frame}address selection.""
2020-01-15 thakis [gn build] Reformat all build files
2020-01-15 thakis Replace CLANG_SPAWN_CC1 env var with a driver mode flag
2020-01-13 mark.murray [ARM][MVE][Intrinsics] Add VMINAQ, VMINNMAQ, VMAXAQ, VMAXNMAQ intrinsics.
2020-01-15 kadircet [clangd] Extract string literals in macro arguments to unbreak gcc buildbots
2020-01-15 benny.kra Revert "[mlir] Create a gpu.module operation for the GPU Dialect."
2020-01-15 tejohnson Fix bot by adjusting wildcard matching
2020-01-15 eleviant [ThinLTO] Always import constants
2020-01-15 arkady.shlykov [Loop Peeling] Add possibility to enable peeling on loop nests.
2020-01-15 spatel [InstCombine] reassociate fsub+fsub into fsub+fadd
2020-01-15 ntv [mlir][Linalg] NFC - Hotfix for gcc-5 build
2020-01-15 ntv [mlir][Linalg] NFC - Cleanup Linalg Pass locations and namespacing
2020-01-14 lhames [ORC] Simplify use of lazyReexports with LLJIT.
2020-01-14 lhames [ORC] Update lazyReexports to support aliases with different symbol names.
2020-01-15 hubert.reinterpretcast DWARFDebugLine.cpp: Format unknown line number standard opcodes
2020-01-15 hubert.reinterpretcast [CMake] Enable -qfuncsect when building with IBM XL
2020-01-15 ntv [mlir][Linalg] NFC - Hotfix for gcc-5 build
2020-01-15 grimar [llvm-readobj][test] - Cleanup SHT_RELR sections testing.
2020-01-13 tejohnson Restore "[ThinLTO] Add additional ThinLTO pipeline testing with new PM"
2020-01-15 kadircet [clangd] Fix windows buildbots

Roll third_party/glslang/ d203754bc..3ed344dd7 (4 commits)

https://github.com/KhronosGroup/glslang/compare/d203754bc116...3ed344dd784e

$ git log d203754bc..3ed344dd7 --date=short --no-merges --format='%ad %ae %s'
2020-01-16 cepheus Fix #2059, and also attempt to skip test bots [skip ci]
2019-12-24 laddoc Add Error check flag in io mapper
2020-01-15 cepheus Update to latest SPIRV-Tools, supporting Vulkan 1.2.
2020-01-15 cepheus SPV/Vulkan: Add support for Vulkan 1.2, which defaults to SPIR-V 1.5.

Roll third_party/shaderc/ 99ca03e1a..f53792645 (3 commits)

https://github.com/google/shaderc/compare/99ca03e1ac3a...f53792645f06

$ git log 99ca03e1a..f53792645 --date=short --no-merges --format='%ad %ae %s'
2020-01-15 rharrison Use the correct comparison when checking for not MSL (#960)
2020-01-15 dneto Support Vulkan 1.2 (#958)
2020-01-15 rharrison Fix incorrect casing on flags in docs (#957)

Roll third_party/spirv-tools/ f8d7df760..323a81fc5 (2 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/f8d7df760c81...323a81fc5e30

$ git log f8d7df760..323a81fc5 --date=short --no-merges --format='%ad %ae %s'
2019-09-04 alanbaker Validate Vulkan 1.2 capabilities
2019-08-28 dneto Add basic support for Vulkan 1.2: SPV_ENV_VULKAN_1_2

Roll third_party/vulkan-loader/ a0099c502..20f2d901c (4 commits)

https://github.com/KhronosGroup/Vulkan-Loader/compare/a0099c502846...20f2d901c085

$ git log a0099c502..20f2d901c --date=short --no-merges --format='%ad %ae %s'
2019-12-20 mikes build: Header update for 1.2.131
2019-10-21 mikes scripts: Tweak extension detection
2019-08-30 lenny scripts: Add support for Vulkan 1.2 codegen
2019-08-30 lenny loader: Add support for Vulkan 1.2

Roll third_party/vulkan-validationlayers/ e91181dfe..ab883b9d2 (2 commits)

https://github.com/KhronosGroup/Vulkan-ValidationLayers/compare/e91181dfeb79...ab883b9d257e

$ git log e91181dfe..ab883b9d2 --date=short --no-merges --format='%ad %ae %s'
2020-01-14 mark tests: Added tests for ycbcr sampler validation check
2020-01-14 mark stateless: Added YCBCR sampler checks

Created with:
  roll-dep third_party/clspv third_party/clspv-llvm third_party/dxc third_party/glslang third_party/googletest third_party/lodepng third_party/shaderc third_party/spirv-headers third_party/spirv-tools third_party/vulkan-headers third_party/vulkan-loader third_party/vulkan-validationlayers