### PR TITLE
Switch to rsplit for repo path in git-sync-deps

### DIFF
--- a/tools/git-sync-deps
+++ b/tools/git-sync-deps
@@ -224,7 +224,7 @@ def git_sync_deps(deps_file_path, command_line_os_requests, verbose):
   list_of_arg_lists = []
   for directory in sorted(dependencies):
     if '@' in dependencies[directory]:
-      repo, checkoutable = dependencies[directory].split('@', 1)
+      repo, checkoutable = dependencies[directory].rsplit('@', 1)
     else:
       raise Exception("please specify commit or tag")
 


### PR DESCRIPTION
This CL changes git-sync-deps to split from the right side when looking
for the @ sign. This should allow SSH URLs which have multiple @'s in
them to work properly.

Fixes #786