### PR TITLE
Improve device feature check

### DIFF
--- a/tests/cases/float16.amber
+++ b/tests/cases/float16.amber
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-INSTANCE_EXTENSION VK_KHR_get_physical_device_properties2
 DEVICE_EXTENSION VK_KHR_shader_float16_int8
+DEVICE_EXTENSION VK_KHR_16bit_storage
+DEVICE_EXTENSION VK_KHR_storage_buffer_storage_class
 DEVICE_FEATURE Float16Int8Features.shaderFloat16
+DEVICE_FEATURE Storage16BitFeatures.storageBuffer16BitAccess
 
 SHADER compute f16 GLSL
 #version 450


### PR DESCRIPTION
Some of the device features were not checked if they are
supported on the device being used. This caused vkCreateDevice
to fail without any error message.

This commit adds the support check for the remaining device
features listed in the amber_script.md. Also adds missing required
extensions to tests/cases/float16.amber.

Fixes #953