### PR TITLE
Set the propoer bytes for OpenCL SET commands

### DIFF
--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -1024,6 +1024,9 @@ Result Parser::ParsePipelineSet(Pipeline* pipeline) {
   if (!type)
     return Result("invalid data type '" + token->AsString() + "' provided");
 
+  if (type->IsVec() || type->IsMatrix() || type->IsArray() || type->IsStruct())
+    return Result("data type must be a scalar type");
+
   token = tokenizer_->NextToken();
   if (!token->IsInteger() && !token->IsDouble())
     return Result("expected data value");

--- a/src/amberscript/parser_pipeline_set_test.cc
+++ b/src/amberscript/parser_pipeline_set_test.cc
@@ -241,5 +241,22 @@ END
   EXPECT_EQ("7: SET can only be used with OPENCL-C shaders", r.Error());
 }
 
+TEST_F(AmberScriptParserTest, OpenCLSetNonScalarDataType) {
+  std::string in = R"(
+SHADER compute my_shader OPENCL-C
+#shader
+END
+PIPELINE compute my_pipeline
+  ATTACH my_shader
+  SET KERNEL ARG_NAME arg_a AS vec4<uint32> 0 0 0 0
+END
+)";
+
+  Parser parser;
+  auto r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess());
+  EXPECT_EQ("7: data type must be a scalar type", r.Error());
+}
+
 }  // namespace amberscript
 }  // namespace amber

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -757,10 +757,9 @@ Result Pipeline::GenerateOpenCLPodBuffers() {
 
     // Convert the argument value into bytes. Currently, only scalar arguments
     // are supported.
-    const auto buffer_byte_size = buffer->GetFormat()->SizeInBytes();
     const auto arg_byte_size = arg_info.fmt->SizeInBytes();
     std::vector<Value> data_bytes;
-    for (auto i = 0; i < arg_byte_size; ++i) {
+    for (uint32_t i = 0; i < arg_byte_size; ++i) {
       Value v;
       if (arg_info.value.IsFloat()) {
         if (arg_byte_size == sizeof(double)) {


### PR DESCRIPTION
Fixes #814

* Convert the SET values into bytes before filling in the buffer
* Add a parser check that the type is a scalar
  * add a test