### PR TITLE
Enable swiftshader on MacOS Debug

### DIFF
--- a/kokoro/macos-clang-debug/build.sh
+++ b/kokoro/macos-clang-debug/build.sh
@@ -17,4 +17,4 @@ set -e  # fail on error
 set -x  # display commands
 
 SCRIPT_DIR=`dirname "$BASH_SOURCE"`
-source $SCRIPT_DIR/../scripts/macos/build.sh DEBUG clang
+source $SCRIPT_DIR/../scripts/macos/build.sh DEBUG clang -DAMBER_ENABLE_SWIFTSHADER=TRUE


### PR DESCRIPTION
There were several fixes that went in to fix timeout issues with Amber
and Swiftshader. They appear as the same validation errors we saw on the
MacOS debug bot.

Fixes #752