### PR TITLE
Fix buffer size for D24_UNORM_S8_INT format

### DIFF
--- a/src/format.cc
+++ b/src/format.cc
@@ -322,6 +322,11 @@ uint32_t Format::AddSegmentsForType(type::Type* type) {
       for (const auto& m : l->Members()) {
         if (AddSegment(Segment{m.name, m.mode, m.num_bits}))
           size += m.SizeInBytes();
+        // 24bit depth component is padded to 32 bits.
+        if (m.name == FormatComponentType::kD && m.SizeInBytes() == 3) {
+          AddSegment(Segment{1});
+          size++;
+        }
       }
 
       if (NeedsPadding(type)) {

--- a/src/format.h
+++ b/src/format.h
@@ -67,8 +67,8 @@ class Format {
    private:
     bool is_padding_ = false;
     bool is_packable_ = false;
-    FormatComponentType name_ = FormatComponentType::kR;
-    FormatMode mode_ = FormatMode::kSInt;
+    FormatComponentType name_ = FormatComponentType::kX;
+    FormatMode mode_ = FormatMode::kUNorm;
     uint32_t num_bits_ = 0;
   };
 

--- a/src/type_parser_test.cc
+++ b/src/type_parser_test.cc
@@ -422,9 +422,10 @@ TEST_F(TypeParserTest, Formats) {
       {"D24_UNORM_S8_UINT",
        FormatType::kD24_UNORM_S8_UINT,
        0U,
-       2U,
+       3U,
        {
            {FormatComponentType::kD, FormatMode::kUNorm, 24},
+           {FormatComponentType::kX, FormatMode::kUNorm, 8},
            {FormatComponentType::kS, FormatMode::kUInt, 8},
        }},
       {"D32_SFLOAT",

--- a/tests/cases/draw_rectangles_depth_test_d24s8.amber
+++ b/tests/cases/draw_rectangles_depth_test_d24s8.amber
@@ -1,0 +1,135 @@
+#!amber
+#
+# Copyright 2021 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHADER vertex vert_shader GLSL
+#version 430
+
+layout(location = 0) in vec4 position;
+layout(location = 0) out vec4 frag_color;
+
+layout(set = 0, binding = 0) readonly buffer block1 {
+  vec4 in_color;
+  float depth;
+};
+
+void main() {
+  gl_Position = vec4(position.xy, depth, 1.0);
+  frag_color = in_color;
+}
+END
+
+SHADER fragment frag_shader GLSL
+#version 430
+
+layout(location = 0) in vec4 frag_color;
+layout(location = 0) out vec4 final_color;
+
+void main() {
+  final_color = frag_color;
+}
+END
+
+SHADER vertex vert_shader_tex GLSL
+#version 430
+layout(location = 0) in vec4 position;
+layout(location = 1) in vec2 texcoords_in;
+layout(location = 0) out vec2 texcoords_out;
+void main() {
+  gl_Position = position;
+  texcoords_out = texcoords_in;
+}
+END
+
+SHADER fragment frag_shader_tex GLSL
+#version 430
+layout(location = 0) in vec2 texcoords_in;
+layout(location = 0) out vec4 color_out;
+uniform layout(set=0, binding=0) sampler2D tex_sampler;
+void main() {
+  float f = texture(tex_sampler, texcoords_in).r;
+  color_out = vec4(f, f, f, 1);
+}
+END
+
+BUFFER data_buf1 DATA_TYPE float DATA  1.0 0.0  0.0 1.0 0.3 END
+BUFFER data_buf2 DATA_TYPE float DATA  0.0 1.0  0.0 1.0 0.5 END
+
+BUFFER position DATA_TYPE vec2<float> DATA
+-1.0 -1.0
+ 1.0 -1.0
+ 1.0  1.0
+-1.0  1.0
+END
+BUFFER texcoords DATA_TYPE vec2<float> DATA
+0.0 0.0
+1.0 0.0
+1.0 1.0
+0.0 1.0
+END
+
+BUFFER framebuffer FORMAT B8G8R8A8_UNORM
+BUFFER ddump FORMAT B8G8R8A8_UNORM
+BUFFER depthstencil FORMAT D24_UNORM_S8_UINT
+
+SAMPLER sampler
+
+PIPELINE graphics pipeline1
+  ATTACH vert_shader
+  ATTACH frag_shader
+
+  FRAMEBUFFER_SIZE 256 256
+  BIND BUFFER framebuffer AS color LOCATION 0
+  BIND BUFFER depthstencil AS depth_stencil
+  BIND BUFFER data_buf1 AS storage DESCRIPTOR_SET 0 BINDING 0
+
+  DEPTH
+    TEST on
+    WRITE on
+    COMPARE_OP less
+    CLAMP off
+    BOUNDS min 0.0 max 1.0
+    BIAS constant 0.0 clamp 0.0 slope 0.0
+  END
+END
+
+DERIVE_PIPELINE pipeline2 FROM pipeline1
+  BIND BUFFER data_buf2 AS storage DESCRIPTOR_SET 0 BINDING 0
+END
+
+PIPELINE graphics depthdump
+  ATTACH vert_shader_tex
+  ATTACH frag_shader_tex
+  BIND BUFFER depthstencil AS combined_image_sampler SAMPLER sampler DESCRIPTOR_SET 0 BINDING 0
+  VERTEX_DATA position LOCATION 0
+  VERTEX_DATA texcoords LOCATION 1
+  FRAMEBUFFER_SIZE 256 256
+  BIND BUFFER ddump AS color LOCATION 0
+END
+
+CLEAR_DEPTH pipeline1 1.0
+CLEAR_COLOR pipeline1 255 255 255 255
+CLEAR pipeline1
+RUN pipeline1 DRAW_RECT POS   0   0 SIZE 200 200
+RUN pipeline2 DRAW_RECT POS   56 56 SIZE 200 200
+RUN depthdump DRAW_ARRAY AS TRIANGLE_FAN START_IDX 0 COUNT 4
+
+EXPECT framebuffer IDX   0   0 SIZE 1 1 EQ_RGBA 255   0   0 255
+EXPECT framebuffer IDX 128 128 SIZE 1 1 EQ_RGBA 255   0   0 255
+EXPECT framebuffer IDX 255 255 SIZE 1 1 EQ_RGBA   0 255   0 255
+EXPECT ddump IDX 0 0 SIZE 1 1 EQ_RGBA 76 76 76 255 TOLERANCE 5% 5% 5% 0
+EXPECT ddump IDX 255 0 SIZE 1 1 EQ_RGBA 255 255 255 255 TOLERANCE 5% 5% 5% 0
+EXPECT ddump IDX 0 255 SIZE 1 1 EQ_RGBA 255 255 255 255 TOLERANCE 5% 5% 5% 0
+EXPECT ddump IDX 255 255 SIZE 1 1 EQ_RGBA 128 128 128 255 TOLERANCE 5% 5% 5% 0

--- a/tests/cases/draw_rectangles_depth_test_x8d24.amber
+++ b/tests/cases/draw_rectangles_depth_test_x8d24.amber
@@ -1,0 +1,135 @@
+#!amber
+#
+# Copyright 2021 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHADER vertex vert_shader GLSL
+#version 430
+
+layout(location = 0) in vec4 position;
+layout(location = 0) out vec4 frag_color;
+
+layout(set = 0, binding = 0) readonly buffer block1 {
+  vec4 in_color;
+  float depth;
+};
+
+void main() {
+  gl_Position = vec4(position.xy, depth, 1.0);
+  frag_color = in_color;
+}
+END
+
+SHADER fragment frag_shader GLSL
+#version 430
+
+layout(location = 0) in vec4 frag_color;
+layout(location = 0) out vec4 final_color;
+
+void main() {
+  final_color = frag_color;
+}
+END
+
+SHADER vertex vert_shader_tex GLSL
+#version 430
+layout(location = 0) in vec4 position;
+layout(location = 1) in vec2 texcoords_in;
+layout(location = 0) out vec2 texcoords_out;
+void main() {
+  gl_Position = position;
+  texcoords_out = texcoords_in;
+}
+END
+
+SHADER fragment frag_shader_tex GLSL
+#version 430
+layout(location = 0) in vec2 texcoords_in;
+layout(location = 0) out vec4 color_out;
+uniform layout(set=0, binding=0) sampler2D tex_sampler;
+void main() {
+  float f = texture(tex_sampler, texcoords_in).r;
+  color_out = vec4(f, f, f, 1);
+}
+END
+
+BUFFER data_buf1 DATA_TYPE float DATA  1.0 0.0  0.0 1.0 0.3 END
+BUFFER data_buf2 DATA_TYPE float DATA  0.0 1.0  0.0 1.0 0.5 END
+
+BUFFER position DATA_TYPE vec2<float> DATA
+-1.0 -1.0
+ 1.0 -1.0
+ 1.0  1.0
+-1.0  1.0
+END
+BUFFER texcoords DATA_TYPE vec2<float> DATA
+0.0 0.0
+1.0 0.0
+1.0 1.0
+0.0 1.0
+END
+
+BUFFER framebuffer FORMAT B8G8R8A8_UNORM
+BUFFER ddump FORMAT B8G8R8A8_UNORM
+BUFFER depthstencil FORMAT X8_D24_UNORM_PACK32
+
+SAMPLER sampler
+
+PIPELINE graphics pipeline1
+  ATTACH vert_shader
+  ATTACH frag_shader
+
+  FRAMEBUFFER_SIZE 256 256
+  BIND BUFFER framebuffer AS color LOCATION 0
+  BIND BUFFER depthstencil AS depth_stencil
+  BIND BUFFER data_buf1 AS storage DESCRIPTOR_SET 0 BINDING 0
+
+  DEPTH
+    TEST on
+    WRITE on
+    COMPARE_OP less
+    CLAMP off
+    BOUNDS min 0.0 max 1.0
+    BIAS constant 0.0 clamp 0.0 slope 0.0
+  END
+END
+
+DERIVE_PIPELINE pipeline2 FROM pipeline1
+  BIND BUFFER data_buf2 AS storage DESCRIPTOR_SET 0 BINDING 0
+END
+
+PIPELINE graphics depthdump
+  ATTACH vert_shader_tex
+  ATTACH frag_shader_tex
+  BIND BUFFER depthstencil AS combined_image_sampler SAMPLER sampler DESCRIPTOR_SET 0 BINDING 0
+  VERTEX_DATA position LOCATION 0
+  VERTEX_DATA texcoords LOCATION 1
+  FRAMEBUFFER_SIZE 256 256
+  BIND BUFFER ddump AS color LOCATION 0
+END
+
+CLEAR_DEPTH pipeline1 1.0
+CLEAR_COLOR pipeline1 255 255 255 255
+CLEAR pipeline1
+RUN pipeline1 DRAW_RECT POS   0   0 SIZE 200 200
+RUN pipeline2 DRAW_RECT POS   56 56 SIZE 200 200
+RUN depthdump DRAW_ARRAY AS TRIANGLE_FAN START_IDX 0 COUNT 4
+
+EXPECT framebuffer IDX   0   0 SIZE 1 1 EQ_RGBA 255   0   0 255
+EXPECT framebuffer IDX 128 128 SIZE 1 1 EQ_RGBA 255   0   0 255
+EXPECT framebuffer IDX 255 255 SIZE 1 1 EQ_RGBA   0 255   0 255
+EXPECT ddump IDX 0 0 SIZE 1 1 EQ_RGBA 76 76 76 255 TOLERANCE 5% 5% 5% 0
+EXPECT ddump IDX 255 0 SIZE 1 1 EQ_RGBA 255 255 255 255 TOLERANCE 5% 5% 5% 0
+EXPECT ddump IDX 0 255 SIZE 1 1 EQ_RGBA 255 255 255 255 TOLERANCE 5% 5% 5% 0
+EXPECT ddump IDX 255 255 SIZE 1 1 EQ_RGBA 128 128 128 255 TOLERANCE 5% 5% 5% 0


### PR DESCRIPTION
Vulkan expects depth component of D24_UNORM format to be padded to 32 bits. This change adds an 8-bit padding after the depth channel.