### PR TITLE
Disable -Wcast-function-type-strict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,7 @@ function(amber_default_compile_options TARGET)
       -Wall
       -Werror
       -Wextra
+      -Wno-cast-function-type-strict
       -Wno-padded
       -Wno-switch-enum
       -Wno-unknown-pragmas


### PR DESCRIPTION
This CL turns off -Wcast-function-type-strict as it triggers on casts of the vulkan function pointers when casting the pointer returned by `getInstanceProcAddr`.

Fixes #1009