### PR TITLE
Docker: Change ownership of core files too

### DIFF
--- a/kokoro/scripts/linux/build.sh
+++ b/kokoro/scripts/linux/build.sh
@@ -38,4 +38,4 @@ docker run --rm -i \
   --entrypoint "${SCRIPT_DIR}/build-docker.sh" \
   "gcr.io/shaderc-build/radial-build:latest"
 
-sudo chown -R "$(id -u):$(id -g)" "${ROOT_DIR}/build"
+sudo chown -R "$(id -u):$(id -g)" "${ROOT_DIR}"


### PR DESCRIPTION
Sometimes bots leave a core file in $ROOT_DIR/core.
(But why are the bots passing in that case too?)