### PR TITLE
Android builds need Android NDK r20

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Alternatives:
 
 ### Android
 
-* Android build needs Android SDK 28, Android NDK 16, Java 8. If you prefer
+* Android build needs Android SDK 28, Android NDK r20, Java 8. If you prefer
   other versions of Android SDK, Android NDK, Java, then you can change
   `ANDROID_PLATFORM` and `ANDROID_BUILD_TOOL_VERSION` in
   `tools/build-amber-sample.sh`.


### PR DESCRIPTION
With NDK r16, you get a compile failure since the Vulkan headers
in that version of the NDK lack support for VK_KHR_shader_float16_int8,
and so are missing VkPhysicalDeviceFloat16Int8FeaturesKHR.

The Kokoro Android bots use NDK r20.