### PR TITLE
Check error return when pushing descriptors

### DIFF
--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -430,7 +430,9 @@ Result Pipeline::SendDescriptorDataToDeviceIfNeeded() {
             "Vulkan: Pipeline::SendDescriptorDataToDeviceIfNeeded() "
             "descriptor's transfer resource is not found");
       }
-      descriptor_transfer_resources_[buffer]->Initialize();
+      Result r = descriptor_transfer_resources_[buffer]->Initialize();
+      if (!r.IsSuccess())
+         return r;
     }
 
     // Note that if a buffer for a descriptor is host accessible and


### PR DESCRIPTION
Pipeline::SendDescriptorDataToDeviceIfNeeded was not checking the error
return when initializing transfer buffers, which can lead to later code
attempting to use invalid buffers and crashing.