### PR TITLE
Remove HLSL debugging tests from suppression list.

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -89,10 +89,6 @@ SUPPRESSIONS_SWIFTSHADER = [
   "glsl_read_and_write_image3d_rgba32i.amber",
   # shaderStorageImageMultisample feature not supported
   "draw_storageimage_multisample.amber",
-  # Fails on Ubuntu bot
-  "debugger_hlsl_basic_vertex_with_legalization.amber",
-  "debugger_hlsl_function_call.amber",
-  "debugger_hlsl_shadowed_vars.amber",
   # Unsupported depth/stencil formats
   "draw_rectangles_depth_test_d24s8.amber",
   "draw_rectangles_depth_test_x8d24.amber",

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -89,6 +89,8 @@ SUPPRESSIONS_SWIFTSHADER = [
   "glsl_read_and_write_image3d_rgba32i.amber",
   # shaderStorageImageMultisample feature not supported
   "draw_storageimage_multisample.amber",
+  # Fails on Ubuntu bot
+  "debugger_hlsl_function_call.amber",
   # Unsupported depth/stencil formats
   "draw_rectangles_depth_test_d24s8.amber",
   "draw_rectangles_depth_test_x8d24.amber",


### PR DESCRIPTION
After some modifications these tests were passing locally so these should not be on a suppression list.