### PR TITLE
Add `build` directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 out
+build
 third_party/clspv
 third_party/clspv-clang
 third_party/clspv-llvm


### PR DESCRIPTION
`build` is extremely common for CMake-based builds.