### PR TITLE
Use proper index type based on index buffer format

### DIFF
--- a/src/vulkan/index_buffer.cc
+++ b/src/vulkan/index_buffer.cc
@@ -36,6 +36,15 @@ Result IndexBuffer::SendIndexData(CommandBuffer* command, Buffer* buffer) {
   if (buffer->ElementCount() == 0)
     return Result("IndexBuffer::SendIndexData |buffer| is empty");
 
+  if (buffer->GetFormat()->IsUint32())
+    index_type_ = VK_INDEX_TYPE_UINT32;
+  else if (buffer->GetFormat()->IsUint16())
+    index_type_ = VK_INDEX_TYPE_UINT16;
+  else if (buffer->GetFormat()->IsUint8())
+    index_type_ = VK_INDEX_TYPE_UINT8_EXT;
+  else
+    return Result("IndexBuffer::SendIndexData unexpected index buffer format");
+
   transfer_buffer_ =
       MakeUnique<TransferBuffer>(device_, buffer->GetSizeInBytes(), nullptr);
   Result r = transfer_buffer_->AddUsageFlags(VK_BUFFER_USAGE_INDEX_BUFFER_BIT |
@@ -62,7 +71,7 @@ Result IndexBuffer::BindToCommandBuffer(CommandBuffer* command) {
 
   device_->GetPtrs()->vkCmdBindIndexBuffer(command->GetVkCommandBuffer(),
                                            transfer_buffer_->GetVkBuffer(), 0,
-                                           VK_INDEX_TYPE_UINT32);
+                                           index_type_);
   return {};
 }
 

--- a/src/vulkan/index_buffer.h
+++ b/src/vulkan/index_buffer.h
@@ -46,6 +46,7 @@ class IndexBuffer {
  private:
   Device* device_ = nullptr;
   std::unique_ptr<TransferBuffer> transfer_buffer_;
+  VkIndexType index_type_;
 };
 
 }  // namespace vulkan

--- a/tests/cases/draw_indexed_uint16.amber
+++ b/tests/cases/draw_indexed_uint16.amber
@@ -1,0 +1,48 @@
+#!amber
+# Copyright 2022 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHADER vertex vert_shader PASSTHROUGH
+SHADER fragment frag_shader GLSL
+#version 430
+layout(location = 0) out vec4 color_out;
+void main() {
+  color_out = vec4(0.0, 1.0, 0.0, 1.0);
+}
+END
+
+BUFFER position DATA_TYPE vec4<float> DATA
+-1.0  1.0 0.0 1.0
+ 1.0  1.0 0.0 1.0
+ 1.0 -1.0 0.0 1.0
+-1.0 -1.0 0.0 1.0
+END
+
+BUFFER indices DATA_TYPE uint16 DATA
+3 2 1 0
+END
+
+IMAGE framebuffer FORMAT B8G8R8A8_UNORM DIM_2D WIDTH 64 HEIGHT 64
+
+PIPELINE graphics pipeline
+  ATTACH vert_shader
+  ATTACH frag_shader
+  VERTEX_DATA position LOCATION 0
+  INDEX_DATA indices
+  FRAMEBUFFER_SIZE 64 64
+  BIND BUFFER framebuffer AS color LOCATION 0
+END
+
+RUN pipeline DRAW_ARRAY AS TRIANGLE_FAN INDEXED START_IDX 0 COUNT 4
+EXPECT framebuffer IDX 0 0 SIZE 64 64 EQ_RGBA 0 255 0 255

--- a/tests/cases/draw_indexed_uint32.amber
+++ b/tests/cases/draw_indexed_uint32.amber
@@ -1,0 +1,48 @@
+#!amber
+# Copyright 2022 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHADER vertex vert_shader PASSTHROUGH
+SHADER fragment frag_shader GLSL
+#version 430
+layout(location = 0) out vec4 color_out;
+void main() {
+  color_out = vec4(0.0, 1.0, 0.0, 1.0);
+}
+END
+
+BUFFER position DATA_TYPE vec4<float> DATA
+-1.0  1.0 0.0 1.0
+ 1.0  1.0 0.0 1.0
+ 1.0 -1.0 0.0 1.0
+-1.0 -1.0 0.0 1.0
+END
+
+BUFFER indices DATA_TYPE uint32 DATA
+3 2 1 0
+END
+
+IMAGE framebuffer FORMAT B8G8R8A8_UNORM DIM_2D WIDTH 64 HEIGHT 64
+
+PIPELINE graphics pipeline
+  ATTACH vert_shader
+  ATTACH frag_shader
+  VERTEX_DATA position LOCATION 0
+  INDEX_DATA indices
+  FRAMEBUFFER_SIZE 64 64
+  BIND BUFFER framebuffer AS color LOCATION 0
+END
+
+RUN pipeline DRAW_ARRAY AS TRIANGLE_FAN INDEXED START_IDX 0 COUNT 4
+EXPECT framebuffer IDX 0 0 SIZE 64 64 EQ_RGBA 0 255 0 255

--- a/tests/cases/draw_indexed_uint8.amber
+++ b/tests/cases/draw_indexed_uint8.amber
@@ -1,0 +1,50 @@
+#!amber
+# Copyright 2022 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DEVICE_EXTENSION VK_EXT_index_type_uint8
+
+SHADER vertex vert_shader PASSTHROUGH
+SHADER fragment frag_shader GLSL
+#version 430
+layout(location = 0) out vec4 color_out;
+void main() {
+  color_out = vec4(0.0, 1.0, 0.0, 1.0);
+}
+END
+
+BUFFER position DATA_TYPE vec4<float> DATA
+-1.0  1.0 0.0 1.0
+ 1.0  1.0 0.0 1.0
+ 1.0 -1.0 0.0 1.0
+-1.0 -1.0 0.0 1.0
+END
+
+BUFFER indices DATA_TYPE uint8 DATA
+3 2 1 0
+END
+
+IMAGE framebuffer FORMAT B8G8R8A8_UNORM DIM_2D WIDTH 64 HEIGHT 64
+
+PIPELINE graphics pipeline
+  ATTACH vert_shader
+  ATTACH frag_shader
+  VERTEX_DATA position LOCATION 0
+  INDEX_DATA indices
+  FRAMEBUFFER_SIZE 64 64
+  BIND BUFFER framebuffer AS color LOCATION 0
+END
+
+RUN pipeline DRAW_ARRAY AS TRIANGLE_FAN INDEXED START_IDX 0 COUNT 4
+EXPECT framebuffer IDX 0 0 SIZE 64 64 EQ_RGBA 0 255 0 255

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -98,6 +98,8 @@ SUPPRESSIONS_SWIFTSHADER = [
   "draw_rectangles_depth_test_x8d24.amber",
   # Tessellation not supported
   "tessellation_isolines.amber",
+  # 8 bit indices not supported
+  "draw_indexed_uint8.amber",
 ]
 
 OPENCL_CASES = [


### PR DESCRIPTION
Amber was assuming the index buffer to always be uint32. Now the buffer format is used to determine the index type when binding the index buffer in Vulkan.