### PR TITLE
Moved Delegate destructor definition into header file

### DIFF
--- a/include/amber/amber.h
+++ b/include/amber/amber.h
@@ -85,7 +85,7 @@ enum class BufferDataFileType : int8_t {
 /// Delegate class for various hook functions
 class Delegate {
  public:
-  virtual ~Delegate();
+  virtual ~Delegate() = default;
 
   /// Log the given message
   virtual void Log(const std::string& message) = 0;

--- a/src/amber.cc
+++ b/src/amber.cc
@@ -80,8 +80,6 @@ BufferInfo::~BufferInfo() = default;
 
 BufferInfo& BufferInfo::operator=(const BufferInfo&) = default;
 
-Delegate::~Delegate() = default;
-
 Amber::Amber(Delegate* delegate) : delegate_(delegate) {}
 
 Amber::~Amber() = default;


### PR DESCRIPTION
Integrating the latest Amber version into CTS gave linker errors when having Delegate destructor defined inside amber.cc.