### PR TITLE
Add alpha blending support for AmberScript

### DIFF
--- a/docs/amber_script.md
+++ b/docs/amber_script.md
@@ -497,6 +497,96 @@ The following commands are all specified within the `PIPELINE` command.
   END
 ```
 
+#### Blend factors
+* `zero`
+* `one`
+* `src_color`
+* `one_minus_src_color`
+* `dst_color`
+* `one_minus_dst_color`
+* `src_alpha`
+* `one_minus_src_alpha`
+* `dst_alpha`
+* `one_minus_dst_alpha`
+* `constant_color`
+* `one_minus_constant_color`
+* `constant_alpha`
+* `one_minus_constant_alpha`
+* `src_alpha_saturate`
+* `src1_color`
+* `one_minus_src1_color`
+* `src1_alpha`
+* `one_minus_src1_alpha`
+
+#### Blend operations
+* `add`
+* `substract`
+* `reverse_substract`
+* `min`
+* `max`
+
+The following operations also require VK_EXT_blend_operation_advanced
+when using a Vulkan backend.
+* `zero`
+* `src`
+* `dst`
+* `src_over`
+* `dst_over`
+* `src_in`
+* `dst_in`
+* `src_out`
+* `dst_out`
+* `src_atop`
+* `dst_atop`
+* `xor`
+* `multiply`
+* `screen`
+* `overlay`
+* `darken`
+* `lighten`
+* `color_dodge`
+* `color_burn`
+* `hard_light`
+* `soft_light`
+* `difference`
+* `exclusion`
+* `invert`
+* `invert_rgb`
+* `linear_dodge`
+* `linear_burn`
+* `vivid_light`
+* `linear_light`
+* `pin_light`
+* `hard_mix`
+* `hsl_hue`
+* `hsl_saturation`
+* `hsl_color`
+* `hsl_luminosity`
+* `plus`
+* `plus_clamped`
+* `plus_clamped_alpha`
+* `plus_darker`
+* `minus`
+* `minus_clamped`
+* `contrast`
+* `invert_org`
+* `red`
+* `green`
+* `blue`
+
+```groovy
+  # Enable alpha blending and set blend factors and operations. Available
+  # blend factors and operations are listed above.
+  BLEND
+    SRC_COLOR_FACTOR {src_color_factor}
+    DST_COLOR_FACTOR {dst_color_factor}
+    COLOR_OP {color_op}
+    SRC_ALPHA_FACTOR {src_alpha_factor}
+    DST_ALPHA_FACTOR {dst_alpha_factor}
+    ALPHA_OP {alpha_op}
+  END
+```
+
 ```groovy
   # Set the size of the render buffers. |width| and |height| are integers and
   # default to 250x250.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -160,6 +160,7 @@ if (${AMBER_ENABLE_TESTS})
     amberscript/parser_shader_opt_test.cc
     amberscript/parser_shader_test.cc
     amberscript/parser_stencil_test.cc
+    amberscript/parser_blend_test.cc
     amberscript/parser_struct_test.cc
     amberscript/parser_subgroup_size_control_test.cc
     amberscript/parser_test.cc

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -624,6 +624,8 @@ Result Parser::ParsePipelineBody(const std::string& cmd_name,
       r = ParsePipelineSubgroup(pipeline.get());
     } else if (tok == "PATCH_CONTROL_POINTS") {
       r = ParsePipelinePatchControlPoints(pipeline.get());
+    } else if (tok == "BLEND") {
+      r = ParsePipelineBlend(pipeline.get());
     } else {
       r = Result("unknown token in pipeline block: " + tok);
     }
@@ -1861,6 +1863,98 @@ Result Parser::ParsePipelineStencil(Pipeline* pipeline) {
   }
 
   return ValidateEndOfStatement("STENCIL command");
+}
+
+Result Parser::ParsePipelineBlend(Pipeline* pipeline) {
+  pipeline->GetPipelineData()->SetEnableBlend(true);
+
+  while (true) {
+    auto token = tokenizer_->NextToken();
+    if (token->IsEOL())
+      continue;
+    if (token->IsEOS())
+      return Result("BLEND missing END command");
+    if (!token->IsIdentifier())
+      return Result("BLEND options must be identifiers");
+    if (token->AsString() == "END")
+      break;
+
+    if (token->AsString() == "SRC_COLOR_FACTOR") {
+      token = tokenizer_->NextToken();
+
+      if (!token->IsIdentifier())
+        return Result("BLEND invalid value for SRC_COLOR_FACTOR");
+
+      const auto factor = NameToBlendFactor(token->AsString());
+      if (factor == BlendFactor::kUnknown)
+        return Result("BLEND invalid value for SRC_COLOR_FACTOR: " +
+                      token->AsString());
+      pipeline->GetPipelineData()->SetSrcColorBlendFactor(
+          NameToBlendFactor(token->AsString()));
+    } else if (token->AsString() == "DST_COLOR_FACTOR") {
+      token = tokenizer_->NextToken();
+
+      if (!token->IsIdentifier())
+        return Result("BLEND invalid value for DST_COLOR_FACTOR");
+
+      const auto factor = NameToBlendFactor(token->AsString());
+      if (factor == BlendFactor::kUnknown)
+        return Result("BLEND invalid value for DST_COLOR_FACTOR: " +
+                      token->AsString());
+      pipeline->GetPipelineData()->SetDstColorBlendFactor(
+          NameToBlendFactor(token->AsString()));
+    } else if (token->AsString() == "SRC_ALPHA_FACTOR") {
+      token = tokenizer_->NextToken();
+
+      if (!token->IsIdentifier())
+        return Result("BLEND invalid value for SRC_ALPHA_FACTOR");
+
+      const auto factor = NameToBlendFactor(token->AsString());
+      if (factor == BlendFactor::kUnknown)
+        return Result("BLEND invalid value for SRC_ALPHA_FACTOR: " +
+                      token->AsString());
+      pipeline->GetPipelineData()->SetSrcAlphaBlendFactor(
+          NameToBlendFactor(token->AsString()));
+    } else if (token->AsString() == "DST_ALPHA_FACTOR") {
+      token = tokenizer_->NextToken();
+
+      if (!token->IsIdentifier())
+        return Result("BLEND invalid value for DST_ALPHA_FACTOR");
+
+      const auto factor = NameToBlendFactor(token->AsString());
+      if (factor == BlendFactor::kUnknown)
+        return Result("BLEND invalid value for DST_ALPHA_FACTOR: " +
+                      token->AsString());
+      pipeline->GetPipelineData()->SetDstAlphaBlendFactor(
+          NameToBlendFactor(token->AsString()));
+    } else if (token->AsString() == "COLOR_OP") {
+      token = tokenizer_->NextToken();
+
+      if (!token->IsIdentifier())
+        return Result("BLEND invalid value for COLOR_OP");
+
+      const auto op = NameToBlendOp(token->AsString());
+      if (op == BlendOp::kUnknown)
+        return Result("BLEND invalid value for COLOR_OP: " + token->AsString());
+      pipeline->GetPipelineData()->SetColorBlendOp(
+          NameToBlendOp(token->AsString()));
+    } else if (token->AsString() == "ALPHA_OP") {
+      token = tokenizer_->NextToken();
+
+      if (!token->IsIdentifier())
+        return Result("BLEND invalid value for ALPHA_OP");
+
+      const auto op = NameToBlendOp(token->AsString());
+      if (op == BlendOp::kUnknown)
+        return Result("BLEND invalid value for ALPHA_OP: " + token->AsString());
+      pipeline->GetPipelineData()->SetAlphaBlendOp(
+          NameToBlendOp(token->AsString()));
+    } else {
+      return Result("BLEND invalid value for BLEND: " + token->AsString());
+    }
+  }
+
+  return ValidateEndOfStatement("BLEND command");
 }
 
 Result Parser::ParseStruct() {

--- a/src/amberscript/parser.h
+++ b/src/amberscript/parser.h
@@ -74,6 +74,7 @@ class Parser : public amber::Parser {
   Result ParsePipelinePolygonMode(Pipeline*);
   Result ParsePipelineDepth(Pipeline* pipeline);
   Result ParsePipelineStencil(Pipeline* pipeline);
+  Result ParsePipelineBlend(Pipeline* pipeline);
   Result ParseRun();
   Result ParseDebug();
   Result ParseDebugThread(debug::Events*, Pipeline* pipeline);

--- a/src/amberscript/parser_blend_test.cc
+++ b/src/amberscript/parser_blend_test.cc
@@ -1,0 +1,140 @@
+// Copyright 2021 The Amber Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or parseried.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+#include "src/amberscript/parser.h"
+
+namespace amber {
+namespace amberscript {
+
+using AmberScriptParserTest = testing::Test;
+
+TEST_F(AmberScriptParserTest, BlendAllValues) {
+  std::string in = R"(
+SHADER vertex my_shader PASSTHROUGH
+SHADER fragment my_fragment GLSL
+# GLSL Shader
+END
+BUFFER my_fb FORMAT R32G32B32A32_SFLOAT
+
+PIPELINE graphics my_pipeline
+  ATTACH my_shader
+  ATTACH my_fragment
+  BIND BUFFER my_fb AS color LOCATION 0
+
+  BLEND
+    SRC_COLOR_FACTOR src_alpha
+    DST_COLOR_FACTOR one_minus_src_alpha
+    COLOR_OP add
+    SRC_ALPHA_FACTOR one
+    DST_ALPHA_FACTOR zero
+    ALPHA_OP max
+  END
+END)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto script = parser.GetScript();
+  const auto& pipelines = script->GetPipelines();
+  ASSERT_EQ(1U, pipelines.size());
+
+  auto* pipeline = pipelines[0].get();
+
+  ASSERT_TRUE(pipeline->GetPipelineData()->GetEnableBlend());
+  ASSERT_EQ(BlendFactor::kSrcAlpha,
+            pipeline->GetPipelineData()->GetSrcColorBlendFactor());
+  ASSERT_EQ(BlendFactor::kOneMinusSrcAlpha,
+            pipeline->GetPipelineData()->GetDstColorBlendFactor());
+  ASSERT_EQ(BlendOp::kAdd,
+            pipeline->GetPipelineData()->GetColorBlendOp());
+
+  ASSERT_EQ(BlendFactor::kOne,
+            pipeline->GetPipelineData()->GetSrcAlphaBlendFactor());
+  ASSERT_EQ(BlendFactor::kZero,
+            pipeline->GetPipelineData()->GetDstAlphaBlendFactor());
+  ASSERT_EQ(BlendOp::kMax,
+            pipeline->GetPipelineData()->GetAlphaBlendOp());
+}
+
+TEST_F(AmberScriptParserTest, BlendDefaultValues) {
+  std::string in = R"(
+SHADER vertex my_shader PASSTHROUGH
+SHADER fragment my_fragment GLSL
+# GLSL Shader
+END
+BUFFER my_fb FORMAT R32G32B32A32_SFLOAT
+
+PIPELINE graphics my_pipeline
+  ATTACH my_shader
+  ATTACH my_fragment
+  BIND BUFFER my_fb AS color LOCATION 0
+
+  BLEND
+  END
+END)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_TRUE(r.IsSuccess()) << r.Error();
+
+  auto script = parser.GetScript();
+  const auto& pipelines = script->GetPipelines();
+  ASSERT_EQ(1U, pipelines.size());
+
+  auto* pipeline = pipelines[0].get();
+
+  ASSERT_TRUE(pipeline->GetPipelineData()->GetEnableBlend());
+  ASSERT_EQ(BlendFactor::kOne,
+            pipeline->GetPipelineData()->GetSrcColorBlendFactor());
+  ASSERT_EQ(BlendFactor::kZero,
+            pipeline->GetPipelineData()->GetDstColorBlendFactor());
+  ASSERT_EQ(BlendOp::kAdd,
+            pipeline->GetPipelineData()->GetColorBlendOp());
+
+  ASSERT_EQ(BlendFactor::kOne,
+            pipeline->GetPipelineData()->GetSrcAlphaBlendFactor());
+  ASSERT_EQ(BlendFactor::kZero,
+            pipeline->GetPipelineData()->GetDstAlphaBlendFactor());
+  ASSERT_EQ(BlendOp::kAdd,
+            pipeline->GetPipelineData()->GetAlphaBlendOp());
+}
+
+TEST_F(AmberScriptParserTest, BlendInvalidColorFactor) {
+  std::string in = R"(
+SHADER vertex my_shader PASSTHROUGH
+SHADER fragment my_fragment GLSL
+# GLSL Shader
+END
+BUFFER my_fb FORMAT R32G32B32A32_SFLOAT
+
+PIPELINE graphics my_pipeline
+  ATTACH my_shader
+  ATTACH my_fragment
+  BIND BUFFER my_fb AS color LOCATION 0
+
+  BLEND
+    SRC_COLOR_FACTOR foo
+  END
+END)";
+
+  Parser parser;
+  Result r = parser.Parse(in);
+  ASSERT_FALSE(r.IsSuccess()) << r.Error();
+  EXPECT_EQ("14: BLEND invalid value for SRC_COLOR_FACTOR: foo", r.Error());
+}
+
+}  // namespace amberscript
+}  // namespace amber

--- a/src/command_data.cc
+++ b/src/command_data.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "src/command_data.h"
+#include <map>
 
 namespace amber {
 
@@ -52,6 +53,96 @@ Topology NameToTopology(const std::string& name) {
   }
 
   return Topology::kUnknown;
+}
+
+BlendFactor NameToBlendFactor(const std::string& name) {
+  static const std::map<const std::string, BlendFactor> map = {
+      {"zero", BlendFactor::kZero},
+      {"one", BlendFactor::kOne},
+      {"src_color", BlendFactor::kSrcColor},
+      {"one_minus_src_color", BlendFactor::kOneMinusSrcColor},
+      {"dst_color", BlendFactor::kDstColor},
+      {"one_minus_dst_color", BlendFactor::kOneMinusDstColor},
+      {"src_alpha", BlendFactor::kSrcAlpha},
+      {"one_minus_src_alpha", BlendFactor::kOneMinusSrcAlpha},
+      {"dst_alpha", BlendFactor::kDstAlpha},
+      {"one_minus_dst_alpha", BlendFactor::kOneMinusDstAlpha},
+      {"constant_color", BlendFactor::kConstantColor},
+      {"one_minus_constant_color", BlendFactor::kOneMinusConstantColor},
+      {"costant_alpha", BlendFactor::kConstantAlpha},
+      {"one_minus_constant_alpha", BlendFactor::kOneMinusConstantAlpha},
+      {"src_alpha_saturate", BlendFactor::kSrcAlphaSaturate},
+      {"src1_color", BlendFactor::kSrc1Color},
+      {"one_minus_src1_color", BlendFactor::kOneMinusSrc1Color},
+      {"src1_alpha", BlendFactor::kSrc1Alpha},
+      {"one_minus_src1_alpha", BlendFactor::kOneMinusSrc1Alpha}};
+
+  auto item = map.find(name);
+  if (item != map.end())
+    return item->second;
+
+  return BlendFactor::kUnknown;
+}
+
+BlendOp NameToBlendOp(const std::string& name) {
+  static const std::map<const std::string, BlendOp> map = {
+      {"add", BlendOp::kAdd},
+      {"substract", BlendOp::kSubtract},
+      {"reverse_substract", BlendOp::kReverseSubtract},
+      {"min", BlendOp::kMin},
+      {"max", BlendOp::kMax},
+      {"zero", BlendOp::kZero},
+      {"src", BlendOp::kSrc},
+      {"dst", BlendOp::kDst},
+      {"src_over", BlendOp::kSrcOver},
+      {"dst_over", BlendOp::kDstOver},
+      {"src_in", BlendOp::kSrcIn},
+      {"dst_in", BlendOp::kDstIn},
+      {"src_out", BlendOp::kSrcOut},
+      {"dst_out", BlendOp::kDstOut},
+      {"src_atop", BlendOp::kSrcAtop},
+      {"dst_atop", BlendOp::kDstAtop},
+      {"xor", BlendOp::kXor},
+      {"multiply", BlendOp::kMultiply},
+      {"screen", BlendOp::kScreen},
+      {"overlay", BlendOp::kOverlay},
+      {"darken", BlendOp::kDarken},
+      {"lighten", BlendOp::kLighten},
+      {"color_dodge", BlendOp::kColorDodge},
+      {"color_burn", BlendOp::kColorBurn},
+      {"hard_light", BlendOp::kHardLight},
+      {"soft_light", BlendOp::kSoftLight},
+      {"difference", BlendOp::kDifference},
+      {"exclusion", BlendOp::kExclusion},
+      {"invert", BlendOp::kInvert},
+      {"invert_rgb", BlendOp::kInvertRGB},
+      {"linear_dodge", BlendOp::kLinearDodge},
+      {"linear_burn", BlendOp::kLinearBurn},
+      {"vivid_light", BlendOp::kVividLight},
+      {"linear_light", BlendOp::kLinearLight},
+      {"pin_light", BlendOp::kPinLight},
+      {"hard_mix", BlendOp::kHardMix},
+      {"hsl_hue", BlendOp::kHslHue},
+      {"hsl_saturation", BlendOp::kHslSaturation},
+      {"hsl_color", BlendOp::kHslColor},
+      {"hsl_luminosity", BlendOp::kHslLuminosity},
+      {"plus", BlendOp::kPlus},
+      {"plus_clamped", BlendOp::kPlusClamped},
+      {"plus_clamped_alpha", BlendOp::kPlusClampedAlpha},
+      {"plus_darker", BlendOp::kPlusDarker},
+      {"minus", BlendOp::kMinus},
+      {"minus_clamped", BlendOp::kMinusClamped},
+      {"contrast", BlendOp::kContrast},
+      {"invert_ovg", BlendOp::kInvertOvg},
+      {"red", BlendOp::kRed},
+      {"green", BlendOp::kGreen},
+      {"blue", BlendOp::kBlue}};
+
+  auto item = map.find(name);
+  if (item != map.end())
+    return item->second;
+
+  return BlendOp::kUnknown;
 }
 
 }  // namespace amber

--- a/src/command_data.cc
+++ b/src/command_data.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "src/command_data.h"
-#include <map>
 
 namespace amber {
 
@@ -56,93 +55,153 @@ Topology NameToTopology(const std::string& name) {
 }
 
 BlendFactor NameToBlendFactor(const std::string& name) {
-  static const std::map<const std::string, BlendFactor> map = {
-      {"zero", BlendFactor::kZero},
-      {"one", BlendFactor::kOne},
-      {"src_color", BlendFactor::kSrcColor},
-      {"one_minus_src_color", BlendFactor::kOneMinusSrcColor},
-      {"dst_color", BlendFactor::kDstColor},
-      {"one_minus_dst_color", BlendFactor::kOneMinusDstColor},
-      {"src_alpha", BlendFactor::kSrcAlpha},
-      {"one_minus_src_alpha", BlendFactor::kOneMinusSrcAlpha},
-      {"dst_alpha", BlendFactor::kDstAlpha},
-      {"one_minus_dst_alpha", BlendFactor::kOneMinusDstAlpha},
-      {"constant_color", BlendFactor::kConstantColor},
-      {"one_minus_constant_color", BlendFactor::kOneMinusConstantColor},
-      {"costant_alpha", BlendFactor::kConstantAlpha},
-      {"one_minus_constant_alpha", BlendFactor::kOneMinusConstantAlpha},
-      {"src_alpha_saturate", BlendFactor::kSrcAlphaSaturate},
-      {"src1_color", BlendFactor::kSrc1Color},
-      {"one_minus_src1_color", BlendFactor::kOneMinusSrc1Color},
-      {"src1_alpha", BlendFactor::kSrc1Alpha},
-      {"one_minus_src1_alpha", BlendFactor::kOneMinusSrc1Alpha}};
-
-  auto item = map.find(name);
-  if (item != map.end())
-    return item->second;
-
-  return BlendFactor::kUnknown;
+  if (name == "zero")
+    return BlendFactor::kZero;
+  else if (name == "one")
+    return BlendFactor::kOne;
+  else if (name == "src_color")
+    return BlendFactor::kSrcColor;
+  else if (name == "one_minus_src_color")
+    return BlendFactor::kOneMinusSrcColor;
+  else if (name == "dst_color")
+    return BlendFactor::kDstColor;
+  else if (name == "one_minus_dst_color")
+    return BlendFactor::kOneMinusDstColor;
+  else if (name == "src_alpha")
+    return BlendFactor::kSrcAlpha;
+  else if (name == "one_minus_src_alpha")
+    return BlendFactor::kOneMinusSrcAlpha;
+  else if (name == "dst_alpha")
+    return BlendFactor::kDstAlpha;
+  else if (name == "one_minus_dst_alpha")
+    return BlendFactor::kOneMinusDstAlpha;
+  else if (name == "constant_color")
+    return BlendFactor::kConstantColor;
+  else if (name == "one_minus_constant_color")
+    return BlendFactor::kOneMinusConstantColor;
+  else if (name == "costant_alpha")
+    return BlendFactor::kConstantAlpha;
+  else if (name == "one_minus_constant_alpha")
+    return BlendFactor::kOneMinusConstantAlpha;
+  else if (name == "src_alpha_saturate")
+    return BlendFactor::kSrcAlphaSaturate;
+  else if (name == "src1_color")
+    return BlendFactor::kSrc1Color;
+  else if (name == "one_minus_src1_color")
+    return BlendFactor::kOneMinusSrc1Color;
+  else if (name == "src1_alpha")
+    return BlendFactor::kSrc1Alpha;
+  else if (name == "one_minus_src1_alpha")
+    return BlendFactor::kOneMinusSrc1Alpha;
+  else
+    return BlendFactor::kUnknown;
 }
 
 BlendOp NameToBlendOp(const std::string& name) {
-  static const std::map<const std::string, BlendOp> map = {
-      {"add", BlendOp::kAdd},
-      {"substract", BlendOp::kSubtract},
-      {"reverse_substract", BlendOp::kReverseSubtract},
-      {"min", BlendOp::kMin},
-      {"max", BlendOp::kMax},
-      {"zero", BlendOp::kZero},
-      {"src", BlendOp::kSrc},
-      {"dst", BlendOp::kDst},
-      {"src_over", BlendOp::kSrcOver},
-      {"dst_over", BlendOp::kDstOver},
-      {"src_in", BlendOp::kSrcIn},
-      {"dst_in", BlendOp::kDstIn},
-      {"src_out", BlendOp::kSrcOut},
-      {"dst_out", BlendOp::kDstOut},
-      {"src_atop", BlendOp::kSrcAtop},
-      {"dst_atop", BlendOp::kDstAtop},
-      {"xor", BlendOp::kXor},
-      {"multiply", BlendOp::kMultiply},
-      {"screen", BlendOp::kScreen},
-      {"overlay", BlendOp::kOverlay},
-      {"darken", BlendOp::kDarken},
-      {"lighten", BlendOp::kLighten},
-      {"color_dodge", BlendOp::kColorDodge},
-      {"color_burn", BlendOp::kColorBurn},
-      {"hard_light", BlendOp::kHardLight},
-      {"soft_light", BlendOp::kSoftLight},
-      {"difference", BlendOp::kDifference},
-      {"exclusion", BlendOp::kExclusion},
-      {"invert", BlendOp::kInvert},
-      {"invert_rgb", BlendOp::kInvertRGB},
-      {"linear_dodge", BlendOp::kLinearDodge},
-      {"linear_burn", BlendOp::kLinearBurn},
-      {"vivid_light", BlendOp::kVividLight},
-      {"linear_light", BlendOp::kLinearLight},
-      {"pin_light", BlendOp::kPinLight},
-      {"hard_mix", BlendOp::kHardMix},
-      {"hsl_hue", BlendOp::kHslHue},
-      {"hsl_saturation", BlendOp::kHslSaturation},
-      {"hsl_color", BlendOp::kHslColor},
-      {"hsl_luminosity", BlendOp::kHslLuminosity},
-      {"plus", BlendOp::kPlus},
-      {"plus_clamped", BlendOp::kPlusClamped},
-      {"plus_clamped_alpha", BlendOp::kPlusClampedAlpha},
-      {"plus_darker", BlendOp::kPlusDarker},
-      {"minus", BlendOp::kMinus},
-      {"minus_clamped", BlendOp::kMinusClamped},
-      {"contrast", BlendOp::kContrast},
-      {"invert_ovg", BlendOp::kInvertOvg},
-      {"red", BlendOp::kRed},
-      {"green", BlendOp::kGreen},
-      {"blue", BlendOp::kBlue}};
-
-  auto item = map.find(name);
-  if (item != map.end())
-    return item->second;
-
-  return BlendOp::kUnknown;
+  if (name == "add")
+    return BlendOp::kAdd;
+  else if (name == "substract")
+    return BlendOp::kSubtract;
+  else if (name == "reverse_substract")
+    return BlendOp::kReverseSubtract;
+  else if (name == "min")
+    return BlendOp::kMin;
+  else if (name == "max")
+    return BlendOp::kMax;
+  else if (name == "zero")
+    return BlendOp::kZero;
+  else if (name == "src")
+    return BlendOp::kSrc;
+  else if (name == "dst")
+    return BlendOp::kDst;
+  else if (name == "src_over")
+    return BlendOp::kSrcOver;
+  else if (name == "dst_over")
+    return BlendOp::kDstOver;
+  else if (name == "src_in")
+    return BlendOp::kSrcIn;
+  else if (name == "dst_in")
+    return BlendOp::kDstIn;
+  else if (name == "src_out")
+    return BlendOp::kSrcOut;
+  else if (name == "dst_out")
+    return BlendOp::kDstOut;
+  else if (name == "src_atop")
+    return BlendOp::kSrcAtop;
+  else if (name == "dst_atop")
+    return BlendOp::kDstAtop;
+  else if (name == "xor")
+    return BlendOp::kXor;
+  else if (name == "multiply")
+    return BlendOp::kMultiply;
+  else if (name == "screen")
+    return BlendOp::kScreen;
+  else if (name == "overlay")
+    return BlendOp::kOverlay;
+  else if (name == "darken")
+    return BlendOp::kDarken;
+  else if (name == "lighten")
+    return BlendOp::kLighten;
+  else if (name == "color_dodge")
+    return BlendOp::kColorDodge;
+  else if (name == "color_burn")
+    return BlendOp::kColorBurn;
+  else if (name == "hard_light")
+    return BlendOp::kHardLight;
+  else if (name == "soft_light")
+    return BlendOp::kSoftLight;
+  else if (name == "difference")
+    return BlendOp::kDifference;
+  else if (name == "exclusion")
+    return BlendOp::kExclusion;
+  else if (name == "invert")
+    return BlendOp::kInvert;
+  else if (name == "invert_rgb")
+    return BlendOp::kInvertRGB;
+  else if (name == "linear_dodge")
+    return BlendOp::kLinearDodge;
+  else if (name == "linear_burn")
+    return BlendOp::kLinearBurn;
+  else if (name == "vivid_light")
+    return BlendOp::kVividLight;
+  else if (name == "linear_light")
+    return BlendOp::kLinearLight;
+  else if (name == "pin_light")
+    return BlendOp::kPinLight;
+  else if (name == "hard_mix")
+    return BlendOp::kHardMix;
+  else if (name == "hsl_hue")
+    return BlendOp::kHslHue;
+  else if (name == "hsl_saturation")
+    return BlendOp::kHslSaturation;
+  else if (name == "hsl_color")
+    return BlendOp::kHslColor;
+  else if (name == "hsl_luminosity")
+    return BlendOp::kHslLuminosity;
+  else if (name == "plus")
+    return BlendOp::kPlus;
+  else if (name == "plus_clamped")
+    return BlendOp::kPlusClamped;
+  else if (name == "plus_clamped_alpha")
+    return BlendOp::kPlusClampedAlpha;
+  else if (name == "plus_darker")
+    return BlendOp::kPlusDarker;
+  else if (name == "minus")
+    return BlendOp::kMinus;
+  else if (name == "minus_clamped")
+    return BlendOp::kMinusClamped;
+  else if (name == "contrast")
+    return BlendOp::kContrast;
+  else if (name == "invert_ovg")
+    return BlendOp::kInvertOvg;
+  else if (name == "red")
+    return BlendOp::kRed;
+  else if (name == "green")
+    return BlendOp::kGreen;
+  else if (name == "blue")
+    return BlendOp::kBlue;
+  else
+    return BlendOp::kUnknown;
 }
 
 }  // namespace amber

--- a/src/command_data.h
+++ b/src/command_data.h
@@ -104,7 +104,8 @@ enum class LogicOp : uint8_t {
 };
 
 enum class BlendOp : uint8_t {
-  kAdd = 0,
+  kUnknown = 0,
+  kAdd,
   kSubtract,
   kReverseSubtract,
   kMin,
@@ -158,7 +159,8 @@ enum class BlendOp : uint8_t {
 };
 
 enum class BlendFactor : uint8_t {
-  kZero = 0,
+  kUnknown = 0,
+  kZero,
   kOne,
   kSrcColor,
   kOneMinusSrcColor,
@@ -180,6 +182,8 @@ enum class BlendFactor : uint8_t {
 };
 
 Topology NameToTopology(const std::string& name);
+BlendFactor NameToBlendFactor(const std::string& name);
+BlendOp NameToBlendOp(const std::string& name);
 
 }  // namespace amber
 

--- a/src/vulkan/graphics_pipeline.cc
+++ b/src/vulkan/graphics_pipeline.cc
@@ -234,6 +234,8 @@ VkBlendFactor ToVkBlendFactor(BlendFactor factor) {
       return VK_BLEND_FACTOR_SRC1_ALPHA;
     case BlendFactor::kOneMinusSrc1Alpha:
       return VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA;
+    case BlendFactor::kUnknown:
+      break;
   }
   assert(false && "Vulkan::Unknown BlendFactor");
   return VK_BLEND_FACTOR_ZERO;
@@ -343,6 +345,8 @@ VkBlendOp ToVkBlendOp(BlendOp op) {
       return VK_BLEND_OP_GREEN_EXT;
     case BlendOp::kBlue:
       return VK_BLEND_OP_BLUE_EXT;
+    case BlendOp::kUnknown:
+      break;
   }
   assert(false && "Vulkan::Unknown BlendOp");
   return VK_BLEND_OP_ADD;

--- a/tests/cases/draw_rect_blend.amber
+++ b/tests/cases/draw_rect_blend.amber
@@ -1,0 +1,46 @@
+#!amber
+# Copyright 2021 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHADER vertex vert_shader PASSTHROUGH
+SHADER fragment frag_shader GLSL
+#version 430
+layout(location = 0) out vec4 color_out;
+void main()
+{
+  color_out = vec4(1.0, 0.0, 0.0, 0.5);
+}
+END
+
+BUFFER framebuffer FORMAT B8G8R8A8_UNORM
+
+PIPELINE graphics pipeline
+  ATTACH vert_shader
+  ATTACH frag_shader
+  BIND BUFFER framebuffer AS color LOCATION 0
+
+  BLEND
+    SRC_COLOR_FACTOR src_alpha
+    DST_COLOR_FACTOR one_minus_src_alpha
+    COLOR_OP add
+    SRC_ALPHA_FACTOR one
+    DST_ALPHA_FACTOR one
+    ALPHA_OP max
+  END
+END
+ 
+CLEAR_COLOR pipeline 0 255 0 255
+CLEAR pipeline
+RUN pipeline DRAW_RECT POS 0 0 SIZE 250 250
+EXPECT framebuffer IDX 0 0 SIZE 250 250 EQ_RGBA 128 128 0 255 TOLERANCE 5%


### PR DESCRIPTION
Alpha blending was previously only supported for VkScript. This change adds the support for AmberScript too.