### PR TITLE
Roll dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -24,7 +24,7 @@ vars = {
   'swiftshader_revision': 'b2af6a85583d1adf61033e82eaa5d067d764ece9',
   'vulkan_headers_revision': '9fe958cdabcaf87650a4517b27df1ec2034d051f',
   'vulkan_loader_revision': '4c901a731a63baf5e6049e1a976a6655fb83be01',
-  'vulkan_validationlayers_revision': '0cb8cc8cfcb2b86a767c9516ac2d62edb4e38ebe',
+  'vulkan_validationlayers_revision': '28bd6d60be55549ce2c617b9c065d44dddf9f146',
 }
 
 deps = {

--- a/DEPS
+++ b/DEPS
@@ -15,7 +15,7 @@ vars = {
   'cpplint_revision': '26470f9ccb354ff2f6d098f831271a1833701b28',
   'dxc_revision': '9f771648e6feee85e70d3a92bd31ec053a4d82b3',
   'glslang_revision': '7f6559d2802d0653541060f0909e33d137b9c8ba',
-  'googletest_revision': '0555b0eacbc56df1fd762c6aa87bb84be9e4ce7e',
+  'googletest_revision': '5b40153003d1a5ad7b8f40cffcd09434afda3428',
   'json_revision': '350ff4f7ced7c4117eae2fb93df02823c8021fcb',
   'lodepng_revision': '7fdcc96a5e5864eee72911c3ca79b1d9f0d12292',
   'shaderc_revision': 'fadb0edb247a1daa74f9a206a27e9a1c0417ce49',

--- a/DEPS
+++ b/DEPS
@@ -11,7 +11,7 @@ vars = {
 
   'clspv_llvm_revision': '7e30989dabce9ddbca0cbad7a8f25fb4e756d334',
   'clspv_revision': 'e0406e7053d1bb46b4bbeb57f0f2bbfca32f5612',
-  'cppdap_revision': '1fd23dda91e01550be1a421de307e6fedb2035a9',
+  'cppdap_revision': 'be5b677c7b85b52f7570c572e99833514e754b62',
   'cpplint_revision': '26470f9ccb354ff2f6d098f831271a1833701b28',
   'dxc_revision': '9f771648e6feee85e70d3a92bd31ec053a4d82b3',
   'glslang_revision': '7f6559d2802d0653541060f0909e33d137b9c8ba',

--- a/DEPS
+++ b/DEPS
@@ -18,7 +18,7 @@ vars = {
   'googletest_revision': '0555b0eacbc56df1fd762c6aa87bb84be9e4ce7e',
   'json_revision': '350ff4f7ced7c4117eae2fb93df02823c8021fcb',
   'lodepng_revision': '7fdcc96a5e5864eee72911c3ca79b1d9f0d12292',
-  'shaderc_revision': '88f9156d7f6a2a30baed1ace196faa3bc5eccc05',
+  'shaderc_revision': 'fadb0edb247a1daa74f9a206a27e9a1c0417ce49',
   'spirv_headers_revision': '5ab5c96198f30804a6a29961b8905f292a8ae600',
   'spirv_tools_revision': '1f2fcddd3963b9c29bf360daf7656c5977c2aadd',
   'swiftshader_revision': '04515da400d5fbc22d852af1369c4d46bd54991e',

--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ vars = {
   'swiftshader_git': 'https://swiftshader.googlesource.com',
 
   'clspv_llvm_revision': '7e30989dabce9ddbca0cbad7a8f25fb4e756d334',
-  'clspv_revision': 'e0406e7053d1bb46b4bbeb57f0f2bbfca32f5612',
+  'clspv_revision': '3970681ca8144e9a8d3cdd3f0d37c12465434211',
   'cppdap_revision': 'be5b677c7b85b52f7570c572e99833514e754b62',
   'cpplint_revision': '26470f9ccb354ff2f6d098f831271a1833701b28',
   'dxc_revision': '9f771648e6feee85e70d3a92bd31ec053a4d82b3',

--- a/DEPS
+++ b/DEPS
@@ -17,7 +17,7 @@ vars = {
   'glslang_revision': 'e0f3fdf43385061a1e3a049208e98527ee6af4af',
   'googletest_revision': '5b40153003d1a5ad7b8f40cffcd09434afda3428',
   'json_revision': '350ff4f7ced7c4117eae2fb93df02823c8021fcb',
-  'lodepng_revision': '7fdcc96a5e5864eee72911c3ca79b1d9f0d12292',
+  'lodepng_revision': '8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a',
   'shaderc_revision': 'fadb0edb247a1daa74f9a206a27e9a1c0417ce49',
   'spirv_headers_revision': 'e7b49d7fb59808a650618e0a4008d4bae927e112',
   'spirv_tools_revision': '175ecd49ed66cb3cb2593a4c6dd24468563bf17d',

--- a/DEPS
+++ b/DEPS
@@ -9,7 +9,7 @@ vars = {
   'nlohmann_git': 'https://github.com/nlohmann',
   'swiftshader_git': 'https://swiftshader.googlesource.com',
 
-  'clspv_llvm_revision': '7e30989dabce9ddbca0cbad7a8f25fb4e756d334',
+  'clspv_llvm_revision': '8b754e2f756775c9ac20363753fc51d011f164db',
   'clspv_revision': '3970681ca8144e9a8d3cdd3f0d37c12465434211',
   'cppdap_revision': 'be5b677c7b85b52f7570c572e99833514e754b62',
   'cpplint_revision': '26470f9ccb354ff2f6d098f831271a1833701b28',

--- a/DEPS
+++ b/DEPS
@@ -20,7 +20,7 @@ vars = {
   'lodepng_revision': '7fdcc96a5e5864eee72911c3ca79b1d9f0d12292',
   'shaderc_revision': 'fadb0edb247a1daa74f9a206a27e9a1c0417ce49',
   'spirv_headers_revision': 'e7b49d7fb59808a650618e0a4008d4bae927e112',
-  'spirv_tools_revision': '1f2fcddd3963b9c29bf360daf7656c5977c2aadd',
+  'spirv_tools_revision': '175ecd49ed66cb3cb2593a4c6dd24468563bf17d',
   'swiftshader_revision': '04515da400d5fbc22d852af1369c4d46bd54991e',
   'vulkan_headers_revision': '9fe958cdabcaf87650a4517b27df1ec2034d051f',
   'vulkan_loader_revision': '4c901a731a63baf5e6049e1a976a6655fb83be01',

--- a/DEPS
+++ b/DEPS
@@ -21,7 +21,7 @@ vars = {
   'shaderc_revision': 'fadb0edb247a1daa74f9a206a27e9a1c0417ce49',
   'spirv_headers_revision': 'e7b49d7fb59808a650618e0a4008d4bae927e112',
   'spirv_tools_revision': '175ecd49ed66cb3cb2593a4c6dd24468563bf17d',
-  'swiftshader_revision': '04515da400d5fbc22d852af1369c4d46bd54991e',
+  'swiftshader_revision': 'b2af6a85583d1adf61033e82eaa5d067d764ece9',
   'vulkan_headers_revision': '9fe958cdabcaf87650a4517b27df1ec2034d051f',
   'vulkan_loader_revision': '4c901a731a63baf5e6049e1a976a6655fb83be01',
   'vulkan_validationlayers_revision': '0cb8cc8cfcb2b86a767c9516ac2d62edb4e38ebe',

--- a/DEPS
+++ b/DEPS
@@ -14,7 +14,7 @@ vars = {
   'cppdap_revision': 'be5b677c7b85b52f7570c572e99833514e754b62',
   'cpplint_revision': '26470f9ccb354ff2f6d098f831271a1833701b28',
   'dxc_revision': '9f771648e6feee85e70d3a92bd31ec053a4d82b3',
-  'glslang_revision': '7f6559d2802d0653541060f0909e33d137b9c8ba',
+  'glslang_revision': 'e0f3fdf43385061a1e3a049208e98527ee6af4af',
   'googletest_revision': '5b40153003d1a5ad7b8f40cffcd09434afda3428',
   'json_revision': '350ff4f7ced7c4117eae2fb93df02823c8021fcb',
   'lodepng_revision': '7fdcc96a5e5864eee72911c3ca79b1d9f0d12292',

--- a/DEPS
+++ b/DEPS
@@ -23,7 +23,7 @@ vars = {
   'spirv_tools_revision': '1f2fcddd3963b9c29bf360daf7656c5977c2aadd',
   'swiftshader_revision': '04515da400d5fbc22d852af1369c4d46bd54991e',
   'vulkan_headers_revision': '11c6670b4a4f766ed4f1e777d1b3c3dc082dfa5f',
-  'vulkan_loader_revision': 'be6ccb9ecaf77dfef59246a1e8502e99c8e1a511',
+  'vulkan_loader_revision': '4c901a731a63baf5e6049e1a976a6655fb83be01',
   'vulkan_validationlayers_revision': '0cb8cc8cfcb2b86a767c9516ac2d62edb4e38ebe',
 }
 

--- a/DEPS
+++ b/DEPS
@@ -22,7 +22,7 @@ vars = {
   'spirv_headers_revision': 'e7b49d7fb59808a650618e0a4008d4bae927e112',
   'spirv_tools_revision': '1f2fcddd3963b9c29bf360daf7656c5977c2aadd',
   'swiftshader_revision': '04515da400d5fbc22d852af1369c4d46bd54991e',
-  'vulkan_headers_revision': '11c6670b4a4f766ed4f1e777d1b3c3dc082dfa5f',
+  'vulkan_headers_revision': '9fe958cdabcaf87650a4517b27df1ec2034d051f',
   'vulkan_loader_revision': '4c901a731a63baf5e6049e1a976a6655fb83be01',
   'vulkan_validationlayers_revision': '0cb8cc8cfcb2b86a767c9516ac2d62edb4e38ebe',
 }

--- a/DEPS
+++ b/DEPS
@@ -13,7 +13,7 @@ vars = {
   'clspv_revision': 'e0406e7053d1bb46b4bbeb57f0f2bbfca32f5612',
   'cppdap_revision': '1fd23dda91e01550be1a421de307e6fedb2035a9',
   'cpplint_revision': '26470f9ccb354ff2f6d098f831271a1833701b28',
-  'dxc_revision': '489c2e4d32417cd6693db5673ab071d82e1f5974',
+  'dxc_revision': '9f771648e6feee85e70d3a92bd31ec053a4d82b3',
   'glslang_revision': '7f6559d2802d0653541060f0909e33d137b9c8ba',
   'googletest_revision': '0555b0eacbc56df1fd762c6aa87bb84be9e4ce7e',
   'json_revision': '350ff4f7ced7c4117eae2fb93df02823c8021fcb',

--- a/DEPS
+++ b/DEPS
@@ -19,7 +19,7 @@ vars = {
   'json_revision': '350ff4f7ced7c4117eae2fb93df02823c8021fcb',
   'lodepng_revision': '7fdcc96a5e5864eee72911c3ca79b1d9f0d12292',
   'shaderc_revision': 'fadb0edb247a1daa74f9a206a27e9a1c0417ce49',
-  'spirv_headers_revision': '5ab5c96198f30804a6a29961b8905f292a8ae600',
+  'spirv_headers_revision': 'e7b49d7fb59808a650618e0a4008d4bae927e112',
   'spirv_tools_revision': '1f2fcddd3963b9c29bf360daf7656c5977c2aadd',
   'swiftshader_revision': '04515da400d5fbc22d852af1369c4d46bd54991e',
   'vulkan_headers_revision': '11c6670b4a4f766ed4f1e777d1b3c3dc082dfa5f',


### PR DESCRIPTION
Rolling dependencies introduced new warnings but no errors:

```
[193/405] Building CXX object third_party/glslang/glslang/CMakeFiles/MachineIndependent.dir/MachineIndependent/attribute.cpp.o
../third_party/glslang/glslang/MachineIndependent/attribute.cpp: In member function ‘void glslang::TParseContext::handleFunctionAttributes(const glslang::TSourceLoc&, const TAttributes&, glslang::TFunction*)’:
../third_party/glslang/glslang/MachineIndependent/attribute.cpp:350:111: warning: unused parameter ‘function’ [-Wunused-parameter]
  350 | void TParseContext::handleFunctionAttributes(const TSourceLoc& loc, const TAttributes& attributes, TFunction* function)
      |                                                                                                    ~~~~~~~~~~~^~~~~~~~
[198/405] Building CXX object third_party/glslang/glslang/CMakeFiles/MachineIndependent.dir/MachineIndependent/Constant.cpp.o
../third_party/glslang/glslang/MachineIndependent/Constant.cpp: In member function ‘virtual glslang::TIntermTyped* glslang::TIntermConstantUnion::fold(glslang::TOperator, const glslang::TType&) const’:
../third_party/glslang/glslang/MachineIndependent/Constant.cpp:534:59: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
  534 |                                 unionArray[i].getIConst() == 0x80000000
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
[282/405] Building CXX object third_party/glslang/SPIRV/CMakeFiles/SPIRV.dir/GlslangToSpv.cpp.o
../third_party/glslang/SPIRV/GlslangToSpv.cpp: In member function ‘virtual bool {anonymous}::TGlslangToSpvTraverser::visitAggregate(glslang::TVisit, glslang::TIntermAggregate*)’:
../third_party/glslang/SPIRV/GlslangToSpv.cpp:3380:31: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<TIntermNode*, glslang::pool_allocator<TIntermNode*> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
 3380 |             for (int i = 0; i < glslangOperands.size(); ++i) {
```