### PR TITLE
CommandBuffer reset fixes.

### DIFF
--- a/src/engine.h
+++ b/src/engine.h
@@ -32,7 +32,7 @@ namespace amber {
 /// EngineData stores information used during engine execution.
 struct EngineData {
   /// The timeout to use for fences, in milliseconds.
-  uint32_t fence_timeout_ms = 1000;
+  uint32_t fence_timeout_ms = 10000;
 };
 
 /// Abstract class which describes a backing engine for Amber.

--- a/src/vulkan/command_buffer.cc
+++ b/src/vulkan/command_buffer.cc
@@ -76,8 +76,6 @@ Result CommandBuffer::SubmitAndReset(uint32_t timeout_ms) {
   if (device_->GetPtrs()->vkEndCommandBuffer(command_) != VK_SUCCESS)
     return Result("Vulkan::Calling vkEndCommandBuffer Fail");
 
-  guarded_ = false;
-
   if (device_->GetPtrs()->vkResetFences(device_->GetVkDevice(), 1, &fence_) !=
       VK_SUCCESS) {
     return Result("Vulkan::Calling vkResetFences Fail");
@@ -103,15 +101,17 @@ Result CommandBuffer::SubmitAndReset(uint32_t timeout_ms) {
   if (device_->GetPtrs()->vkResetCommandBuffer(command_, 0) != VK_SUCCESS)
     return Result("Vulkan::Calling vkResetCommandBuffer Fail");
 
+  guarded_ = false;
+
   return {};
 }
 
 void CommandBuffer::Reset() {
   if (guarded_) {
     device_->GetPtrs()->vkEndCommandBuffer(command_);
+    device_->GetPtrs()->vkResetCommandBuffer(command_, 0);
     guarded_ = false;
   }
-  device_->GetPtrs()->vkResetCommandBuffer(command_, 0);
 }
 
 CommandBufferGuard::CommandBufferGuard(CommandBuffer* buffer)

--- a/src/vulkan/command_buffer.cc
+++ b/src/vulkan/command_buffer.cc
@@ -103,7 +103,6 @@ Result CommandBuffer::SubmitAndReset(uint32_t timeout_ms) {
   if (device_->GetPtrs()->vkResetCommandBuffer(command_, 0) != VK_SUCCESS)
     return Result("Vulkan::Calling vkResetCommandBuffer Fail");
 
-
   return {};
 }
 

--- a/src/vulkan/pipeline.h
+++ b/src/vulkan/pipeline.h
@@ -120,7 +120,7 @@ class Pipeline {
   std::vector<DescriptorSetInfo> descriptor_set_info_;
   std::vector<VkPipelineShaderStageCreateInfo> shader_stage_info_;
 
-  uint32_t fence_timeout_ms_ = 100;
+  uint32_t fence_timeout_ms_ = 1000;
   bool descriptor_related_objects_already_created_ = false;
   std::unordered_map<VkShaderStageFlagBits,
                      std::string,

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -78,11 +78,6 @@ SUPPRESSIONS_SWIFTSHADER = [
   "draw_triangle_list_in_r8g8b8a8_snorm_color_frame.vkscript",
   # No supporting device for Float16Int8Features
   "float16.amber",
-  # SEGV: github.com/google/amber/issues/726
-  "matrices_uniform_draw.amber",
-  # SEGV: github.com/google/amber/issues/725
-  "multiple_ssbo_update_with_graphics_pipeline.vkscript",
-  "multiple_ssbo_with_sparse_descriptor_set_in_compute_pipeline_less_than_4.vkscript",
   # Exceeded maxBoundDescriptorSets limit of physical device
   "multiple_ssbo_with_sparse_descriptor_set_in_compute_pipeline.vkscript",
   # shaderStorageImageWriteWithoutFormat but is not enabled on the device

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -78,6 +78,9 @@ SUPPRESSIONS_SWIFTSHADER = [
   "draw_triangle_list_in_r8g8b8a8_snorm_color_frame.vkscript",
   # No supporting device for Float16Int8Features
   "float16.amber",
+  # SEGV: github.com/google/amber/issues/725
+  "multiple_ssbo_update_with_graphics_pipeline.vkscript",
+  "multiple_ssbo_with_sparse_descriptor_set_in_compute_pipeline_less_than_4.vkscript",
   # Exceeded maxBoundDescriptorSets limit of physical device
   "multiple_ssbo_with_sparse_descriptor_set_in_compute_pipeline.vkscript",
   # shaderStorageImageWriteWithoutFormat but is not enabled on the device


### PR DESCRIPTION
Currently it is possible for the command buffer to have begun work and
not be reset before we shut down the vulkan engine. This CL moves the
reset call into the command buffer and moves the guards into the command
buffer methods themselves.

As well, the fence timeout is updated to 10s from 1s which gives more time for Swiftshader to execute the submissions.

Fixes #726 