### PR TITLE
Roll SwiftShader forward & fix debugger test

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -21,7 +21,7 @@ vars = {
   'shaderc_revision': '821d564bc7896fdd5d68484e10aac30ea192568f',
   'spirv_headers_revision': 'dc77030acc9c6fe7ca21fff54c5a9d7b532d7da6',
   'spirv_tools_revision': '97f1d485b76303ea7094fa164c0cc770b79f6f78',
-  'swiftshader_revision': '5ba2a5b9a43cc07f1d3042d649907ace92e4cb58',
+  'swiftshader_revision': 'ce54c59e657ddf3ffec4b64d024960854aaf8a69',
   'vulkan_headers_revision': '7264358702061d3ed819d62d3d6fd66ab1da33c3',
   'vulkan_loader_revision': '44ac9b2f406f863c69a297a77bd23c28fa29e78d',
   'vulkan_validationlayers_revision': 'c51d450ef72c36014e821a289f38f8a5b5ea1010',

--- a/tests/cases/debugger_spirv_line_stepping.amber
+++ b/tests/cases/debugger_spirv_line_stepping.amber
@@ -89,65 +89,11 @@ END
 # there are no race conditions.
 DEBUG pipeline 1 1 1
     THREAD GLOBAL_INVOCATION_ID 2 0 0
-        EXPECT LOCATION "ComputeShader0.spvasm"  1 "OpCapability Shader"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm"  2 "OpMemoryModel Logical GLSL450"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm"  3 "OpEntryPoint GLCompute %1 \"main\" %2"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm"  4 "OpExecutionMode %1 LocalSize 4 1 1"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm"  5 "OpDecorate %3 ArrayStride 4"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm"  6 "OpMemberDecorate %4 0 Offset 0"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm"  7 "OpDecorate %4 BufferBlock"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm"  8 "OpDecorate %5 DescriptorSet 0"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm"  9 "OpDecorate %5 Binding 1"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 10 "OpDecorate %2 BuiltIn GlobalInvocationId"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 11 "OpDecorate %6 DescriptorSet 0"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 12 "OpDecorate %6 Binding 0"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 13 "%7 = OpTypeVoid"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 14 "%8 = OpTypeFunction %7"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 15 "%9 = OpTypeInt 32 1"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 16 "%10 = OpTypeInt 32 0"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 17 "%3 = OpTypeRuntimeArray %9"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 18 "%4 = OpTypeStruct %3"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 19 "%11 = OpTypePointer Uniform %4"
-        STEP_IN
         EXPECT LOCATION "ComputeShader0.spvasm" 20 "%5 = OpVariable %11 Uniform"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 21 "%12 = OpConstant %9 0"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 22 "%13 = OpConstant %10 0"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 23 "%14 = OpTypeVector %10 3"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 24 "%15 = OpTypePointer Input %14"
         STEP_IN
         EXPECT LOCATION "ComputeShader0.spvasm" 25 "%2 = OpVariable %15 Input"
         STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 26 "%16 = OpTypePointer Input %10"
-        STEP_IN
         EXPECT LOCATION "ComputeShader0.spvasm" 27 "%6 = OpVariable %11 Uniform"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 28 "%17 = OpTypePointer Uniform %9"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 29 "%1 = OpFunction %7 None %8"
-        STEP_IN
-        EXPECT LOCATION "ComputeShader0.spvasm" 30 "%18 = OpLabel"
         STEP_IN
         EXPECT LOCATION "ComputeShader0.spvasm" 31 "%19 = OpAccessChain %16 %2 %13"
         STEP_IN


### PR DESCRIPTION
SwiftShader now ignores SPIR-V 'non-statement' opcodes for the debugger. These are no longer steppable.

`tests/cases/debugger_spirv_line_stepping.amber` has been updated to match this new behaviour.