### PR TITLE
Debugger: Fix gcc warning

### DIFF
--- a/src/vulkan/engine_vulkan_debugger.cc
+++ b/src/vulkan/engine_vulkan_debugger.cc
@@ -489,8 +489,6 @@ bool InvocationKey::operator==(const InvocationKey& other) const {
 
 // Thread controls and verifies a single debugger thread of execution.
 class Thread : public debug::Thread {
-  using Result = Result;
-
  public:
   Thread(std::shared_ptr<dap::Session> session,
          int threadId,


### PR DESCRIPTION
```
error: declaration of ‘using Result = class amber::Result’ [-fpermissive] ... 
changes meaning of ‘Result’ from ‘class amber::Result’ [-fpermissive]
```

This type alias is now actually not required, as the anonymous namespace was moved into the `amber::vulkan` namespace as part of an earlier review comment. Just remove it.