### PR TITLE
Add support for 16-bit storage features

### DIFF
--- a/docs/amber_script.md
+++ b/docs/amber_script.md
@@ -42,6 +42,10 @@ with:
  * `Storage8BitFeatures.storageBuffer8BitAccess`
  * `Storage8BitFeatures.uniformAndStorageBuffer8BitAccess`
  * `Storage8BitFeatures.storagePushConstant8`
+ * `Storage16BitFeatures.storageBuffer16BitAccess`
+ * `Storage16BitFeatures.uniformAndStorageBuffer16BitAccess`
+ * `Storage16BitFeatures.storagePushConstant16`
+ * `Storage16BitFeatures.storageInputOutput16`
 
 Extensions can be enabled with the `DEVICE_EXTENSION` and `INSTANCE_EXTENSION`
 commands.

--- a/samples/config_helper_vulkan.cc
+++ b/samples/config_helper_vulkan.cc
@@ -54,6 +54,14 @@ const char k8BitStorage_UniformAndStorage[] =
     "Storage8BitFeatures.uniformAndStorageBuffer8BitAccess";
 const char k8BitStorage_PushConstant[] =
     "Storage8BitFeatures.storagePushConstant8";
+const char k16BitStorage_Storage[] =
+    "Storage16BitFeatures.storageBuffer16BitAccess";
+const char k16BitStorage_UniformAndStorage[] =
+    "Storage16BitFeatures.uniformAndStorageBuffer16BitAccess";
+const char k16BitStorage_PushConstant[] =
+    "Storage16BitFeatures.storagePushConstant16";
+const char k16BitStorage_InputOutput[] =
+    "Storage16BitFeatures.storageInputOutput16";
 
 const char kExtensionForValidationLayer[] = "VK_EXT_debug_report";
 
@@ -608,7 +616,8 @@ ConfigHelperVulkan::ConfigHelperVulkan()
       available_features2_(VkPhysicalDeviceFeatures2KHR()),
       variable_pointers_feature_(VkPhysicalDeviceVariablePointerFeaturesKHR()),
       float16_int8_feature_(VkPhysicalDeviceFloat16Int8FeaturesKHR()),
-      int8_storage_feature_(VkPhysicalDevice8BitStorageFeaturesKHR()) {}
+      storage_8bit_feature_(VkPhysicalDevice8BitStorageFeaturesKHR()),
+      storage_16bit_feature_(VkPhysicalDevice16BitStorageFeaturesKHR()) {}
 
 ConfigHelperVulkan::~ConfigHelperVulkan() {
   if (vulkan_device_)
@@ -787,7 +796,9 @@ amber::Result ConfigHelperVulkan::CheckVulkanPhysicalDeviceRequirements(
     if (ext == "VK_KHR_shader_float16_int8")
       supports_shader_float16_int8_ = true;
     else if (ext == "VK_KHR_8bit_storage")
-      supports_shader_int8_storage_ = true;
+      supports_shader_8bit_storage_ = true;
+    else if (ext == "VK_KHR_16bit_storage")
+      supports_shader_16bit_storage_ = true;
   }
 
   vulkan_queue_family_index_ = ChooseQueueFamilyIndex(physical_device);
@@ -904,9 +915,13 @@ amber::Result ConfigHelperVulkan::CreateDeviceWithFeatures2(
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR;
   float16_int8_feature_.pNext = nullptr;
 
-  int8_storage_feature_.sType =
+  storage_8bit_feature_.sType =
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR;
-  int8_storage_feature_.pNext = nullptr;
+  storage_8bit_feature_.pNext = nullptr;
+
+  storage_16bit_feature_.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES_KHR;
+  storage_16bit_feature_.pNext = nullptr;
 
   void** next_ptr = &variable_pointers_feature_.pNext;
 
@@ -915,9 +930,14 @@ amber::Result ConfigHelperVulkan::CreateDeviceWithFeatures2(
     next_ptr = &float16_int8_feature_.pNext;
   }
 
-  if (supports_shader_int8_storage_) {
-    *next_ptr = &int8_storage_feature_;
-    next_ptr = &int8_storage_feature_.pNext;
+  if (supports_shader_8bit_storage_) {
+    *next_ptr = &storage_8bit_feature_;
+    next_ptr = &storage_8bit_feature_.pNext;
+  }
+
+  if (supports_shader_16bit_storage_) {
+    *next_ptr = &storage_16bit_feature_;
+    next_ptr = &storage_16bit_feature_.pNext;
   }
 
   available_features2_.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR;
@@ -940,11 +960,19 @@ amber::Result ConfigHelperVulkan::CreateDeviceWithFeatures2(
     else if (feature == kFloat16Int8_Int8)
       float16_int8_feature_.shaderInt8 = VK_TRUE;
     else if (feature == k8BitStorage_Storage)
-      int8_storage_feature_.storageBuffer8BitAccess = VK_TRUE;
+      storage_8bit_feature_.storageBuffer8BitAccess = VK_TRUE;
     else if (feature == k8BitStorage_UniformAndStorage)
-      int8_storage_feature_.uniformAndStorageBuffer8BitAccess = VK_TRUE;
+      storage_8bit_feature_.uniformAndStorageBuffer8BitAccess = VK_TRUE;
     else if (feature == k8BitStorage_PushConstant)
-      int8_storage_feature_.storagePushConstant8 = VK_TRUE;
+      storage_8bit_feature_.storagePushConstant8 = VK_TRUE;
+    else if (feature == k16BitStorage_Storage)
+      storage_16bit_feature_.storageBuffer16BitAccess = VK_TRUE;
+    else if (feature == k16BitStorage_UniformAndStorage)
+      storage_16bit_feature_.uniformAndStorageBuffer16BitAccess = VK_TRUE;
+    else if (feature == k16BitStorage_PushConstant)
+      storage_16bit_feature_.storagePushConstant16 = VK_TRUE;
+    else if (feature == k16BitStorage_InputOutput)
+      storage_16bit_feature_.storageInputOutput16 = VK_TRUE;
   }
 
   VkPhysicalDeviceFeatures required_vulkan_features =

--- a/samples/config_helper_vulkan.h
+++ b/samples/config_helper_vulkan.h
@@ -111,12 +111,14 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
 
   bool supports_get_physical_device_properties2_ = false;
   bool supports_shader_float16_int8_ = false;
-  bool supports_shader_int8_storage_ = false;
+  bool supports_shader_8bit_storage_ = false;
+  bool supports_shader_16bit_storage_ = false;
   VkPhysicalDeviceFeatures available_features_;
   VkPhysicalDeviceFeatures2KHR available_features2_;
   VkPhysicalDeviceVariablePointerFeaturesKHR variable_pointers_feature_;
   VkPhysicalDeviceFloat16Int8FeaturesKHR float16_int8_feature_;
-  VkPhysicalDevice8BitStorageFeaturesKHR int8_storage_feature_;
+  VkPhysicalDevice8BitStorageFeaturesKHR storage_8bit_feature_;
+  VkPhysicalDevice16BitStorageFeaturesKHR storage_16bit_feature_;
 };
 
 }  // namespace sample

--- a/src/amberscript/parser_device_feature_test.cc
+++ b/src/amberscript/parser_device_feature_test.cc
@@ -28,7 +28,11 @@ DEVICE_FEATURE Float16Int8Features.shaderFloat16
 DEVICE_FEATURE Float16Int8Features.shaderInt8
 DEVICE_FEATURE Storage8BitFeatures.storageBuffer8BitAccess
 DEVICE_FEATURE Storage8BitFeatures.uniformAndStorageBuffer8BitAccess
-DEVICE_FEATURE Storage8BitFeatures.storagePushConstant8)";
+DEVICE_FEATURE Storage8BitFeatures.storagePushConstant8
+DEVICE_FEATURE Storage16BitFeatures.storageBuffer16BitAccess
+DEVICE_FEATURE Storage16BitFeatures.uniformAndStorageBuffer16BitAccess
+DEVICE_FEATURE Storage16BitFeatures.storagePushConstant16
+DEVICE_FEATURE Storage16BitFeatures.storageInputOutput16)";
 
   Parser parser;
   Result r = parser.Parse(in);
@@ -36,7 +40,7 @@ DEVICE_FEATURE Storage8BitFeatures.storagePushConstant8)";
 
   auto script = parser.GetScript();
   const auto& features = script->GetRequiredFeatures();
-  ASSERT_EQ(7U, features.size());
+  ASSERT_EQ(11U, features.size());
   EXPECT_EQ("vertexPipelineStoresAndAtomics", features[0]);
   EXPECT_EQ("VariablePointerFeatures.variablePointersStorageBuffer",
             features[1]);
@@ -46,6 +50,11 @@ DEVICE_FEATURE Storage8BitFeatures.storagePushConstant8)";
   EXPECT_EQ("Storage8BitFeatures.uniformAndStorageBuffer8BitAccess",
             features[5]);
   EXPECT_EQ("Storage8BitFeatures.storagePushConstant8", features[6]);
+  EXPECT_EQ("Storage16BitFeatures.storageBuffer16BitAccess", features[7]);
+  EXPECT_EQ("Storage16BitFeatures.uniformAndStorageBuffer16BitAccess",
+            features[8]);
+  EXPECT_EQ("Storage16BitFeatures.storagePushConstant16", features[9]);
+  EXPECT_EQ("Storage16BitFeatures.storageInputOutput16", features[10]);
 }
 
 TEST_F(AmberScriptParserTest, DeviceFeatureMissingFeature) {

--- a/src/script.cc
+++ b/src/script.cc
@@ -105,7 +105,11 @@ bool Script::IsKnownFeature(const std::string& name) const {
          name == "Float16Int8Features.shaderInt8" ||
          name == "Storage8BitFeatures.storageBuffer8BitAccess" ||
          name == "Storage8BitFeatures.uniformAndStorageBuffer8BitAccess" ||
-         name == "Storage8BitFeatures.storagePushConstant8";
+         name == "Storage8BitFeatures.storagePushConstant8" ||
+         name == "Storage16BitFeatures.storageBuffer16BitAccess" ||
+         name == "Storage16BitFeatures.uniformAndStorageBuffer16BitAccess" ||
+         name == "Storage16BitFeatures.storagePushConstant16" ||
+         name == "Storage16BitFeatures.storageInputOutput16";
 }
 
 type::Type* Script::ParseType(const std::string& str) {

--- a/src/vulkan/device.cc
+++ b/src/vulkan/device.cc
@@ -40,6 +40,14 @@ const char k8BitStorage_UniformAndStorage[] =
     "Storage8BitFeatures.uniformAndStorageBuffer8BitAccess";
 const char k8BitStorage_PushConstant[] =
     "Storage8BitFeatures.storagePushConstant8";
+const char k16BitStorage_Storage[] =
+    "Storage16BitFeatures.storageBuffer16BitAccess";
+const char k16BitStorage_UniformAndStorage[] =
+    "Storage16BitFeatures.uniformAndStorageBuffer16BitAccess";
+const char k16BitStorage_PushConstant[] =
+    "Storage16BitFeatures.storagePushConstant16";
+const char k16BitStorage_InputOutput[] =
+    "Storage16BitFeatures.storageInputOutput16";
 
 struct BaseOutStructure {
   VkStructureType sType;
@@ -404,6 +412,7 @@ Result Device::Initialize(
     VkPhysicalDeviceVariablePointerFeaturesKHR* var_ptrs = nullptr;
     VkPhysicalDeviceFloat16Int8FeaturesKHR* float16_ptrs = nullptr;
     VkPhysicalDevice8BitStorageFeaturesKHR* storage8_ptrs = nullptr;
+    VkPhysicalDevice16BitStorageFeaturesKHR* storage16_ptrs = nullptr;
     void* ptr = available_features2.pNext;
     while (ptr != nullptr) {
       BaseOutStructure* s = static_cast<BaseOutStructure*>(ptr);
@@ -419,6 +428,10 @@ Result Device::Initialize(
                  VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR) {
         storage8_ptrs =
             static_cast<VkPhysicalDevice8BitStorageFeaturesKHR*>(ptr);
+      } else if (s->sType ==
+                 VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES_KHR) {
+        storage16_ptrs =
+            static_cast<VkPhysicalDevice16BitStorageFeaturesKHR*>(ptr);
       }
       ptr = s->pNext;
     }
@@ -482,6 +495,32 @@ Result Device::Initialize(
       if (feature == k8BitStorage_PushConstant &&
           storage8_ptrs->storagePushConstant8 != VK_TRUE) {
         return amber::Result("Missing 8-bit push constant access");
+      }
+
+      if ((feature == k16BitStorage_Storage ||
+           feature == k16BitStorage_UniformAndStorage ||
+           feature == k16BitStorage_PushConstant ||
+           feature == k16BitStorage_InputOutput) &&
+          storage16_ptrs == nullptr) {
+        return amber::Result(
+            "Shader 16-bit storage requested but feature not returned");
+      }
+
+      if (feature == k16BitStorage_Storage &&
+          storage16_ptrs->storageBuffer16BitAccess != VK_TRUE) {
+        return amber::Result("Missing 16-bit storage access");
+      }
+      if (feature == k16BitStorage_UniformAndStorage &&
+          storage16_ptrs->uniformAndStorageBuffer16BitAccess != VK_TRUE) {
+        return amber::Result("Missing 16-bit uniform and storage access");
+      }
+      if (feature == k16BitStorage_PushConstant &&
+          storage16_ptrs->storagePushConstant16 != VK_TRUE) {
+        return amber::Result("Missing 16-bit push constant access");
+      }
+      if (feature == k16BitStorage_InputOutput &&
+          storage16_ptrs->storageInputOutput16 != VK_TRUE) {
+        return amber::Result("Missing 16-bit input/output access");
       }
     }
 

--- a/tests/cases/storage16.amber
+++ b/tests/cases/storage16.amber
@@ -1,0 +1,52 @@
+#!amber
+# Copyright 2020 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+INSTANCE_EXTENSION VK_KHR_get_physical_device_properties2
+DEVICE_EXTENSION VK_KHR_storage_buffer_storage_class
+DEVICE_EXTENSION VK_KHR_16bit_storage
+DEVICE_FEATURE shaderInt16
+DEVICE_FEATURE Storage16BitFeatures.uniformAndStorageBuffer16BitAccess
+DEVICE_FEATURE Storage16BitFeatures.storagePushConstant16
+
+SHADER compute comp_shader GLSL
+#version 450
+#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require
+
+layout(set=0, binding=0) buffer Buf {
+  int16_t value;
+} data;
+
+layout(push_constant) uniform PushConstantsBlock {
+  int16_t factor;
+} pushConstants;
+
+void main() {
+  data.value = data.value * pushConstants.factor;
+}
+END
+
+BUFFER buf DATA_TYPE int16 DATA 16383 END
+BUFFER pushc DATA_TYPE int16 DATA 2 END
+
+PIPELINE compute pipeline
+  ATTACH comp_shader
+
+  BIND BUFFER buf AS storage DESCRIPTOR_SET 0 BINDING 0
+  BIND BUFFER pushc AS push_constant
+END
+
+RUN pipeline 1 1 1
+
+EXPECT buf IDX 0 EQ 32766

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -79,6 +79,8 @@ SUPPRESSIONS_SWIFTSHADER = [
   # No supporting device for Float16Int8Features
   "float16.amber",
   "int8.amber",
+  # No supporting device for the required 16-bit storage features
+  "storage16.amber",
   # SEGV: github.com/google/amber/issues/725
   "multiple_ssbo_update_with_graphics_pipeline.vkscript",
   "multiple_ssbo_with_sparse_descriptor_set_in_compute_pipeline_less_than_4.vkscript",


### PR DESCRIPTION
This commits adds support for requesting 16-bit storage features as
specified in VkPhysicalDevice16BitStorageFeaturesKHR by using the
following feature names:

  * Storage16BitFeatures.storageBuffer16BitAccess
  * Storage16BitFeatures.uniformAndStorageBuffer16BitAccess
  * Storage16BitFeatures.storagePushConstant16
  * Storage16BitFeatures.storageInputOutput16