### PR TITLE
Debugger: Add support for EXPECT CALLSTACK

### DIFF
--- a/docs/debugger.md
+++ b/docs/debugger.md
@@ -70,7 +70,18 @@ Within each `THREAD` command block, you may use any of the following commands to
 * `EXPECT LOCATION` \<file name\> \<line number\> [\<line source\>]
 
   Verifies that the debugger is currently paused at the given line location.
-  The [\<line source\>] is an additional, optional check that verifies the line of the file reported by the debuggeer is as expected.
+  The [\<line source\>] is an additional, optional check that verifies the line of the file reported by the debugger is as expected.
+
+* `EXPECT CALLSTACK`
+
+  Verifies that the debugger is currently paused with the given complete stack frame.
+  Each frame must be declared on a separate line, starting with the most nested call, and has the form:
+
+    \<function name\> [\<file name\> [\<line number\>]]
+
+  The [\<file name\>] and [\<line number\>] fields are additional, optionals checks that verify the file and line numbers reported by the debugger for the frame are as expected.
+
+  The list of stack frames is terminated with `END`.
 
 * `EXPECT LOCAL` \<name\> `EQ` [\<value\>]
 

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -96,6 +96,10 @@ class ThreadScriptImpl : public ThreadScript {
         [=](Thread* t) { t->ExpectLocation(location, line); });
   }
 
+  void ExpectCallstack(const std::vector<StackFrame>& callstack) override {
+    sequence_.emplace_back([=](Thread* t) { t->ExpectCallstack(callstack); });
+  }
+
   void ExpectLocal(const std::string& name, int64_t value) override {
     sequence_.emplace_back([=](Thread* t) { t->ExpectLocal(name, value); });
   }

--- a/src/debug.h
+++ b/src/debug.h
@@ -20,6 +20,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "amber/result.h"
 
@@ -32,8 +33,14 @@ class ThreadScript;
 
 /// Location holds a file path and a 1-based line number.
 struct Location {
-  std::string file;
-  uint32_t line;
+  std::string file;   // empty represents unspecified.
+  uint32_t line = 0;  // 0 represents unspecified.
+};
+
+// StackFrame holds name and location of a stack frame.
+struct StackFrame {
+  std::string name;
+  Location location;
 };
 
 /// Thread is the interface used to control a single debugger thread of
@@ -65,6 +72,12 @@ class Thread {
   /// non-empty, then the line's textual source will also be verified.
   virtual void ExpectLocation(const Location& location,
                               const std::string& line) = 0;
+
+  /// ExpectCallstack verifies that the debugger is currently suspended for the
+  /// given thread of execution with the specified callstack.
+  /// callstack is ordered with the 0th element representing the most nested
+  /// call.
+  virtual void ExpectCallstack(const std::vector<StackFrame>& callstack) = 0;
 
   /// ExpectLocal verifies that the local variable with the given name has the
   /// expected value. |name| may contain `.` delimiters to index structure or

--- a/tests/cases/debugger_hlsl_line_stepping.amber
+++ b/tests/cases/debugger_hlsl_line_stepping.amber
@@ -328,6 +328,10 @@ CLEAR pipeline
 
 DEBUG pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 0 COUNT 6
     THREAD VERTEX_INDEX 2
+        EXPECT CALLSTACK
+            "main" "simple_vs.hlsl" 9
+            "VertexShader"
+        END
         EXPECT LOCATION "simple_vs.hlsl" 9 "  VS_OUTPUT vout;"
         EXPECT LOCAL "pos.x" EQ -1.007874
         EXPECT LOCAL "pos.y" EQ 1.000000

--- a/tests/cases/debugger_spirv_line_stepping.amber
+++ b/tests/cases/debugger_spirv_line_stepping.amber
@@ -89,6 +89,9 @@ END
 # there are no race conditions.
 DEBUG pipeline 1 1 1
     THREAD GLOBAL_INVOCATION_ID 2 0 0
+        EXPECT CALLSTACK
+            "ComputeShader" "ComputeShader0.spvasm" 20
+        END
         EXPECT LOCATION "ComputeShader0.spvasm" 20 "%5 = OpVariable %11 Uniform"
         STEP_IN
         EXPECT LOCATION "ComputeShader0.spvasm" 25 "%2 = OpVariable %15 Input"
@@ -109,6 +112,9 @@ DEBUG pipeline 1 1 1
         STEP_IN
         EXPECT LOCATION "ComputeShader0.spvasm" 36 "OpStore %23 %22"
         STEP_IN
+        EXPECT CALLSTACK
+            "ComputeShader" "ComputeShader0.spvasm" 37
+        END
         EXPECT LOCATION "ComputeShader0.spvasm" 37 "OpReturn"
         CONTINUE
     END


### PR DESCRIPTION
Checks the callstack is as expected.
Note: I've updated the .amber scripts with the current SwiftShader
output. It's clear that this is somewhat wonky, and will change.