### PR TITLE
Add example for row_major, col_major matrices

### DIFF
--- a/tests/cases/compute_mat2x4_row_major_col_major.amber
+++ b/tests/cases/compute_mat2x4_row_major_col_major.amber
@@ -1,0 +1,89 @@
+#!amber
+# Copyright 2020 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Demonstrate reads and writes on row major and column major matrices.
+
+SHADER compute copy_vertex GLSL
+#version 450
+
+layout(set=0, binding=0) buffer A {
+   layout(column_major) mat2x4 mcols;
+   layout(row_major) mat2x4 mrows;
+} inbound;
+
+layout(set=0, binding=1) buffer B {
+   vec4 first;
+   vec4 second;
+} outbound;
+
+void main() {
+  outbound.first = inbound.mcols[1];
+  outbound.second = inbound.mrows[1];  // Read is a gather
+  inbound.mcols[0] = inbound.mrows[0];
+  inbound.mrows[1] = inbound.mcols[1]; // Write is a scatter
+}
+END
+
+BUFFER buf0 DATA_TYPE float DATA
+
+ # Column major mcols.
+
+   # first column
+   00.0 01.0 02.0 03.0
+   # second column
+   10.0 11.0 12.0 13.0
+
+ # Row major
+   # first row
+   100.0 110.0
+   # second row
+   101.0 111.0
+   # third row
+   102.0 112.0
+   # fourth row
+   103.0 113.0
+END
+
+BUFFER buf1 DATA_TYPE float DATA
+   # Initialize with garbage data.
+   -1.0 -1.0 -1.0 -1.0
+   -2.0 -2.0 -2.0 -2.0
+END
+
+PIPELINE compute pipeline
+  ATTACH copy_vertex
+  BIND BUFFER buf0 AS storage DESCRIPTOR_SET 0 BINDING 0
+  BIND BUFFER buf1 AS storage DESCRIPTOR_SET 0 BINDING 1
+END
+
+RUN pipeline 1 1 1
+
+# Check the column vectors we copied out.
+# From inbound.mcols[1]
+EXPECT buf1 IDX 0  EQ 10.0 11.0 12. 13.0
+# From inbound.mrows[1]
+# Did a gather from mrows[1] to collect these values before writing them out.
+EXPECT buf1 IDX 16 EQ 110.0 111.0 112. 113.0
+
+# Check the contents of inbound.mcols
+EXPECT buf0 IDX 0 EQ 100.0 101.0 102.0 103.0  # Did a gather from mrows[0]
+EXPECT buf0 IDX 16 EQ 10.0 11.0 12.0 13.0     # Second column is unchanged
+# Check the conents of inbound.mrows
+# Writing to second column of row major is a scatter operation
+EXPECT buf0 IDX 32 EQ 100.0 10.0
+EXPECT buf0 IDX 40 EQ 101.0 11.0
+EXPECT buf0 IDX 48 EQ 102.0 12.0
+EXPECT buf0 IDX 56 EQ 103.0 13.0
+


### PR DESCRIPTION
Demonstrates that reading a column vector from a row-major matrix
is a gather operation, and writing it is a scatter operation.