### PR TITLE
Fix build on Clang 11

### DIFF
--- a/src/command.h
+++ b/src/command.h
@@ -471,7 +471,7 @@ class ProbeSSBOCommand : public Probe {
 class BindableResourceCommand : public PipelineCommand {
  public:
   BindableResourceCommand(Type type, Pipeline* pipeline);
-  virtual ~BindableResourceCommand();
+  ~BindableResourceCommand() override;
 
   void SetDescriptorSet(uint32_t set) { descriptor_set_ = set; }
   uint32_t GetDescriptorSet() const { return descriptor_set_; }

--- a/src/debug.h
+++ b/src/debug.h
@@ -125,7 +125,7 @@ class Events {
 /// with |ThreadScript::Run|.
 class ThreadScript : public Thread {
  public:
-  ~ThreadScript();
+  ~ThreadScript() override;
 
   /// Run replays all the calls made to the |ThreadScript| on the given |Thread|
   /// parameter.
@@ -140,7 +140,7 @@ class ThreadScript : public Thread {
 /// |Script::Run|.
 class Script : public Events {
  public:
-  ~Script();
+  ~Script() override;
 
   /// Run replays all the calls made to the |Script| on the given |Events|
   /// parameter.

--- a/src/engine.h
+++ b/src/engine.h
@@ -59,7 +59,7 @@ class Engine {
   /// Debugger is the interface to the engine's shader debugger.
   class Debugger : public debug::Events {
    public:
-    ~Debugger();
+    ~Debugger() override;
 
     /// Flush waits for all the debugger commands issued to complete, and
     /// returns a Result that includes any debugger test failure.

--- a/src/executor_test.cc
+++ b/src/executor_test.cc
@@ -207,7 +207,7 @@ class EngineStub : public Engine {
 class VkScriptExecutorTest : public testing::Test {
  public:
   VkScriptExecutorTest() = default;
-  ~VkScriptExecutorTest() = default;
+  ~VkScriptExecutorTest() override = default;
 
   std::unique_ptr<Engine> MakeEngine() { return MakeUnique<EngineStub>(); }
   std::unique_ptr<Engine> MakeAndInitializeEngine(

--- a/src/verifier_test.cc
+++ b/src/verifier_test.cc
@@ -34,7 +34,7 @@ namespace {
 class VerifierTest : public testing::Test {
  public:
   VerifierTest() = default;
-  ~VerifierTest() = default;
+  ~VerifierTest() override = default;
 
   const Format* GetColorFormat() {
     if (color_frame_format_)

--- a/src/vulkan/vertex_buffer_test.cc
+++ b/src/vulkan/vertex_buffer_test.cc
@@ -144,7 +144,7 @@ class VertexBufferTest : public testing::Test {
     commandBuffer_->Initialize();
   }
 
-  ~VertexBufferTest() { vertex_buffer_.reset(); }
+  ~VertexBufferTest() override { vertex_buffer_.reset(); }
 
   Result SetData(uint8_t location, Format* format, std::vector<Value> values) {
     auto buffer = MakeUnique<Buffer>();


### PR DESCRIPTION
Explicitly specify some destructor overrides to suppress `-Wsuggest-destructor-override` warnings.

This affects building the CTS with Clang 11.

[amber_build_failure_clang_11.txt](https://github.com/google/amber/files/5440683/amber_build_failure_clang_11.txt)