### PR TITLE
Don't add an amber sampler for sampled images

### DIFF
--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -320,7 +320,7 @@ Result Pipeline::AddBufferDescriptor(const BufferCommand* cmd) {
       auto image_desc = MakeUnique<ImageDescriptor>(
           cmd->GetBuffer(), desc_type, device_, cmd->GetBaseMipLevel(),
           cmd->GetDescriptorSet(), cmd->GetBinding());
-      if (cmd->IsSampledImage() || cmd->IsCombinedImageSampler())
+      if (cmd->IsCombinedImageSampler())
         image_desc->SetAmberSampler(cmd->GetSampler());
       descriptors.push_back(std::move(image_desc));
     } else {


### PR DESCRIPTION
Fixes #927

* When adding a buffer for an image, do not add a sampler for sampled
  image binding (only for combined sampled image bindings)