### PR TITLE
Expose target environment to shader info

### DIFF
--- a/include/amber/shader_info.h
+++ b/include/amber/shader_info.h
@@ -54,6 +54,8 @@ struct ShaderInfo {
   std::string shader_source;
   /// A list of SPIR-V optimization passes to execute on the shader.
   std::vector<std::string> optimizations;
+  /// Target environment for the shader compilation.
+  std::string target_env;
   /// The shader SPIR-V if it was compiled by Amber
   std::vector<uint32_t> shader_data;
 };

--- a/src/script.cc
+++ b/src/script.cc
@@ -48,6 +48,7 @@ std::vector<ShaderInfo> Script::GetShaderInfo() const {
                                   shader->GetName(),
                                   shader->GetData(),
                                   {},
+                                  shader->GetTargetEnv(),
                                   {}});
     }
   }

--- a/src/script.cc
+++ b/src/script.cc
@@ -32,10 +32,11 @@ std::vector<ShaderInfo> Script::GetShaderInfo() const {
     for (const auto& pipeline : pipelines_) {
       auto shader_info = pipeline->GetShader(shader.get());
       if (shader_info) {
-        ret.emplace_back(ShaderInfo{
-            shader->GetFormat(), shader->GetType(),
-            pipeline->GetName() + "-" + shader->GetName(), shader->GetData(),
-            shader_info->GetShaderOptimizations(), shader_info->GetData()});
+        ret.emplace_back(
+            ShaderInfo{shader->GetFormat(), shader->GetType(),
+                       pipeline->GetName() + "-" + shader->GetName(),
+                       shader->GetData(), shader_info->GetShaderOptimizations(),
+                       shader->GetTargetEnv(), shader_info->GetData()});
 
         in_pipeline = true;
       }


### PR DESCRIPTION
This change exposes shader target environment parsed from Amber Script into shader info structure. This allows Vulkan CTS to compile GLSL into SPIR-V using the specified SPIR-V version.