### PR TITLE
Add support for 8-bit int shader/storage features

### DIFF
--- a/docs/amber_script.md
+++ b/docs/amber_script.md
@@ -38,6 +38,10 @@ with:
  * `VariablePointerFeatures.variablePointers`
  * `VariablePointerFeatures.variablePointersStorageBuffer`
  * `Float16Int8Features.shaderFloat16`
+ * `Float16Int8Features.shaderInt8`
+ * `Storage8BitFeatures.storageBuffer8BitAccess`
+ * `Storage8BitFeatures.uniformAndStorageBuffer8BitAccess`
+ * `Storage8BitFeatures.storagePushConstant8`
 
 Extensions can be enabled with the `DEVICE_EXTENSION` and `INSTANCE_EXTENSION`
 commands.

--- a/samples/config_helper_vulkan.h
+++ b/samples/config_helper_vulkan.h
@@ -111,10 +111,12 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
 
   bool supports_get_physical_device_properties2_ = false;
   bool supports_shader_float16_int8_ = false;
+  bool supports_shader_int8_storage_ = false;
   VkPhysicalDeviceFeatures available_features_;
   VkPhysicalDeviceFeatures2KHR available_features2_;
   VkPhysicalDeviceVariablePointerFeaturesKHR variable_pointers_feature_;
   VkPhysicalDeviceFloat16Int8FeaturesKHR float16_int8_feature_;
+  VkPhysicalDevice8BitStorageFeaturesKHR int8_storage_feature_;
 };
 
 }  // namespace sample

--- a/src/amberscript/parser_device_feature_test.cc
+++ b/src/amberscript/parser_device_feature_test.cc
@@ -24,7 +24,11 @@ TEST_F(AmberScriptParserTest, DeviceFeature) {
   std::string in = R"(
 DEVICE_FEATURE vertexPipelineStoresAndAtomics
 DEVICE_FEATURE VariablePointerFeatures.variablePointersStorageBuffer
-DEVICE_FEATURE Float16Int8Features.shaderFloat16)";
+DEVICE_FEATURE Float16Int8Features.shaderFloat16
+DEVICE_FEATURE Float16Int8Features.shaderInt8
+DEVICE_FEATURE Storage8BitFeatures.storageBuffer8BitAccess
+DEVICE_FEATURE Storage8BitFeatures.uniformAndStorageBuffer8BitAccess
+DEVICE_FEATURE Storage8BitFeatures.storagePushConstant8)";
 
   Parser parser;
   Result r = parser.Parse(in);
@@ -32,11 +36,16 @@ DEVICE_FEATURE Float16Int8Features.shaderFloat16)";
 
   auto script = parser.GetScript();
   const auto& features = script->GetRequiredFeatures();
-  ASSERT_EQ(3U, features.size());
+  ASSERT_EQ(7U, features.size());
   EXPECT_EQ("vertexPipelineStoresAndAtomics", features[0]);
   EXPECT_EQ("VariablePointerFeatures.variablePointersStorageBuffer",
             features[1]);
   EXPECT_EQ("Float16Int8Features.shaderFloat16", features[2]);
+  EXPECT_EQ("Float16Int8Features.shaderInt8", features[3]);
+  EXPECT_EQ("Storage8BitFeatures.storageBuffer8BitAccess", features[4]);
+  EXPECT_EQ("Storage8BitFeatures.uniformAndStorageBuffer8BitAccess",
+            features[5]);
+  EXPECT_EQ("Storage8BitFeatures.storagePushConstant8", features[6]);
 }
 
 TEST_F(AmberScriptParserTest, DeviceFeatureMissingFeature) {

--- a/src/script.cc
+++ b/src/script.cc
@@ -101,7 +101,11 @@ bool Script::IsKnownFeature(const std::string& name) const {
          name == "variableMultisampleRate" || name == "inheritedQueries" ||
          name == "VariablePointerFeatures.variablePointers" ||
          name == "VariablePointerFeatures.variablePointersStorageBuffer" ||
-         name == "Float16Int8Features.shaderFloat16";
+         name == "Float16Int8Features.shaderFloat16" ||
+         name == "Float16Int8Features.shaderInt8" ||
+         name == "Storage8BitFeatures.storageBuffer8BitAccess" ||
+         name == "Storage8BitFeatures.uniformAndStorageBuffer8BitAccess" ||
+         name == "Storage8BitFeatures.storagePushConstant8";
 }
 
 type::Type* Script::ParseType(const std::string& str) {

--- a/tests/cases/int8.amber
+++ b/tests/cases/int8.amber
@@ -1,0 +1,53 @@
+#!amber
+# Copyright 2020 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+INSTANCE_EXTENSION VK_KHR_get_physical_device_properties2
+DEVICE_EXTENSION VK_KHR_shader_float16_int8
+DEVICE_EXTENSION VK_KHR_storage_buffer_storage_class
+DEVICE_EXTENSION VK_KHR_8bit_storage
+DEVICE_FEATURE Float16Int8Features.shaderInt8
+DEVICE_FEATURE Storage8BitFeatures.uniformAndStorageBuffer8BitAccess
+DEVICE_FEATURE Storage8BitFeatures.storagePushConstant8
+
+SHADER compute comp_shader GLSL
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+
+layout(set=0, binding=0) buffer Buf {
+  int8_t value;
+} data;
+
+layout(push_constant) uniform PushConstantsBlock {
+  int8_t factor;
+} pushConstants;
+
+void main() {
+  data.value = data.value * pushConstants.factor;
+}
+END
+
+BUFFER buf DATA_TYPE int8 DATA 63 END
+BUFFER pushc DATA_TYPE int8 DATA 2 END
+
+PIPELINE compute pipeline
+  ATTACH comp_shader
+
+  BIND BUFFER buf AS storage DESCRIPTOR_SET 0 BINDING 0
+  BIND BUFFER pushc AS push_constant
+END
+
+RUN pipeline 1 1 1
+
+EXPECT buf IDX 0 EQ 126

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -78,6 +78,7 @@ SUPPRESSIONS_SWIFTSHADER = [
   "draw_triangle_list_in_r8g8b8a8_snorm_color_frame.vkscript",
   # No supporting device for Float16Int8Features
   "float16.amber",
+  "int8.amber",
   # SEGV: github.com/google/amber/issues/725
   "multiple_ssbo_update_with_graphics_pipeline.vkscript",
   "multiple_ssbo_with_sparse_descriptor_set_in_compute_pipeline_less_than_4.vkscript",


### PR DESCRIPTION
This pull request adds support for 8-bit integers to be used in shaders, both as a basic type and for input/output as part of push constants and uniform/storage blocks. It adds 4 new features understood by Amberscript which are needed to request the corresponding Vulkan features. The original structure is called "8BitStorageFeatures" but it has been renamed to "Storage8BitFeatures" due to the leading digit causing problems to the parser.