### PR TITLE
Rolling 8 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,20 +8,20 @@ vars = {
   'swiftshader_git': 'https://swiftshader.googlesource.com',
   'microsoft_git': 'https://github.com/Microsoft',
 
-  'clspv_llvm_revision': 'ce23515f5ab01161c98449d833b3ae013b553aa8',
+  'clspv_llvm_revision': 'ac9b2a6297420a461f7b9db9e2dbd67f5f07f301',
   'clspv_revision': '50e3cd23a763372a0ccf5c9bbfc21b6c5e2df57d',
   'cpplint_revision': '26470f9ccb354ff2f6d098f831271a1833701b28',
-  'dxc_revision': '0532d8cd08c9535af2ca5407a3c6289766312f53',
-  'glslang_revision': 'b0ada80356ca7b560c600b93a596af1331442542',
+  'dxc_revision': '32168eac845b1dca4b0b3bd086434ec1503a6ae7',
+  'glslang_revision': '07a55839eed550d84ef62e0c7f503e0d67692708',
   'googletest_revision': '10b1902d893ea8cc43c69541d70868f91af3646b',
   'lodepng_revision': '5a0dba103893e6b8084be13945a826663917d00a',
-  'shaderc_revision': '9ad78aa7dba268ef8b808d23b135ea636fd893b1',
+  'shaderc_revision': '821d564bc7896fdd5d68484e10aac30ea192568f',
   'spirv_headers_revision': 'dc77030acc9c6fe7ca21fff54c5a9d7b532d7da6',
-  'spirv_tools_revision': 'ab7ac60f14ae66006bed5c989a2cfd4c4881704c',
-  'swiftshader_revision': 'cb4d2c38a3430437b1fceeb1d066e2d98d1916b1',
+  'spirv_tools_revision': '97f1d485b76303ea7094fa164c0cc770b79f6f78',
+  'swiftshader_revision': '6c3dc3581eaf4345c0507d5ac7bb013d55351547',
   'vulkan_headers_revision': '7264358702061d3ed819d62d3d6fd66ab1da33c3',
-  'vulkan_validationlayers_revision': '8317b28e672a6bff682f8406575e5daf446a80f3',
-  'vulkan_loader_revision': '37d3a235af2cc822c6aaf62616cf19db43d9bc8b',
+  'vulkan_validationlayers_revision': 'c51d450ef72c36014e821a289f38f8a5b5ea1010',
+  'vulkan_loader_revision': '44ac9b2f406f863c69a297a77bd23c28fa29e78d',
 }
 
 deps = {


### PR DESCRIPTION
Roll third_party/clspv-llvm/ ce23515f5..ac9b2a629 (470 commits)

https://github.com/llvm/llvm-project/compare/ce23515f5ab0...ac9b2a629742

$ git log ce23515f5..ac9b2a629 --date=short --no-merges --format='%ad %ae %s'
2020-01-28 Konstantin.Pyzhov Add missing clang tests for 6d614a82a4230ea69e322f56dc18dcbd815ed37b (AMDGPU MFMA built-ins)
2020-01-28 flo [Matrix] Mark expressions shared between multiple remarks.
2020-01-23 medismail.bennani [lldb/Target] Add Assert StackFrame Recognizer
2020-01-26 jroelofs [llvm] Fix broken cases of 'CHECK[^:]*$' in tests
2020-01-28 florian_hahn [LV] Hoist code to mark conditional assumes as dead to caller (NFC).
2020-01-28 Konstantin.Pyzhov Summary: This CL adds clang declarations of built-in functions for AMDGPU MFMA intrinsics and instructions. OpenCL tests for new built-ins are included.
2020-01-22 andrew.ng [LLD] Avoid exiting with a locked mutex NFC
2020-01-28 a.bataev [OPENMP50]Check for lastprivate conditional updates in atomic constructs.
2020-01-28 michael.hliao Fix warning of `-Wcast-qual`. NFC.
2020-01-28 flo [LV] Do not try to sink dead instructions.
2020-01-23 yaxun.liu [HIP] Fix environment variable HIP_DEVICE_LIB_PATH
2020-01-28 pavel Revert "[lldb/PDB] Use the new line table constructor"
2020-01-28 llvmgnsyncbot [gn build] Port a32f894f17b
2020-01-23 jroelofs [ADT] Remove more llvm::make_unique
2020-01-26 jroelofs [clang] Fix EOL whitespace. NFC
2020-01-23 kadircet [clang][CodeComplete] Support for designated initializers
2020-01-27 kostyak [scudo][standalone] Secondary & general other improvements
2020-01-28 khalikov.denis [mlir][spirv] Add GroupNonUniform arithmetic operations.
2020-01-28 kadircet [clangd] Make bin/llvm-lit run standalone clangd tests
2020-01-28 thakis Prevent building with MSVC 14.24
2020-01-28 jbcoe [clang-format] Handle quotes and escaped braces in C# interpolated strings
2020-01-28 thakis Revert "[Clang] Warn about 'z' printf modifier in old MSVC."
2020-01-28 wei.huang [PowerPC][Future] Add pld and pstd to future CPU Add the prefixed instructions pld and pstd to future CPU. These are load and store instructions that require new operand types that are 34 bits. This patch adds the two instructions as well as the operand types required.
2020-01-28 whitneyt [CodeMoverUtils] Improve IsControlFlowEquivalent.
2020-01-28 pavel [lldb/PDB] Use the new line table constructor
2020-01-28 pengfei.wang Fix sphinx build bot failure. NFCI.
2020-01-28 thakis Revert "PR44684: Look through parens and similar constructs when determining"
2020-01-28 sam.parker [NFC][RDA] typedef SmallPtrSetImpl<MachineInstr*>
2020-01-28 n.james93 [ASTMatchers] Add cxxNoexceptExpr AST matcher
2020-01-28 benny.kra [ADT] Implicitly convert between StringRef and std::string_view when we have C++17
2020-01-28 pavel Revert "[lldb/DWARF] Only match mangled name in full-name function lookup (with accelerators)"
2020-01-15 pengfei.wang [FPEnv] Add pragma FP_CONTRACT support under strict FP.
2020-01-27 Milos.Stojanovic [mips][NFC] Remove unused instruction formats
2020-01-15 pengfei.wang [X86] Add combination for fma and fneg on X86 under strict FP.
2020-01-23 peter.smith [LLD][ELF][ARM] Do not insert interworking thunks for non STT_FUNC symbols
2020-01-28 peter.smith [LLD][ELF][ARM] clang-format function signature [NFC]
2020-01-28 james.henderson Revert "[DebugInfo] Make most debug line prologue errors non-fatal to parsing"
2020-01-03 james.henderson [DebugInfo] Make most debug line prologue errors non-fatal to parsing
2020-01-27 hokein.wu [clangd] use SCOPED_TRACE to better trace the testcase in test failure, NFC
2020-01-28 jarin [lldb/DWARF] Only match mangled name in full-name function lookup (with accelerators)
2020-01-28 benny.kra [docs] Clarify llvm.used semantics with less awkward wording
2020-01-24 herhut Add lowering for loop.parallel to cfg.
2020-01-28 zinenko [mlir] NFC: use ValueRange in AffineToStandard conversion
2019-10-30 jay.foad [AMDGPU] Fix vccz after v_readlane/v_readfirstlane to vcc_lo/hi
2020-01-28 teemperor [lldb][NFC] Simplify Materializer/Dematerializer constructors
2020-01-24 kadircet [clangd][Hover] Handle uninstantiated templates
2020-01-10 sam.mccall [clangd] Support pseudo-obj expr, opaque values, and property references in findExplicitReferences()
2020-01-28 teemperor [lldb] Cut off unused suffix in CompletionRequest::GetRawLine
2020-01-13 sam.mccall [clangd] Improve ObjC property handling in SelectionTree.
2020-01-27 julian.gross [mlir] fixed invalid LLVM intrinsics in LLVMOPs.td and llvmir-intrinsics.mlir.
(...)
2020-01-23 lebedev.ri Revert "[Sema] Attempt to perform call-size-specific `__attribute__((alloc_align(param_idx)))` validation"
2020-01-23 Matthew.Arsenault AMDGPU: Fix ubsan error
2020-01-23 lebedev.ri [Sema] Don't disallow placing `__attribute__((alloc_align(param_idx)))` on `std::align_val_t`-typed parameters
2020-01-23 lebedev.ri [Codegen] If reasonable, materialize clang's `AllocAlignAttr` as llvm's Alignment Attribute on call-site function return value
2020-01-23 lebedev.ri [Codegen] If reasonable, materialize clang's `AssumeAlignedAttr` as llvm's Alignment Attribute on call-site function return value
2020-01-23 lebedev.ri [IR] Attribute/AttrBuilder: use Value::MaximumAlignment magic constant
2020-01-23 lebedev.ri [Sema] Attempt to perform call-size-specific `__attribute__((alloc_align(param_idx)))` validation
2020-01-23 lebedev.ri [Sema] Sanity-check alignment requested via `__attribute__((assume_aligned(imm)))`
2020-01-17 phosek Include phabricator.uri in .arcconfig
2019-12-26 tejohnson [WPD/VFE] Always emit vcall_visibility metadata for -fwhole-program-vtables
2020-01-22 asbirlea [LoopIdiomRecognize] Teach LoopIdiomRecognize to preserve MemorySSA.
2020-01-22 hayarms [mlir] Add option to use custom base class for dialect in LLVMIRIntrinsicGen.
2020-01-23 jonas [lldb] s/lldb/%lldb in another test
2020-01-23 asbirlea [IndVarSimplify] Fix for MemorySSA preserve.
2020-01-23 maskray [AArch64][test] Fix MC/AArch64 tests after D72799
2020-01-23 maskray [AArch64][test] Fix tests after D72799
2020-01-22 maskray [ELF] Pass `Relocation` to relaxGot and relaxTls{GdToIe,GdToLe,LdToLe,IeToLe}
2020-01-23 mail [LoopUnroll] Avoid UB when converting from WeakVH to `Value *`
2020-01-23 mgorny [openmp] Disable archer if LIBOMP_OMPT_SUPPORT is off
2020-01-15 danilo.carvalho.grael [SVE] Add SVE2 patterns for unpredicated multiply instructions
2020-01-22 ataei [mlir] Fix vectorize transform crashing on none-op operand
2020-01-23 llvm-dev [X86] LowerRotate - early out for vector rotates by zero
2020-01-23 llvm-dev [X86] Add test showing failure to remove vector rotate by zero
2020-01-23 llvm-dev [X86] Add AVX512 tests for vector rotations
2020-01-23 llvm-dev [SelectionDAG] ComputeNumSignBits - add ISD::ADD demanded elts support
2020-01-22 saar [Concepts] Placeholder constraints and abbreviated templates
2020-01-22 xazax [analyzer] Improve FuchsiaHandleChecker's diagnostic messages
2020-01-23 sam.parker [RDA] Skip debug values
2020-01-21 Matthew.Arsenault AMDGPU/GlobalISel: Select V_ADD3_U32/V_XOR3_B32
2020-01-23 Matthew.Arsenault GlobalISel: Use Register
2020-01-23 hans clang-cl: Parse /QIntel-jcc-erratum
2020-01-23 llvm-dev [SelectionDAG] ComputeNumSignBits - add ISD::ADD vector support
2020-01-23 llvm-dev [X86][SSE] Add ComputeNumSignBits tests for (ADD (AND X, 1), -1) vectors
2020-01-23 gchatelet [Alignment][NFC] Use Align with CreateAlignedStore
2020-01-23 Matthew.Arsenault AMDGPU: Check for other uses when looking through casted select
2020-01-23 sam.parker [NFC][ARM] Add test
2020-01-23 llvm-dev [SelectionDAG] ComputeNumSignBits - add ISD::SUB demanded elts support
2020-01-23 llvm-dev [X86][AVX] Add AVX1/AVX2 ashr vector tests
2020-01-23 kkwli0 [OpenMP] change omp_atk_* and omp_atv_* enumerators to lowercase [NFC]
2020-01-23 a.bataev [OPENMP]Fix use of local allocators in allocate clauses.
2020-01-22 michael.hliao [hip] Remove `-Werror=format-nonliteral`
2020-01-23 michael.hliao Fix GCC warning/error '-fpermission'. NFC.
2020-01-23 kparzysz [Hexagon] Remove unused operand definitions: s10_0Imm and s10_6Imm
2020-01-23 jaskiewiczs Revert "[tablegen] Emit string literals instead of char arrays"
2020-01-12 a.v.lapshin [Dsymutil][Debuginfo][NFC] #4 Refactor dsymutil to separate DWARF optimizing part.
2020-01-23 marukawa [VE] add, sub, left/right shift isel patterns
2020-01-23 kazu Revert "Resubmit: [JumpThreading] Thread jumps through two basic blocks"
2020-01-22 kadircet [clang][CodeComplete] Make completion work after initializer lists
2020-01-23 simon.moll [VE][NFC] re-write RR* isel class using null_frag
2020-01-23 simon.tatham [ARM,MVE] Make the MVE intrinsics work in C++!

Roll third_party/dxc/ 0532d8cd0..32168eac8 (5 commits)

https://github.com/Microsoft/DirectXShaderCompiler/compare/0532d8cd08c9...32168eac845b

$ git log 0532d8cd0..32168eac8 --date=short --no-merges --format='%ad %ae %s'
2020-01-27 texr Add pragma control for diagnostics and option printing (#2656)
2020-01-27 jaebaek [spirv] fix invalid index of member in derived class (#2657)
2020-01-24 hekotas Fix hctbuild -fv build break (#2662)
2020-01-23 grroth Correct official versioning in master branch (#2658)
2020-01-23 grroth Clear Cmake defines on reuse of hctbuild (#2659)

Roll third_party/glslang/ b0ada8035..07a55839e (15 commits)

https://github.com/KhronosGroup/glslang/compare/b0ada80356ca...07a55839eed5

$ git log b0ada8035..07a55839e --date=short --no-merges --format='%ad %ae %s'
2020-01-27 rharrison Use correct enum type in case statement
2020-01-27 cepheus Build: Fix more build warnings caused by PR #2038.
2020-01-26 cepheus Build warning: Fix #2062, missing enum value in a switch.
2020-01-08 sk Public: replaced tabs with spaces
2020-01-08 sk CInterface: replaced tabs with spaces
2019-12-30 sk CInterface: added static asserts to compare C/C++ enums
2019-12-30 sk Added LAST_ELEMENT_MARKER for every enum used in the C interface
2019-12-26 sk CInterface: replaced SH_ prefix with GLSLANG_
2019-12-25 sk CInterface: added glslang_program_SPIRV_get_ptr()
2019-12-25 sk CInterface: added files to CMakeLists.txt
2019-12-25 sk CInterface: added _BIT suffix to glslang_messages_t and glslang_reflection_options_t, fixed const-correctness
2019-12-25 sk CInterface: reformatted according to .clang-format rules
2019-12-24 sk Added original glslang_c_interface implementation by Viktor Latypov
2019-12-24 laddoc Add Tess machine dependent built-in variables initialization for GLES 3.2
2019-10-18 timo.suoranta Fixes for gcc 9 / -Werror=deprecated-copy

Roll third_party/shaderc/ 9ad78aa7d..821d564bc (4 commits)

https://github.com/google/shaderc/compare/9ad78aa7dba2...821d564bc789

$ git log 9ad78aa7d..821d564bc --date=short --no-merges --format='%ad %ae %s'
2020-01-27 rharrison Rolling 5 dependencies and updating expectations (#975)
2020-01-27 rharrison Remove deprecated APIs (#974)
2020-01-24 dneto Handle new Glslang profile enum in switch (#973)
2020-01-23 rharrison Big cleanup to normalize API behaviour (#967)

Roll third_party/spirv-tools/ ab7ac60f1..97f1d485b (9 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/ab7ac60f14ae...97f1d485b763

$ git log ab7ac60f1..97f1d485b --date=short --no-merges --format='%ad %ae %s'
2020-01-28 stevenperron Dead branch elim fix (#3160)
2020-01-24 syoussefi Fix chromium build (#3152)
2020-01-24 dneto Clarify mapping of target env to SPIR-V version (#3150)
2020-01-24 greg Use dummy switch instead of dummy loop in MergeReturn pass. (#3151)
2020-01-23 alanbaker Fix structured exit validation (#3141)
2020-01-23 dneto Add spvParseVulkanEnv (#3142)
2020-01-23 jaebaek Handle conflict between debug info and existing validation rule (#3104)
2020-01-23 syoussefi Use spirv-headers' BUILD.gn (#3148)
2020-01-23 syoussefi Roll external/spirv-headers/ af64a9e82..dc77030ac (4 commits) (#3147)

Roll third_party/swiftshader/ cb4d2c38a..6c3dc3581 (17 commits)

https://swiftshader.googlesource.com/SwiftShader.git/+log/cb4d2c38a343..6c3dc3581eaf

$ git log cb4d2c38a..6c3dc3581 --date=short --no-merges --format='%ad %ae %s'
2020-01-28 capn Support LLVM 8+ build changes
2020-01-28 bclayton SpirvShaderDebugger: Fix double nesting of struct members
2020-01-27 sugoi Revert "VK_EXT_shader_stencil_export support"
2020-01-23 sugoi Sample location fix
2020-01-27 capn Avoid ignoring unsuccessful routine creation
2020-01-25 capn Implement byte swizzle operations
2020-01-27 bclayton Docs: Add VulkanShaderDebugging.md
2020-01-23 sugoi VK_EXT_shader_stencil_export support
2020-01-16 capn Don't override vkQueuePresentKHR() failure codes with VK_SUBOPTIMAL_KHR
2020-01-16 capn Discern between per-swapchain and vkQueuePresent command results
2020-01-21 amaiorano Subzero: replace globals with external memory for constant vectors
2019-12-31 amaiorano SubzeroReactor: implement missing atomic ops
2020-01-24 bclayton Regres: add cmd/run_testlist
2020-01-24 bclayton Regres: Restructure directories for main packages
2020-01-21 amaiorano Subzero: temp fix Float4 % Float4 (FRem)
2020-01-22 capn Use UNIMPLEMENTED() for missing functionality we claim support for
2020-01-21 capn Replace all UNIMPLEMENTED() with UNSUPPORTED()

Roll third_party/vulkan-loader/ 37d3a235a..44ac9b2f4 (3 commits)

https://github.com/KhronosGroup/Vulkan-Loader/compare/37d3a235af2c...44ac9b2f406f

$ git log 37d3a235a..44ac9b2f4 --date=short --no-merges --format='%ad %ae %s'
2020-01-20 charles Fix spelling mistakes
2020-01-27 lenny loader: Update comments for shared aliases
2020-01-24 shannon loader: Update copyright date to include 2020

Roll third_party/vulkan-validationlayers/ 8317b28e6..c51d450ef (21 commits)

https://github.com/KhronosGroup/Vulkan-ValidationLayers/compare/8317b28e672a...c51d450ef72c

$ git log 8317b28e6..c51d450ef --date=short --no-merges --format='%ad %ae %s'
2020-01-23 tony tests: Add test for 02829 and 02830
2020-01-23 tony layers: Add validation for 02829 and 02830
2020-01-26 s.fricke layers: Removed redundant sType check
2020-01-20 s.fricke layers: Fix shader not looping correctly
2020-01-15 jeremy tests: Test specialization constant size
2020-01-15 jeremy layers: Fix specialization constant size
2020-01-17 tony tests: Better checking for 1.2
2019-12-30 jzulauf layers: Optimize descriptor allocation
2020-01-20 Andrew.Fobel tests: Add tests for VK_EXT_separate_stencil_usage
2020-01-20 Andrew.Fobel layers: Add VK_EXT_separate_stencil_usage support
2020-01-23 jzulauf build: Update copyright header dates for modified
2020-01-15 jzulauf layers: Bug fix for parallel iterator
2019-12-09 jzulauf layers: performance tune ImageSubresourceLayoutMap
2019-11-27 jzulauf layers: implement small range map and wrapper
2019-11-25 jzulauf layers: Cleanups and fixes from further unit test
2019-11-22 jzulauf layers: Fix ImageLayoutIntialState tracking
2019-11-21 jzulauf layers: Add range map view to image_layout
2019-11-20 jzulauf layers: Apply google style to new image layout impl
2019-11-19 jzulauf layers: ImageLayout traversal to iterators
2019-11-19 jzulauf layers: Refactor heavyweight ForRange/Iterator
2019-11-15 jzulauf layers: New sparse map for image subresource data

Created with:
  roll-dep third_party/clspv third_party/clspv-llvm third_party/dxc third_party/glslang third_party/googletest third_party/lodepng third_party/shaderc third_party/spirv-headers third_party/spirv-tools third_party/swiftshader third_party/vulkan-headers third_party/vulkan-loader third_party/vulkan-validationlayers