### PR TITLE
Move delegate destructor to header file.

### DIFF
--- a/include/amber/amber.h
+++ b/include/amber/amber.h
@@ -103,6 +103,8 @@ class Delegate {
                                        amber::BufferInfo* buffer) const = 0;
 };
 
+inline Delegate::~Delegate() = default;
+
 /// Stores configuration options for Amber.
 struct Options {
   Options();

--- a/src/amber.cc
+++ b/src/amber.cc
@@ -80,8 +80,6 @@ BufferInfo::~BufferInfo() = default;
 
 BufferInfo& BufferInfo::operator=(const BufferInfo&) = default;
 
-Delegate::~Delegate() = default;
-
 Amber::Amber(Delegate* delegate) : delegate_(delegate) {}
 
 Amber::~Amber() = default;


### PR DESCRIPTION
This CL moves the delegate virtual destructor to the header fix to fix
translation unit issues.