### PR TITLE
Fix Python warnings related to 'is' operator

### DIFF
--- a/kokoro/scripts/linux/build.sh
+++ b/kokoro/scripts/linux/build.sh
@@ -71,10 +71,10 @@ if [[ "$EXTRA_CONFIG" =~ "USE_CLSPV=TRUE" ]]; then
   DEPS_ARGS+=" --with-clspv"
 fi
 if [[ "$EXTRA_CONFIG" =~ "USE_DXC=TRUE" ]]; then
-  DEPS_ARGS+=" --use-dxc"
+  DEPS_ARGS+=" --with-dxc"
 fi
 if [[ "$EXTRA_CONFIG" =~ "ENABLE_SWIFTSHADER=TRUE" ]]; then
-  DEPS_ARGS+=" --use-swiftshader"
+  DEPS_ARGS+=" --with-swiftshader"
 fi
 
 cd $SRC

--- a/kokoro/scripts/macos/build.sh
+++ b/kokoro/scripts/macos/build.sh
@@ -32,7 +32,7 @@ echo $(date): $(cmake --version)
 
 DEPS_ARGS=""
 if [[ "$EXTRA_CONFIG" =~ "ENABLE_SWIFTSHADER=TRUE" ]]; then
-  DEPS_ARGS+=" --use-swiftshader"
+  DEPS_ARGS+=" --with-swiftshader"
 fi
 
 cd $SRC

--- a/tools/git-sync-deps
+++ b/tools/git-sync-deps
@@ -228,16 +228,16 @@ def git_sync_deps(deps_file_path, command_line_os_requests, verbose):
     else:
       raise Exception("please specify commit or tag")
 
-    if not with_clspv and directory is 'third_party/clspv':
+    if not with_clspv and directory == 'third_party/clspv':
       continue
 
-    if not with_clspv and directory is 'third_party/clspv-llvm':
+    if not with_clspv and directory == 'third_party/clspv-llvm':
       continue
 
-    if not with_dxc and directory is 'third_party/dxc':
+    if not with_dxc and directory == 'third_party/dxc':
       continue
 
-    if not with_swiftshader and directory is 'third_party/swiftshader':
+    if not with_swiftshader and directory == 'third_party/swiftshader':
       continue
 
     relative_directory = os.path.join(deps_file_directory, directory)

--- a/tools/git-sync-deps
+++ b/tools/git-sync-deps
@@ -266,6 +266,9 @@ def multithread(function, list_of_arg_lists):
 
 
 def main(argv):
+  global with_clspv
+  global with_dxc
+  global with_swiftshader
   deps_file_path = os.environ.get('GIT_SYNC_DEPS_PATH', DEFAULT_DEPS_PATH)
   verbose = not bool(os.environ.get('GIT_SYNC_DEPS_QUIET', False))
 


### PR DESCRIPTION
Replace the 'is' operators with '==' when there is a literal among the
arguments. The Python 'is' operator is not meant to be used with
literals, and the code emitted warnings like:

tools/git-sync-deps:231: SyntaxWarning: "is" with a literal. Did you mean "=="?

For the origin of this warning in Python, see
https://bugs.python.org/issue34850

Fix: #890