### PR TITLE
Change gcc install to use aptitude

### DIFF
--- a/kokoro/scripts/linux/build.sh
+++ b/kokoro/scripts/linux/build.sh
@@ -29,7 +29,7 @@ BUILD_TYPE="Debug"
 # Always update gcc so we get a newer standard library.
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt-get update
-sudo apt-get install -y gcc-7 g++-7
+sudo aptitude install -y gcc-7 g++-7
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100 --slave /usr/bin/g++ g++ /usr/bin/g++-7
 sudo update-alternatives --set gcc "/usr/bin/gcc-7"
 


### PR DESCRIPTION
apt-get install gcc-7 g++-7 was unable to fix some broken dependencies. Aptitude seems able to do so.