### PR TITLE
tokenizer: Tokenize quoted strings

### DIFF
--- a/src/amberscript/parser_buffer_test.cc
+++ b/src/amberscript/parser_buffer_test.cc
@@ -594,11 +594,11 @@ INSTANTIATE_TEST_SUITE_P(
     AmberScriptParserBufferParseErrorTest,
     testing::Values(
         BufferParseError{"BUFFER my_buf FORMAT 123",
-                         "1: BUFFER FORMAT must be a string"},
+                         "1: BUFFER FORMAT must be an identifier"},
         BufferParseError{"BUFFER my_buf FORMAT A23A32",
                          "1: invalid BUFFER FORMAT"},
         BufferParseError{"BUFFER my_buf FORMAT",
-                         "1: BUFFER FORMAT must be a string"},
+                         "1: BUFFER FORMAT must be an identifier"},
         BufferParseError{"BUFFER my_buffer FORMAT R32G32B32A32_SFLOAT EXTRA",
                          "1: unknown token: EXTRA"},
         BufferParseError{"BUFFER 1234 DATA_TYPE uint8 SIZE 5 FILL 5",

--- a/src/amberscript/parser_image_test.cc
+++ b/src/amberscript/parser_image_test.cc
@@ -127,7 +127,7 @@ IMAGE image DATA_TYPE uint32 4
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("2: IMAGE dimensionality must be a string: 4", r.Error());
+  EXPECT_EQ("2: IMAGE dimensionality must be an identifier: 4", r.Error());
 }
 
 TEST_F(AmberScriptParserTest, ImageWidthMissing) {

--- a/src/amberscript/parser_shader_opt_test.cc
+++ b/src/amberscript/parser_shader_opt_test.cc
@@ -168,7 +168,7 @@ END)";
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("6: SHADER_OPTIMIZATION options must be strings", r.Error());
+  EXPECT_EQ("6: SHADER_OPTIMIZATION options must be identifiers", r.Error());
 }
 
 }  // namespace amberscript

--- a/src/amberscript/parser_test.cc
+++ b/src/amberscript/parser_test.cc
@@ -40,7 +40,7 @@ TEST_F(AmberScriptParserTest, InvalidStartToken) {
   Parser parser;
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("3: expected string", r.Error());
+  EXPECT_EQ("3: expected identifier", r.Error());
 }
 
 TEST_F(AmberScriptParserTest, UnknownStartToken) {

--- a/src/descriptor_set_and_binding_parser.cc
+++ b/src/descriptor_set_and_binding_parser.cc
@@ -65,7 +65,7 @@ Result DescriptorSetAndBindingParser::Parse(const std::string& buffer_id) {
     descriptor_set_ = val;
   }
 
-  if (!token->IsString())
+  if (!token->IsIdentifier())
     return Result("Invalid buffer id: " + buffer_id);
 
   auto& str = token->AsString();

--- a/src/tokenizer.cc
+++ b/src/tokenizer.cc
@@ -31,7 +31,7 @@ Result Token::ConvertToDouble() {
   if (IsDouble())
     return {};
 
-  if (IsString() || IsEOL() || IsEOS())
+  if (IsIdentifier() || IsEOL() || IsEOS())
     return Result("Invalid conversion to double");
 
   if (IsInteger()) {
@@ -78,7 +78,7 @@ std::unique_ptr<Token> Tokenizer::NextToken() {
   // want to consume any other characters.
   if (data_[current_position_] == ',' || data_[current_position_] == '(' ||
       data_[current_position_] == ')') {
-    auto tok = MakeUnique<Token>(TokenType::kString);
+    auto tok = MakeUnique<Token>(TokenType::kIdentifier);
     std::string str(1, data_[current_position_]);
     tok->SetStringValue(str);
     ++current_position_;
@@ -125,7 +125,7 @@ std::unique_ptr<Token> Tokenizer::NextToken() {
       }
     }
 
-    auto tok = MakeUnique<Token>(TokenType::kString);
+    auto tok = MakeUnique<Token>(TokenType::kIdentifier);
     tok->SetStringValue(tok_str);
     return tok;
   }

--- a/src/tokenizer.cc
+++ b/src/tokenizer.cc
@@ -74,6 +74,86 @@ std::unique_ptr<Token> Tokenizer::NextToken() {
     return MakeUnique<Token>(TokenType::kEOL);
   }
 
+  if (data_[current_position_] == '"') {
+    current_position_++;  // Skip opening quote
+    std::string tok_str;
+    bool escape = false;
+    for (; current_position_ < data_.length(); current_position_++) {
+      auto c = data_[current_position_];
+      switch (c) {
+        case '\\':
+          if (!escape) {
+            escape = true;
+            continue;
+          }
+          break;
+        case '"':
+          if (!escape) {
+            current_position_++;  // Skip closing quote
+            auto tok = MakeUnique<Token>(TokenType::kString);
+            tok->SetStringValue(tok_str);
+            return tok;
+          }
+          break;
+        case 'a':
+          if (escape) {
+            tok_str += '\a';
+            escape = false;
+            continue;
+          }
+          break;
+        case 'b':
+          if (escape) {
+            tok_str += '\b';
+            escape = false;
+            continue;
+          }
+          break;
+        case 't':
+          if (escape) {
+            tok_str += '\t';
+            escape = false;
+            continue;
+          }
+          break;
+        case 'n':
+          if (escape) {
+            tok_str += '\n';
+            escape = false;
+            continue;
+          }
+          break;
+        case 'v':
+          if (escape) {
+            tok_str += '\v';
+            escape = false;
+            continue;
+          }
+          break;
+        case 'f':
+          if (escape) {
+            tok_str += '\f';
+            escape = false;
+            continue;
+          }
+          break;
+        case 'r':
+          if (escape) {
+            tok_str += '\r';
+            escape = false;
+            continue;
+          }
+          break;
+      }
+      escape = false;
+      tok_str += c;
+    }
+
+    auto tok = MakeUnique<Token>(TokenType::kString);
+    tok->SetStringValue(tok_str);
+    return tok;
+  }
+
   // If the current position is a , ( or ) then handle it specially as we don't
   // want to consume any other characters.
   if (data_[current_position_] == ',' || data_[current_position_] == '(' ||

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -27,6 +27,7 @@ enum class TokenType : uint8_t {
   kEOS = 0,
   kEOL,
   kIdentifier,
+  kString,
   kInteger,
   kDouble,
   kHex,
@@ -42,6 +43,7 @@ class Token {
   bool IsInteger() const { return type_ == TokenType::kInteger; }
   bool IsDouble() const { return type_ == TokenType::kDouble; }
   bool IsIdentifier() const { return type_ == TokenType::kIdentifier; }
+  bool IsString() const { return type_ == TokenType::kString; }
   bool IsEOS() const { return type_ == TokenType::kEOS; }
   bool IsEOL() const { return type_ == TokenType::kEOL; }
 

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -26,7 +26,7 @@ namespace amber {
 enum class TokenType : uint8_t {
   kEOS = 0,
   kEOL,
-  kString,
+  kIdentifier,
   kInteger,
   kDouble,
   kHex,
@@ -41,18 +41,18 @@ class Token {
   bool IsHex() const { return type_ == TokenType::kHex; }
   bool IsInteger() const { return type_ == TokenType::kInteger; }
   bool IsDouble() const { return type_ == TokenType::kDouble; }
-  bool IsString() const { return type_ == TokenType::kString; }
+  bool IsIdentifier() const { return type_ == TokenType::kIdentifier; }
   bool IsEOS() const { return type_ == TokenType::kEOS; }
   bool IsEOL() const { return type_ == TokenType::kEOL; }
 
   bool IsComma() const {
-    return type_ == TokenType::kString && string_value_ == ",";
+    return type_ == TokenType::kIdentifier && string_value_ == ",";
   }
   bool IsOpenBracket() const {
-    return type_ == TokenType::kString && string_value_ == "(";
+    return type_ == TokenType::kIdentifier && string_value_ == "(";
   }
   bool IsCloseBracket() const {
-    return type_ == TokenType::kString && string_value_ == ")";
+    return type_ == TokenType::kIdentifier && string_value_ == ")";
   }
 
   void SetNegative() { is_negative_ = true; }

--- a/src/tokenizer_test.cc
+++ b/src/tokenizer_test.cc
@@ -298,6 +298,56 @@ TEST_F(TokenizerTest, StringStartingWithNum) {
   EXPECT_EQ("/ABC", next->AsString());
 }
 
+TEST_F(TokenizerTest, StringQuotedSingleLine) {
+  Tokenizer t("\"Hello world\"");
+  auto next = t.NextToken();
+  ASSERT_TRUE(next != nullptr);
+  EXPECT_TRUE(next->IsString());
+  EXPECT_EQ("Hello world", next->AsString());
+
+  next = t.NextToken();
+  ASSERT_TRUE(next != nullptr);
+  EXPECT_TRUE(next->IsEOS());
+}
+
+TEST_F(TokenizerTest, StringQuotedMultiLine) {
+  Tokenizer t("\"Hello\n\nworld\"");
+  auto next = t.NextToken();
+  ASSERT_TRUE(next != nullptr);
+  EXPECT_TRUE(next->IsString());
+  EXPECT_EQ("Hello\n\nworld", next->AsString());
+
+  next = t.NextToken();
+  ASSERT_TRUE(next != nullptr);
+  EXPECT_TRUE(next->IsEOS());
+}
+
+TEST_F(TokenizerTest, StringQuotedUnterminated) {
+  Tokenizer t("\"Hello\n\nworld");
+  auto next = t.NextToken();
+  ASSERT_TRUE(next != nullptr);
+  EXPECT_TRUE(next->IsString());
+  EXPECT_EQ("Hello\n\nworld", next->AsString());
+
+  next = t.NextToken();
+  ASSERT_TRUE(next != nullptr);
+  EXPECT_TRUE(next->IsEOS());
+}
+
+TEST_F(TokenizerTest, StringQuotedEscapeSequences) {
+  Tokenizer t(R"("_\"\\_a\aa_b\bb_t\tt_n\nn_v\vv_f\ff_r\rr_")");
+  auto next = t.NextToken();
+  ASSERT_TRUE(next != nullptr);
+  EXPECT_TRUE(next->IsString());
+
+  std::string expect = "_\"\\_a\aa_b\bb_t\tt_n\nn_v\vv_f\ff_r\rr_";
+  EXPECT_EQ(expect, next->AsString());
+
+  next = t.NextToken();
+  ASSERT_TRUE(next != nullptr);
+  EXPECT_TRUE(next->IsEOS());
+}
+
 TEST_F(TokenizerTest, BracketsAndCommas) {
   Tokenizer t("(1.0, 2, abc)");
   auto next = t.NextToken();

--- a/src/tokenizer_test.cc
+++ b/src/tokenizer_test.cc
@@ -30,12 +30,12 @@ TEST_F(TokenizerTest, ProcessEmpty) {
   EXPECT_TRUE(next->IsEOS());
 }
 
-TEST_F(TokenizerTest, ProcessString) {
-  Tokenizer t("TestString");
+TEST_F(TokenizerTest, ProcessIdentifier) {
+  Tokenizer t("TestIdentifier");
   auto next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
-  EXPECT_TRUE(next->IsString());
-  EXPECT_EQ("TestString", next->AsString());
+  EXPECT_TRUE(next->IsIdentifier());
+  EXPECT_EQ("TestIdentifier", next->AsString());
 
   next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
@@ -133,7 +133,7 @@ TEST_F(TokenizerTest, ProcessStringWithNumberInName) {
   Tokenizer t("BufferAccess32");
   auto next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
-  EXPECT_TRUE(next->IsString());
+  EXPECT_TRUE(next->IsIdentifier());
   EXPECT_EQ("BufferAccess32", next->AsString());
 
   next = t.NextToken();
@@ -145,7 +145,7 @@ TEST_F(TokenizerTest, ProcessMultiStatement) {
   Tokenizer t("TestValue 123.456");
   auto next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
-  EXPECT_TRUE(next->IsString());
+  EXPECT_TRUE(next->IsIdentifier());
   EXPECT_EQ("TestValue", next->AsString());
 
   next = t.NextToken();
@@ -162,7 +162,7 @@ TEST_F(TokenizerTest, ProcessMultiLineStatement) {
   Tokenizer t("TestValue 123.456\nAnotherValue\n\nThirdValue 456");
   auto next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
-  EXPECT_TRUE(next->IsString());
+  EXPECT_TRUE(next->IsIdentifier());
   EXPECT_EQ("TestValue", next->AsString());
   EXPECT_EQ(1U, t.GetCurrentLine());
 
@@ -178,7 +178,7 @@ TEST_F(TokenizerTest, ProcessMultiLineStatement) {
 
   next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
-  EXPECT_TRUE(next->IsString());
+  EXPECT_TRUE(next->IsIdentifier());
   EXPECT_EQ("AnotherValue", next->AsString());
   EXPECT_EQ(2U, t.GetCurrentLine());
 
@@ -192,7 +192,7 @@ TEST_F(TokenizerTest, ProcessMultiLineStatement) {
 
   next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
-  EXPECT_TRUE(next->IsString());
+  EXPECT_TRUE(next->IsIdentifier());
   EXPECT_EQ("ThirdValue", next->AsString());
   EXPECT_EQ(4U, t.GetCurrentLine());
 
@@ -221,7 +221,7 @@ ThirdValue 456)");
 
   next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
-  EXPECT_TRUE(next->IsString());
+  EXPECT_TRUE(next->IsIdentifier());
   EXPECT_EQ("TestValue", next->AsString());
 
   next = t.NextToken();
@@ -235,7 +235,7 @@ ThirdValue 456)");
 
   next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
-  EXPECT_TRUE(next->IsString());
+  EXPECT_TRUE(next->IsIdentifier());
   EXPECT_EQ("AnotherValue", next->AsString());
 
   next = t.NextToken();
@@ -248,7 +248,7 @@ ThirdValue 456)");
 
   next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
-  EXPECT_TRUE(next->IsString());
+  EXPECT_TRUE(next->IsIdentifier());
   EXPECT_EQ("ThirdValue", next->AsString());
 
   next = t.NextToken();
@@ -294,7 +294,7 @@ TEST_F(TokenizerTest, StringStartingWithNum) {
 
   next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
-  EXPECT_TRUE(next->IsString());
+  EXPECT_TRUE(next->IsIdentifier());
   EXPECT_EQ("/ABC", next->AsString());
 }
 
@@ -324,7 +324,7 @@ TEST_F(TokenizerTest, BracketsAndCommas) {
 
   next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
-  EXPECT_TRUE(next->IsString());
+  EXPECT_TRUE(next->IsIdentifier());
   EXPECT_EQ("abc", next->AsString());
 
   next = t.NextToken();
@@ -362,7 +362,7 @@ TEST_F(TokenizerTest, DashToken) {
   Tokenizer t("-");
   auto next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
-  ASSERT_TRUE(next->IsString());
+  ASSERT_TRUE(next->IsIdentifier());
   EXPECT_EQ("-", next->AsString());
 }
 
@@ -421,7 +421,7 @@ TEST_F(TokenizerTest, TokenToDoubleFromString) {
   Tokenizer t("INVALID");
   auto next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
-  ASSERT_TRUE(next->IsString());
+  ASSERT_TRUE(next->IsIdentifier());
 
   Result r = next->ConvertToDouble();
   ASSERT_FALSE(r.IsSuccess());
@@ -490,7 +490,7 @@ TEST_F(TokenizerTest, ContinuationAtEndOfString) {
 
   next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
-  ASSERT_TRUE(next->IsString());
+  ASSERT_TRUE(next->IsIdentifier());
   EXPECT_EQ("\\", next->AsString());
 
   next = t.NextToken();
@@ -507,7 +507,7 @@ TEST_F(TokenizerTest, ContinuationTokenAtOfLine) {
 
   next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
-  ASSERT_TRUE(next->IsString());
+  ASSERT_TRUE(next->IsIdentifier());
   EXPECT_EQ("\\2", next->AsString());
 
   next = t.NextToken();
@@ -524,7 +524,7 @@ TEST_F(TokenizerTest, ContinuationTokenInMiddleOfLine) {
 
   next = t.NextToken();
   ASSERT_TRUE(next != nullptr);
-  ASSERT_TRUE(next->IsString());
+  ASSERT_TRUE(next->IsIdentifier());
   EXPECT_EQ("\\", next->AsString());
 
   next = t.NextToken();
@@ -541,14 +541,14 @@ TEST_F(TokenizerTest, ExtractToNext) {
   Tokenizer t("this\nis\na\ntest\nEND");
 
   auto next = t.NextToken();
-  EXPECT_TRUE(next->IsString());
+  EXPECT_TRUE(next->IsIdentifier());
   EXPECT_EQ("this", next->AsString());
 
   std::string s = t.ExtractToNext("END");
   ASSERT_EQ("\nis\na\ntest\n", s);
 
   next = t.NextToken();
-  EXPECT_TRUE(next->IsString());
+  EXPECT_TRUE(next->IsIdentifier());
   EXPECT_EQ("END", next->AsString());
   EXPECT_EQ(5U, t.GetCurrentLine());
 
@@ -560,7 +560,7 @@ TEST_F(TokenizerTest, ExtractToNextMissingNext) {
   Tokenizer t("this\nis\na\ntest\n");
 
   auto next = t.NextToken();
-  EXPECT_TRUE(next->IsString());
+  EXPECT_TRUE(next->IsIdentifier());
   EXPECT_EQ("this", next->AsString());
 
   std::string s = t.ExtractToNext("END");
@@ -577,7 +577,7 @@ TEST_F(TokenizerTest, ExtractToNextCurrentIsNext) {
   ASSERT_EQ("", s);
 
   auto next = t.NextToken();
-  EXPECT_TRUE(next->IsString());
+  EXPECT_TRUE(next->IsIdentifier());
   EXPECT_EQ("END", next->AsString());
 
   next = t.NextToken();

--- a/src/vkscript/parser.cc
+++ b/src/vkscript/parser.cc
@@ -155,7 +155,7 @@ Result Parser::ProcessRequireBlock(const SectionParser::Section& section) {
        token = tokenizer.NextToken()) {
     if (token->IsEOL())
       continue;
-    if (!token->IsString()) {
+    if (!token->IsIdentifier()) {
       return Result(make_error(
           tokenizer,
           "Invalid token in requirements block: " + token->ToOriginalString()));
@@ -166,7 +166,7 @@ Result Parser::ProcessRequireBlock(const SectionParser::Section& section) {
       script_->AddRequiredFeature(str);
     } else if (str == Pipeline::kGeneratedColorBuffer) {
       token = tokenizer.NextToken();
-      if (!token->IsString())
+      if (!token->IsIdentifier())
         return Result(make_error(tokenizer, "Missing framebuffer format"));
 
       TypeParser type_parser;
@@ -186,7 +186,7 @@ Result Parser::ProcessRequireBlock(const SectionParser::Section& section) {
 
     } else if (str == "depthstencil") {
       token = tokenizer.NextToken();
-      if (!token->IsString())
+      if (!token->IsIdentifier())
         return Result(make_error(tokenizer, "Missing depthStencil format"));
 
       TypeParser type_parser;
@@ -347,7 +347,7 @@ Result Parser::ProcessVertexDataBlock(const SectionParser::Section& section) {
     uint8_t loc = token->AsUint8();
 
     token = tokenizer.NextToken();
-    if (!token->IsString()) {
+    if (!token->IsIdentifier()) {
       return Result(
           make_error(tokenizer, "Unable to process vertex data header: " +
                                     token->ToOriginalString()));


### PR DESCRIPTION
Handles the basic set of escape sequences: `'\a'`, `'\b'`, `'\t'`, `'\n'`, `'\v'`, `'\f'`, `'\r'`.
Also supports multi-line strings.

Added tests.