### PR TITLE
Update license checker config

### DIFF
--- a/license-checker.cfg
+++ b/license-checker.cfg
@@ -1,5 +1,6 @@
 {
     "licenses": [
+        "Apache-2.0",
         "Apache-2.0-Header"
     ],
     "paths": [


### PR DESCRIPTION
The license classification rules in github.com/google/licensecheck have been updated.