### PR TITLE
Workaround for GCC 11 uninit variable warnings

### DIFF
--- a/src/float16_helper.cc
+++ b/src/float16_helper.cc
@@ -15,6 +15,7 @@
 #include "src/float16_helper.h"
 
 #include <cassert>
+#include <cstring>
 
 // Float10
 // | 9 8 7 6 5 | 4 3 2 1 0 |
@@ -75,8 +76,11 @@ float HexFloat16ToFloat(const uint8_t* value) {
   }
 
   uint32_t hex = sign | exponent | mantissa;
-  float* hex_float = reinterpret_cast<float*>(&hex);
-  return *hex_float;
+  float hex_float;
+  static_assert((sizeof(uint32_t) == sizeof(float)),
+                "sizeof(uint32_t) != sizeof(float)");
+  memcpy(&hex_float, &hex, sizeof(float));
+  return hex_float;
 }
 
 // Convert float |value| whose size is 11 bits to 32 bits float
@@ -89,8 +93,11 @@ float HexFloat11ToFloat(const uint8_t* value) {
   uint32_t mantissa = (static_cast<uint32_t>(value[0]) & 0x3f) << 17U;
 
   uint32_t hex = exponent | mantissa;
-  float* hex_float = reinterpret_cast<float*>(&hex);
-  return *hex_float;
+  float hex_float;
+  static_assert((sizeof(uint32_t) == sizeof(float)),
+                "sizeof(uint32_t) != sizeof(float)");
+  memcpy(&hex_float, &hex, sizeof(float));
+  return hex_float;
 }
 
 // Convert float |value| whose size is 10 bits to 32 bits float
@@ -103,8 +110,11 @@ float HexFloat10ToFloat(const uint8_t* value) {
   uint32_t mantissa = (static_cast<uint32_t>(value[0]) & 0x1f) << 18U;
 
   uint32_t hex = exponent | mantissa;
-  float* hex_float = reinterpret_cast<float*>(&hex);
-  return *hex_float;
+  float hex_float;
+  static_assert((sizeof(uint32_t) == sizeof(float)),
+                "sizeof(uint32_t) != sizeof(float)");
+  memcpy(&hex_float, &hex, sizeof(float));
+  return hex_float;
 }
 
 }  // namespace


### PR DESCRIPTION
Release builds of Amber (and the CTS) with GCC 11.0.1 produce some uninitialized variable warnings:

```
external/amber/src/src/float16_helper.cc: In function ‘float amber::float16::{anonymous}::HexFloat16ToFloat(const uint8_t*)’:
external/amber/src/src/float16_helper.cc:79:11: error: ‘hex’ is used uninitialized [-Werror=uninitialized]
   79 |   return *hex_float;
      |           ^~~~~~~~~
external/amber/src/src/float16_helper.cc:77:12: note: ‘hex’ declared here
   77 |   uint32_t hex = sign | exponent | mantissa;
      |            ^~~
```

I'm not sure if this is a bug in GCC. This commit works around the warnings by replacing reinterpret_cast with memcpy when type punning unsigned integers to floats. At least on GCC the generated code should be unchanged compared to the current approach:

- reinterpret_cast: https://gcc.godbolt.org/z/P5zrTGTPv
- memcpy: https://gcc.godbolt.org/z/TKexGx6e1

There's also a new stringop-truncation warning in SPIRV-tools which affects building Amber but not the CTS.