### PR TITLE
Support targeting Vulkan 1.2 and SPIR-V 1.5

### DIFF
--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -78,7 +78,7 @@ const char kUsage[] = R"(Usage: amber [options] SCRIPT [SCRIPTS...]
   -d                        -- Disable validation layers.
   -D <ID>                   -- ID of device to run with (Vulkan only).
   -f <value>                -- Sets the fence timeout value to |value|
-  -t <spirv_env>            -- The target SPIR-V environment e.g., spv1.3, vulkan1.1.
+  -t <spirv_env>            -- The target SPIR-V environment e.g., spv1.3, vulkan1.1, vulkan1.2.
                                If a SPIR-V environment, assume the lowest version of Vulkan that
                                requires support of that version of SPIR-V.
                                If a Vulkan environment, use the highest version of SPIR-V required

--- a/src/shader_compiler.cc
+++ b/src/shader_compiler.cc
@@ -299,12 +299,14 @@ const uint32_t kVulkan = 0;
 // Values for versions of the Vulkan API, used in the Shaderc API
 const uint32_t kVulkan_1_0 = (uint32_t(1) << 22);
 const uint32_t kVulkan_1_1 = (uint32_t(1) << 22) | (1 << 12);
+const uint32_t kVulkan_1_2 = (uint32_t(1) << 22) | (2 << 12);
 // Values for SPIR-V versions, used in the Shaderc API
 const uint32_t kSpv_1_0 = uint32_t(0x10000);
 const uint32_t kSpv_1_1 = uint32_t(0x10100);
 const uint32_t kSpv_1_2 = uint32_t(0x10200);
 const uint32_t kSpv_1_3 = uint32_t(0x10300);
 const uint32_t kSpv_1_4 = uint32_t(0x10400);
+const uint32_t kSpv_1_5 = uint32_t(0x10500);
 
 #if AMBER_ENABLE_SHADERC
 // Check that we have the right values, from the original definitions
@@ -315,6 +317,8 @@ static_assert(kVulkan_1_0 == shaderc_env_version_vulkan_1_0,
               "enum vulkan1.0 value mismatch");
 static_assert(kVulkan_1_1 == shaderc_env_version_vulkan_1_1,
               "enum vulkan1.1 value mismatch");
+static_assert(kVulkan_1_2 == shaderc_env_version_vulkan_1_2,
+              "enum vulkan1.2 value mismatch");
 static_assert(kSpv_1_0 == shaderc_spirv_version_1_0,
               "enum spv1.0 value mismatch");
 static_assert(kSpv_1_1 == shaderc_spirv_version_1_1,
@@ -325,6 +329,8 @@ static_assert(kSpv_1_3 == shaderc_spirv_version_1_3,
               "enum spv1.3 value mismatch");
 static_assert(kSpv_1_4 == shaderc_spirv_version_1_4,
               "enum spv1.4 value mismatch");
+static_assert(kSpv_1_5 == shaderc_spirv_version_1_5,
+              "enum spv1.5 value mismatch");
 #endif
 
 }  // namespace
@@ -353,7 +359,12 @@ Result ParseSpvEnv(const std::string& spv_env,
   } else if (spv_env == "spv1.3") {
     values = {kVulkan, kVulkan_1_1, kSpv_1_3};
   } else if (spv_env == "spv1.4") {
-    values = {kVulkan, kVulkan_1_1, kSpv_1_4};
+    // Vulkan 1.2 requires support for SPIR-V 1.4,
+    // but Vulkan 1.1 permits it with an extension.
+    // So Vulkan 1.2 is the right answer here.
+    values = {kVulkan, kVulkan_1_2, kSpv_1_4};
+  } else if (spv_env == "spv1.5") {
+    values = {kVulkan, kVulkan_1_2, kSpv_1_5};
   } else if (spv_env == "vulkan1.0") {
     values = {kVulkan, kVulkan_1_0, kSpv_1_0};
   } else if (spv_env == "vulkan1.1") {
@@ -361,6 +372,8 @@ Result ParseSpvEnv(const std::string& spv_env,
     values = {kVulkan, kVulkan_1_1, kSpv_1_3};
   } else if (spv_env == "vulkan1.1spv1.4") {
     values = {kVulkan, kVulkan_1_1, kSpv_1_4};
+  } else if (spv_env == "vulkan1.2") {
+    values = {kVulkan, kVulkan_1_2, kSpv_1_5};
   } else {
     return Result(std::string("Unrecognized environment ") + spv_env);
   }

--- a/src/shader_compiler_test.cc
+++ b/src/shader_compiler_test.cc
@@ -508,11 +508,13 @@ TEST_P(ParseSpvEnvTest, Samples) {
 const uint32_t vulkan = 0;
 const uint32_t vulkan_1_0 = ((uint32_t(1) << 22));
 const uint32_t vulkan_1_1 = ((uint32_t(1) << 22) | (1 << 12));
+const uint32_t vulkan_1_2 = ((uint32_t(1) << 22) | (2 << 12));
 const uint32_t spv_1_0 = uint32_t(0x10000);
 const uint32_t spv_1_1 = uint32_t(0x10100);
 const uint32_t spv_1_2 = uint32_t(0x10200);
 const uint32_t spv_1_3 = uint32_t(0x10300);
 const uint32_t spv_1_4 = uint32_t(0x10400);
+const uint32_t spv_1_5 = uint32_t(0x10500);
 
 INSTANTIATE_TEST_SUITE_P(ParseSpvEnvFailures,
                          ParseSpvEnvTest,
@@ -522,7 +524,7 @@ INSTANTIATE_TEST_SUITE_P(ParseSpvEnvFailures,
                              {"spv99.9", false, 0u, 0u, 0u},
                              {"spv1.0.1", false, 0u, 0u, 0u},
                              {"spv1.0.1", false, 0u, 0u, 0u},
-                             {"spv1.5", false, 0u, 0u, 0u},
+                             {"spv1.9", false, 0u, 0u, 0u},
                              {"vulkan99", false, 0u, 0u, 0u},
                              {"vulkan99.9", false, 0u, 0u, 0u},
                          }));
@@ -535,11 +537,13 @@ INSTANTIATE_TEST_SUITE_P(ParseSpvEnvSuccesses,
                              {"spv1.1", true, vulkan, vulkan_1_1, spv_1_1},
                              {"spv1.2", true, vulkan, vulkan_1_1, spv_1_2},
                              {"spv1.3", true, vulkan, vulkan_1_1, spv_1_3},
-                             {"spv1.4", true, vulkan, vulkan_1_1, spv_1_4},
+                             {"spv1.4", true, vulkan, vulkan_1_2, spv_1_4},
+                             {"spv1.5", true, vulkan, vulkan_1_2, spv_1_5},
                              {"vulkan1.0", true, vulkan, vulkan_1_0, spv_1_0},
                              {"vulkan1.1", true, vulkan, vulkan_1_1, spv_1_3},
                              {"vulkan1.1spv1.4", true, vulkan, vulkan_1_1,
                               spv_1_4},
+                             {"vulkan1.2", true, vulkan, vulkan_1_2, spv_1_5},
                          }));
 
 }  // namespace amber


### PR DESCRIPTION
Also, now that Vulkan 1.2 exists, the proper target API for "spv1.4"
is Vulkan 1.2 because Vulkan 1.1 supports SPIR-V 1.4 when you also
use extension VK_KHR_spirv_1_4.