### PR TITLE
Fix probing when either value is a NaN

### DIFF
--- a/src/verifier.cc
+++ b/src/verifier.cc
@@ -75,6 +75,11 @@ bool IsEqualWithTolerance(const double actual,
                           const double expected,
                           double tolerance,
                           const bool is_tolerance_percent = true) {
+  // Special case for NaN.
+  if (std::isunordered(actual, expected)) {
+    return std::isnan(actual) == std::isnan(expected);
+  }
+
   double difference = std::fabs(actual - expected);
   if (is_tolerance_percent) {
     if (difference > ((tolerance / 100.0) * std::fabs(expected))) {

--- a/src/verifier_test.cc
+++ b/src/verifier_test.cc
@@ -14,6 +14,7 @@
 
 #include "src/verifier.h"
 
+#include <cmath>
 #include <memory>
 #include <utility>
 #include <vector>

--- a/src/verifier_test.cc
+++ b/src/verifier_test.cc
@@ -1573,7 +1573,7 @@ TEST_F(VerifierTest, ProbeSSBOFloatNaN) {
     values.back().SetDoubleValue(13.7);
     probe_ssbo.SetValues(std::move(values));
 
-    float ssbo = std::nan("");
+    float ssbo = std::nanf("");
 
     Verifier verifier;
     Result r =
@@ -1590,7 +1590,7 @@ TEST_F(VerifierTest, ProbeSSBOFloatNaN) {
     values.back().SetDoubleValue(std::nan(""));
     probe_ssbo.SetValues(std::move(values));
 
-    float ssbo = 13.7;
+    float ssbo = 13.7f;
 
     Verifier verifier;
     Result r =
@@ -1607,7 +1607,7 @@ TEST_F(VerifierTest, ProbeSSBOFloatNaN) {
     values.back().SetDoubleValue(std::nan(""));
     probe_ssbo.SetValues(std::move(values));
 
-    float ssbo = std::nan("");
+    float ssbo = std::nanf("");
 
     Verifier verifier;
     Result r =


### PR DESCRIPTION
The Verifier::IsEqualWithTolerance method was previously always
returning true when one of the values was a NaN. This adds a special
case to make sure that NaNs are handled properly.