### PR TITLE
Add support for new clspv interface types

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -9,8 +9,8 @@ vars = {
   'nlohmann_git': 'https://github.com/nlohmann',
   'swiftshader_git': 'https://swiftshader.googlesource.com',
 
-  'clspv_llvm_revision': '627e01feb718dd1aa8e184545976b7229de312a2',
-  'clspv_revision': '1356838737b0fbe1f3b9d0744df46ebc716d7b5c',
+  'clspv_llvm_revision': 'a2bb19ca420d0801f5b9a5363dec1d7bcb829030',
+  'clspv_revision': '4e6c283e15420ba6e949d44850929b8d78b45ad9',
   'cppdap_revision': '4dcca5775616ada2796ff7f84c3a4843eee9b506',
   'cpplint_revision': '26470f9ccb354ff2f6d098f831271a1833701b28',
   'dxc_revision': 'ef73f1da8ad79a42405e8c75cf7d66ed8a0bb345',

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -117,7 +117,7 @@ class Pipeline {
     struct PushConstant {
       enum class PushConstantType {
         kDimensions = 0,
-        kGlobalOffset
+        kGlobalOffset,
       };
       PushConstantType type;
       uint32_t offset = 0;

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -91,6 +91,7 @@ class Pipeline {
         UBO,
         POD,
         POD_UBO,
+        POD_PUSHCONSTANT,
         RO_IMAGE,
         WO_IMAGE,
         SAMPLER,
@@ -116,7 +117,7 @@ class Pipeline {
     struct PushConstant {
       enum class PushConstantType {
         kDimensions = 0,
-        kGlobalOffset,
+        kGlobalOffset
       };
       PushConstantType type;
       uint32_t offset = 0;
@@ -343,6 +344,8 @@ class Pipeline {
 
  private:
   void UpdateFramebufferSizes();
+
+  Result CreatePushConstantBuffer();
 
   Result ValidateGraphics() const;
   Result ValidateCompute() const;

--- a/src/pipeline_test.cc
+++ b/src/pipeline_test.cc
@@ -869,8 +869,8 @@ TEST_F(PipelineTest, OpenCLPodPushConstants) {
   Pipeline::ShaderInfo::DescriptorMapEntry entry1;
   entry1.kind =
       Pipeline::ShaderInfo::DescriptorMapEntry::Kind::POD_PUSHCONSTANT;
-  entry1.descriptor_set = -1;
-  entry1.binding = -1;
+  entry1.descriptor_set = static_cast<uint32_t>(-1);
+  entry1.binding = static_cast<uint32_t>(-1);
   entry1.arg_name = "arg_a";
   entry1.arg_ordinal = 0;
   entry1.pod_offset = 0;
@@ -880,8 +880,8 @@ TEST_F(PipelineTest, OpenCLPodPushConstants) {
   Pipeline::ShaderInfo::DescriptorMapEntry entry2;
   entry2.kind =
       Pipeline::ShaderInfo::DescriptorMapEntry::Kind::POD_PUSHCONSTANT;
-  entry2.descriptor_set = -1;
-  entry2.binding = -1;
+  entry2.descriptor_set = static_cast<uint32_t>(-1);
+  entry2.binding = static_cast<uint32_t>(-1);
   entry2.arg_name = "arg_b";
   entry2.arg_ordinal = 1;
   entry2.pod_offset = 4;
@@ -891,8 +891,8 @@ TEST_F(PipelineTest, OpenCLPodPushConstants) {
   Pipeline::ShaderInfo::DescriptorMapEntry entry3;
   entry3.kind =
       Pipeline::ShaderInfo::DescriptorMapEntry::Kind::POD_PUSHCONSTANT;
-  entry3.descriptor_set = -1;
-  entry3.binding = -1;
+  entry3.descriptor_set = static_cast<uint32_t>(-1);
+  entry3.binding = static_cast<uint32_t>(-1);
   entry3.arg_name = "arg_c";
   entry3.arg_ordinal = 2;
   entry3.pod_offset = 8;

--- a/src/pipeline_test.cc
+++ b/src/pipeline_test.cc
@@ -856,4 +856,90 @@ TEST_F(PipelineTest, OpenCLGeneratePushConstants) {
   EXPECT_EQ(0U, bytes[6]);
 }
 
+TEST_F(PipelineTest, OpenCLPodPushConstants) {
+  Pipeline p(PipelineType::kCompute);
+  p.SetName("my_pipeline");
+
+  Shader cs(kShaderTypeCompute);
+  cs.SetFormat(kShaderFormatOpenCLC);
+  p.AddShader(&cs, kShaderTypeCompute);
+  p.SetShaderEntryPoint(&cs, "my_main");
+
+  // Descriptor map.
+  Pipeline::ShaderInfo::DescriptorMapEntry entry1;
+  entry1.kind =
+      Pipeline::ShaderInfo::DescriptorMapEntry::Kind::POD_PUSHCONSTANT;
+  entry1.descriptor_set = -1;
+  entry1.binding = -1;
+  entry1.arg_name = "arg_a";
+  entry1.arg_ordinal = 0;
+  entry1.pod_offset = 0;
+  entry1.pod_arg_size = 4;
+  p.GetShaders()[0].AddDescriptorEntry("my_main", std::move(entry1));
+
+  Pipeline::ShaderInfo::DescriptorMapEntry entry2;
+  entry2.kind =
+      Pipeline::ShaderInfo::DescriptorMapEntry::Kind::POD_PUSHCONSTANT;
+  entry2.descriptor_set = -1;
+  entry2.binding = -1;
+  entry2.arg_name = "arg_b";
+  entry2.arg_ordinal = 1;
+  entry2.pod_offset = 4;
+  entry2.pod_arg_size = 1;
+  p.GetShaders()[0].AddDescriptorEntry("my_main", std::move(entry2));
+
+  Pipeline::ShaderInfo::DescriptorMapEntry entry3;
+  entry3.kind =
+      Pipeline::ShaderInfo::DescriptorMapEntry::Kind::POD_PUSHCONSTANT;
+  entry3.descriptor_set = -1;
+  entry3.binding = -1;
+  entry3.arg_name = "arg_c";
+  entry3.arg_ordinal = 2;
+  entry3.pod_offset = 8;
+  entry3.pod_arg_size = 4;
+  p.GetShaders()[0].AddDescriptorEntry("my_main", std::move(entry3));
+
+  // Set commands.
+  Value int_value;
+  int_value.SetIntValue(1);
+
+  TypeParser parser;
+  auto int_type = parser.Parse("R32_SINT");
+  auto int_fmt = MakeUnique<Format>(int_type.get());
+  auto char_type = parser.Parse("R8_SINT");
+  auto char_fmt = MakeUnique<Format>(char_type.get());
+
+  Pipeline::ArgSetInfo arg_info1;
+  arg_info1.name = "arg_a";
+  arg_info1.ordinal = 99;
+  arg_info1.fmt = int_fmt.get();
+  arg_info1.value = int_value;
+  p.SetArg(std::move(arg_info1));
+
+  Pipeline::ArgSetInfo arg_info2;
+  arg_info2.name = "arg_b";
+  arg_info2.ordinal = 99;
+  arg_info2.fmt = char_fmt.get();
+  arg_info2.value = int_value;
+  p.SetArg(std::move(arg_info2));
+
+  Pipeline::ArgSetInfo arg_info3;
+  arg_info3.name = "arg_c";
+  arg_info3.ordinal = 99;
+  arg_info3.fmt = int_fmt.get();
+  arg_info3.value = int_value;
+  p.SetArg(std::move(arg_info3));
+
+  auto r = p.GenerateOpenCLPodBuffers();
+  auto* buf = p.GetPushConstantBuffer().buffer;
+  EXPECT_NE(nullptr, buf);
+  EXPECT_EQ(12U, buf->GetSizeInBytes());
+
+  const uint32_t* ints = buf->GetValues<uint32_t>();
+  const uint8_t* bytes = buf->GetValues<uint8_t>();
+  EXPECT_EQ(1U, ints[0]);
+  EXPECT_EQ(1U, bytes[4]);
+  EXPECT_EQ(1U, ints[2]);
+}
+
 }  // namespace amber

--- a/tests/cases/opencl_set_arg.amber
+++ b/tests/cases/opencl_set_arg.amber
@@ -24,6 +24,7 @@ BUFFER out_buf1 DATA_TYPE uint32 DATA 0 END
 BUFFER out_buf2 DATA_TYPE uint32 DATA 0 END
 BUFFER out_buf3 DATA_TYPE uint32 DATA 0 END
 BUFFER out_buf4 DATA_TYPE uint32 DATA 0 END
+BUFFER out_buf5 DATA_TYPE uint32 DATA 0 END
 
 PIPELINE compute p1
   ATTACH my_shader ENTRY_POINT line
@@ -56,12 +57,23 @@ DERIVE_PIPELINE p4 FROM p1
   END
 END
 
+DERIVE_PIPELINE p5 FROM p1
+  BIND BUFFER out_buf5 KERNEL ARG_NAME out
+  SET KERNEL ARG_NAME slope AS int32 3
+  COMPILE_OPTIONS my_shader
+    -cluster-pod-kernel-args
+    -pod-pushconstant
+  END
+END
+
 RUN p1 1 1 1
 RUN p2 1 1 1
 RUN p3 1 1 1
 RUN p4 1 1 1
+RUN p5 1 1 1
 
 EXPECT out_buf1 IDX 0 EQ 7
 EXPECT out_buf2 IDX 0 EQ 7
 EXPECT out_buf3 IDX 0 EQ 7
 EXPECT out_buf4 IDX 0 EQ 10
+EXPECT out_buf5 IDX 0 EQ 10


### PR DESCRIPTION
* Add support for kernel decls
  * no-op
* Add support for pod args in push constants
  * piggybacks push constant support
  * pod buffer generation supports push constants
  * New test
* Don't assert on unknown interface types in clspv
* update OpenCL SET example
* Refactor some code into CreatePushConstantBuffer

FYI @jrprice 