### PR TITLE
Fix all warnings in engine_vulkan_debugger

### DIFF
--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -38,8 +38,6 @@ namespace vulkan {
 /// Engine implementation based on Vulkan.
 class EngineVulkan : public Engine {
  public:
-  class VkDebugger;
-
   EngineVulkan();
   ~EngineVulkan() override;
 


### PR DESCRIPTION
Remove unused functions.
Add explicit casts.
Avoid variable shadowing.
Be explicit with virtual `override`s
Use epsilons for float compares.
Move VkDebugger to anonymous namespace, as it isn't referenced outside
the `engine_vulkan_debugger` compilation unit.
Remove pointless semi-colons.