### PR TITLE
git-sync-deps: show the tail, not the head of what's being checked out

### DIFF
--- a/tools/git-sync-deps
+++ b/tools/git-sync-deps
@@ -116,11 +116,11 @@ def is_git_toplevel(git, directory):
 
 
 def status(directory, checkoutable):
-  def truncate(s, length):
-    return s if len(s) <= length else s[:(length - 3)] + '...'
+  def tail_truncate(s, length):
+    return s if len(s) <= length else s[-(length - 3):] + '...'
   dlen = 36
-  directory = truncate(directory, dlen)
-  checkoutable = truncate(checkoutable, 40)
+  directory = tail_truncate(directory, dlen)
+  checkoutable = tail_truncate(checkoutable, 40)
   sys.stdout.write('%-*s @ %s\n' % (dlen, directory, checkoutable))
 
 


### PR DESCRIPTION
This is more informative when in a deep path.