### PR TITLE
Fix vkscript buffers being added twice

### DIFF
--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -338,7 +338,12 @@ Result Pipeline::AddBufferDescriptor(const BufferCommand* cmd) {
           "Descriptors bound to the same binding needs to have matching "
           "descriptor types");
     }
-    desc->AsBufferBackedDescriptor()->AddAmberBuffer(cmd->GetBuffer());
+    // Check that the buffer is not added already.
+    const auto& buffers = desc->AsBufferBackedDescriptor()->GetAmberBuffers();
+    if (std::find(buffers.begin(), buffers.end(), cmd->GetBuffer()) ==
+        buffers.end()) {
+      desc->AsBufferBackedDescriptor()->AddAmberBuffer(cmd->GetBuffer());
+    }
   }
 
   if (cmd->IsUniformDynamic() || cmd->IsSSBODynamic())


### PR DESCRIPTION
Some of the buffers were added twice if  vkscript format was used.

This patch prevents same buffers to be added multiple times.