### PR TITLE
Debugger: Scan for VIRTUAL_FILEs and wait for steps

### DIFF
--- a/src/dawn/engine_dawn.h
+++ b/src/dawn/engine_dawn.h
@@ -63,7 +63,7 @@ class EngineDawn : public Engine {
       const PatchParameterVerticesCommand* cmd) override;
   Result DoBuffer(const BufferCommand* cmd) override;
 
-  std::pair<Debugger*, Result> GetDebugger() override {
+  std::pair<Debugger*, Result> GetDebugger(VirtualFileStore*) override {
     return {nullptr, Result("Dawn does not currently support a debugger")};
   }
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -29,6 +29,8 @@
 
 namespace amber {
 
+class VirtualFileStore;
+
 /// EngineData stores information used during engine execution.
 struct EngineData {
   /// The timeout to use for fences, in milliseconds.
@@ -123,7 +125,7 @@ class Engine {
   /// GetDebugger returns the shader debugger from the engine.
   /// If the engine does not support a shader debugger then the Result will be a
   /// failure.
-  virtual std::pair<Debugger*, Result> GetDebugger() = 0;
+  virtual std::pair<Debugger*, Result> GetDebugger(VirtualFileStore*) = 0;
 
   /// Sets the engine data to use.
   void SetEngineData(const EngineData& data) { engine_data_ = data; }

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -116,7 +116,8 @@ Result Executor::Execute(Engine* engine,
       if (debugger == nullptr) {
         // Lazilly obtain the debugger from the engine.
         Result res;
-        std::tie(debugger, res) = engine->GetDebugger();
+        std::tie(debugger, res) =
+            engine->GetDebugger(script->GetVirtualFiles());
         if (!res.IsSuccess()) {
           return res;
         }

--- a/src/executor_test.cc
+++ b/src/executor_test.cc
@@ -167,7 +167,7 @@ class EngineStub : public Engine {
     return {};
   }
 
-  std::pair<Debugger*, Result> GetDebugger() override {
+  std::pair<Debugger*, Result> GetDebugger(VirtualFileStore*) override {
     return {nullptr,
             Result("EngineStub does not currently support a debugger")};
   }

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -64,7 +64,7 @@ class EngineVulkan : public Engine {
       const PatchParameterVerticesCommand* cmd) override;
   Result DoBuffer(const BufferCommand* cmd) override;
 
-  std::pair<Debugger*, Result> GetDebugger() override;
+  std::pair<Debugger*, Result> GetDebugger(VirtualFileStore*) override;
 
  private:
   struct PipelineInfo {

--- a/tests/cases/debugger_hlsl_line_stepping.amber
+++ b/tests/cases/debugger_hlsl_line_stepping.amber
@@ -15,6 +15,21 @@
 
 SET ENGINE_DATA fence_timeout_ms 1000000
 
+VIRTUAL_FILE "vertex-shader.hlsl"
+/* 1*/ struct VS_OUTPUT {
+/* 2*/   float4 pos : SV_POSITION;
+/* 3*/   float4 color : COLOR;
+/* 4*/ };
+/* 5*/
+/* 6*/ VS_OUTPUT main(float4 pos : POSITION,
+/* 7*/                float4 color : COLOR) {
+/* 8*/   VS_OUTPUT vout;
+/* 9*/   vout.pos = pos;
+/*10*/   vout.color = color;
+/*11*/   return vout;
+/*12*/ }
+END
+
 SHADER vertex vtex_shader SPIRV-ASM
 ; SPIR-V
 ; Version: 1.0
@@ -25,35 +40,7 @@ SHADER vertex vtex_shader SPIRV-ASM
      %DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main" %pos %color %gl_Position %out_var_COLOR
-        %src = OpString "simple_vs.hlsl"
-       %code = OpString "
-struct VS_OUTPUT {
-  float4 pos : SV_POSITION;
-  float4 color : COLOR;
-};
-
-VS_OUTPUT main(float4 pos : POSITION,
-               float4 color : COLOR) {
-  VS_OUTPUT vout;
-  vout.pos = pos;
-  vout.color = color;
-  return vout;
-}
-"
-               OpSource HLSL 600 %src "
-struct VS_OUTPUT {
-  float4 pos : SV_POSITION;
-  float4 color : COLOR;
-};
-
-VS_OUTPUT main(float4 pos : POSITION,
-               float4 color : COLOR) {
-  VS_OUTPUT vout;
-  vout.pos = pos;
-  vout.color = color;
-  return vout;
-}
-"
+        %src = OpString "vertex-shader.hlsl"
                OpName %out_var_COLOR "out.var.COLOR"
                OpName %main "main"
                OpName %VS_OUTPUT "VS_OUTPUT"
@@ -81,7 +68,7 @@ VS_OUTPUT main(float4 pos : POSITION,
 %_ptr_Function_VS_OUTPUT = OpTypePointer Function %VS_OUTPUT
 
 ; Compilation Unit
-%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
 
 ; Type names
@@ -112,11 +99,11 @@ VS_OUTPUT main(float4 pos : POSITION,
 ; DebugExpression without any information
 %null_expr = OpExtInst %void %DbgExt DebugExpression
 
-; Lexical scope for main
-%main_lex_scope = OpExtInst %void %DbgExt DebugLexicalBlock %dbg_src 6 1 %comp_unit
-
 ; Function information
-%main_func = OpExtInst %void %DbgExt DebugFunction %main_name %main_type %dbg_src 6 1 %main_lex_scope %main_linkage_name FlagIsPublic 7 %src_main
+%main_func = OpExtInst %void %DbgExt DebugFunction %main_name %main_type %dbg_src 6 1 %comp_unit %main_linkage_name FlagIsPublic 7 %src_main
+
+; Lexical scope for main
+%main_lex_scope = OpExtInst %void %DbgExt DebugLexicalBlock %dbg_src 6 1 %main_func
 
 ; Local variable information
 %pos_info = OpExtInst %void %DbgExt DebugLocalVariable %pos_name %v4float_info %dbg_src 6 16 %main_lex_scope FlagIsLocal 0
@@ -146,7 +133,7 @@ VS_OUTPUT main(float4 pos : POSITION,
 ; Declaration of "VS_OUTPUT vout" local variable in main()
 %vout_decl = OpExtInst %void %DbgExt DebugDeclare %vout_info %vout %null_expr
 
-               OpLine %src 9 3
+               OpLine %src 8 3
          %21 = OpLoad %v4float %pos
          %22 = OpAccessChain %_ptr_Function_v4float %vout %int_0
 
@@ -154,7 +141,7 @@ VS_OUTPUT main(float4 pos : POSITION,
 %vout_pos_value = OpExtInst %void %DbgExt DebugValue %vout_info %22 %null_expr %int_0
 
                OpStore %22 %21
-               OpLine %src 10 3
+               OpLine %src 9 3
          %23 = OpLoad %v4float %color
          %24 = OpAccessChain %_ptr_Function_v4float %vout %int_1
 
@@ -162,13 +149,13 @@ VS_OUTPUT main(float4 pos : POSITION,
 %vout_color_value = OpExtInst %void %DbgExt DebugValue %vout_info %24 %null_expr %int_1
 
                OpStore %24 %23
-               OpLine %src 11 3
+               OpLine %src 10 3
          %25 = OpLoad %VS_OUTPUT %vout
          %26 = OpCompositeExtract %v4float %25 0
                OpStore %gl_Position %26
          %27 = OpCompositeExtract %v4float %25 1
                OpStore %out_var_COLOR %27
-               OpLine %src 12 3
+               OpLine %src 11 3
                OpReturn
 
 ; End the scope of function "main()"
@@ -184,24 +171,9 @@ SHADER fragment frag_shader SPIRV-ASM
 ; Bound: 14
 ; Schema: 0
                OpCapability Shader
-     %DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %color %out_var_SV_TARGET
                OpExecutionMode %main OriginUpperLeft
-        %src = OpString "simple_ps.hlsl"
-       %code = OpString "#line 1 \"simple_ps.hlsl\"
-float4 main(float4 color : COLOR) : SV_TARGET {
-  return color;
-}
-"
-               OpSource HLSL 600 %src "#line 1 \"simple_ps.hlsl\"
-float4 main(float4 color : COLOR) : SV_TARGET {
-  return color;
-}
-"
-               OpName %out_var_SV_TARGET "out.var.SV_TARGET"
-               OpName %main "main"
-               OpName %color "color"
                OpDecorate %color Location 0
                OpDecorate %out_var_SV_TARGET Location 0
         %int = OpTypeInt 32 1
@@ -213,62 +185,13 @@ float4 main(float4 color : COLOR) : SV_TARGET {
           %9 = OpTypeFunction %void
 %_ptr_Function_v4float = OpTypePointer Function %v4float
          %11 = OpTypeFunction %v4float %_ptr_Function_v4float
-
-; Compilation Unit
-%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
-%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
-
-; Type names
-%float_name = OpString "float"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v4f_main_v4f"
-%color_name = OpString "color : COLOR"
-
-; Type sizes in bit unit. For example, 128 means "128 bits"
-%int_32 = OpConstant %int 32
-%int_128 = OpConstant %int 128
-
-; Type information
-%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %int_32 Float
-%v4float_info = OpExtInst %void %DbgExt DebugTypeVector %float_info 4
-%main_type = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %v4float_info %v4float_info
-
-; DebugExpression without any information
-%null_expr = OpExtInst %void %DbgExt DebugExpression
-
-; Lexical scope for main
-%main_lex_scope = OpExtInst %void %DbgExt DebugLexicalBlock %dbg_src 1 1 %comp_unit
-
-; Function information
-%main_func = OpExtInst %void %DbgExt DebugFunction %main_name %main_type %dbg_src 1 1 %main_lex_scope %main_linkage_name FlagIsPublic 1 %src_main
-
-; Local variable information
-%color_info = OpExtInst %void %DbgExt DebugLocalVariable %color_name %v4float_info %dbg_src 1 13 %main_lex_scope FlagIsLocal 0
-
-               OpLine %src 1 28
       %color = OpVariable %_ptr_Input_v4float Input
-
-; Declaration of "float4 color : COLOR" argument of main()
-%color_decl = OpExtInst %void %DbgExt DebugDeclare %color_info %color %null_expr
-
-               OpLine %src 1 37
 %out_var_SV_TARGET = OpVariable %_ptr_Output_v4float Output
-               OpLine %src 1 1
        %main = OpFunction %void None %9
          %12 = OpLabel
-
-; Start the scope of function "main()"
-%main_scope = OpExtInst %void %DbgExt DebugScope %main_lex_scope
-
-               OpLine %src 2 10
          %13 = OpLoad %v4float %color
-               OpLine %src 2 3
                OpStore %out_var_SV_TARGET %13
                OpReturn
-
-; End the scope of function "main()"
-%main_scope_end = OpExtInst %void %DbgExt DebugNoScope
-
                OpFunctionEnd
 END
 
@@ -329,10 +252,10 @@ CLEAR pipeline
 DEBUG pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 0 COUNT 6
     THREAD VERTEX_INDEX 2
         EXPECT CALLSTACK
-            "main" "simple_vs.hlsl" 9
+            "main" "vertex-shader.hlsl" 8
             "VertexShader"
         END
-        EXPECT LOCATION "simple_vs.hlsl" 9 "  VS_OUTPUT vout;"
+        EXPECT LOCATION "vertex-shader.hlsl" 8 "/* 8*/   VS_OUTPUT vout;"
         EXPECT LOCAL "pos.x" EQ -1.007874
         EXPECT LOCAL "pos.y" EQ 1.000000
         EXPECT LOCAL "pos.z" EQ 0.000000
@@ -340,17 +263,17 @@ DEBUG pipeline DRAW_ARRAY AS TRIANGLE_LIST START_IDX 0 COUNT 6
         EXPECT LOCAL "color.y" EQ 0.000000
         EXPECT LOCAL "color.z" EQ 0.000000
         STEP_IN
-        EXPECT LOCATION "simple_vs.hlsl" 10 "  vout.pos = pos;"
+        EXPECT LOCATION "vertex-shader.hlsl" 9 "/* 9*/   vout.pos = pos;"
         STEP_IN
         EXPECT LOCAL "vout.pos.x" EQ -1.007874
         EXPECT LOCAL "vout.pos.y" EQ 1.000000
         EXPECT LOCAL "vout.pos.z" EQ 0.000000
-        EXPECT LOCATION "simple_vs.hlsl" 11 "  vout.color = color;"
+        EXPECT LOCATION "vertex-shader.hlsl" 10 "/*10*/   vout.color = color;"
         STEP_IN
         EXPECT LOCAL "vout.color.x" EQ 1.000000
         EXPECT LOCAL "vout.color.y" EQ 0.000000
         EXPECT LOCAL "vout.color.z" EQ 0.000000
-        EXPECT LOCATION "simple_vs.hlsl" 12 "  return vout;"
+        EXPECT LOCATION "vertex-shader.hlsl" 11 "/*11*/   return vout;"
         CONTINUE
     END
 END


### PR DESCRIPTION
If the `dap::Source` does not provide the embedded source, scan the virtual file system for the file by path.

Also fix a race condition where we would instruct the debugger to step, but not actually wait for it to notify us that the step had completed before making further checks.

Updated the `debugger_hlsl_line_stepping.amber` to:
* Use `VIRTUAL_FILE` for the file content
* Fix the scoping of `CompilationUnit` <- `Function` <- `LexicalBlock`
* Remove the unused and incorrect debug info from the fragment shader. We'll have proper testing for this once DXC produces correct debug info.