### PR TITLE
[AmberScript] Add support for runtime arrays

### DIFF
--- a/docs/amber_script.md
+++ b/docs/amber_script.md
@@ -209,6 +209,8 @@ either image buffers or, what the target API would refer to as a buffer.
  * vec[2,3,4]{type}
  * mat[2,3,4]x[2,3,4]{type}  (mat<columns>x<rows>)
  * Any of the `Image Formats` listed below.
+ * For any of the non-Image Formats types above appending '[]' will treat the
+    data as an array. e.g. int8[], vec2<float>[]
 
 Sized arrays and structures are not currently representable.
 

--- a/src/type_parser.h
+++ b/src/type_parser.h
@@ -41,7 +41,7 @@ class TypeParser {
 
  private:
   std::unique_ptr<type::Type> ParseGlslFormat(const std::string& fmt);
-  void ProcessChunk(const std::string&);
+  bool ProcessChunk(const std::string&);
   void AddPiece(FormatComponentType type, FormatMode mode, uint8_t bits);
   void FlushPieces(type::Type* type, FormatMode mode);
 

--- a/tests/cases/runtime_array_std140.amber
+++ b/tests/cases/runtime_array_std140.amber
@@ -1,0 +1,42 @@
+#!amber
+# Copyright 2020 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHADER vertex vert_shader PASSTHROUGH
+SHADER fragment frag_shader GLSL
+#version 430
+layout(location = 0) out vec4 color_out;
+layout(std140, binding = 0) readonly buffer Data {
+  float d[];
+} data;
+
+void main() {
+  color_out = vec4(data.d[0]/255, data.d[1]/255, data.d[2]/255, data.d[3]/255);
+}
+END
+
+BUFFER framebuffer FORMAT B8G8R8A8_UNORM
+
+BUFFER data DATA_TYPE float[] STD140 DATA 1.0 64.0 128.0 220.0 END
+
+PIPELINE graphics my_pipeline
+  ATTACH vert_shader
+  ATTACH frag_shader
+
+  BIND BUFFER framebuffer AS color LOCATION 0
+  BIND BUFFER data AS storage DESCRIPTOR_SET 0 BINDING 0
+END
+
+RUN my_pipeline DRAW_RECT POS 0 0 SIZE 250 250
+EXPECT framebuffer IDX 0 0 SIZE 250 250 EQ_RGBA 1 64 128 220

--- a/tests/cases/runtime_array_std430.amber
+++ b/tests/cases/runtime_array_std430.amber
@@ -1,0 +1,42 @@
+#!amber
+# Copyright 2020 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHADER vertex vert_shader PASSTHROUGH
+SHADER fragment frag_shader GLSL
+#version 430
+layout(location = 0) out vec4 color_out;
+layout(std430, binding = 0) readonly buffer Data {
+  float d[];
+} data;
+
+void main() {
+  color_out = vec4(data.d[0]/255, data.d[1]/255, data.d[2]/255, data.d[3]/255);
+}
+END
+
+BUFFER framebuffer FORMAT B8G8R8A8_UNORM
+
+BUFFER data DATA_TYPE float[] STD430 DATA 1.0 64.0 128.0 220.0 END
+
+PIPELINE graphics my_pipeline
+  ATTACH vert_shader
+  ATTACH frag_shader
+
+  BIND BUFFER framebuffer AS color LOCATION 0
+  BIND BUFFER data AS storage DESCRIPTOR_SET 0 BINDING 0
+END
+
+RUN my_pipeline DRAW_RECT POS 0 0 SIZE 250 250
+EXPECT framebuffer IDX 0 0 SIZE 250 250 EQ_RGBA 1 64 128 220


### PR DESCRIPTION
This CL adds the ability to specify the data_type for an AmberScript buffer to be an array.