### PR TITLE
Fix Vulkan synchronization validation errors

### DIFF
--- a/src/vulkan/transfer_image.cc
+++ b/src/vulkan/transfer_image.cc
@@ -342,10 +342,12 @@ void TransferImage::ImageBarrier(CommandBuffer* command_buffer,
 
   switch (to_layout) {
     case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
-      barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+      barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
       break;
     case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
-      barrier.dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+      barrier.dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+                              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
       break;
     case VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL:
       barrier.dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT;


### PR DESCRIPTION
In Vulkan CTS TransferImage::ImageBarrier() is often used to
synchronize images which are then used as attachments in
a RenderPass. Depending on the load operation used, the RenderPass
may need either read or write access. (see Section 8.1 Render Pass
Creation in the Vulkan 1.2.x specification).

To allow any load operation to work correctly, set both read and write
access in the dstAccessMask when transitioning to an attachment layout.