### PR TITLE
Remove -Weverything compiler option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,7 +225,6 @@ function(amber_default_compile_options TARGET)
         -Wno-c++98-compat-pedantic
         -Wno-format-pedantic
         -Wno-unknown-warning-option
-        -Weverything
       )
     endif()
   endif()


### PR DESCRIPTION
This flag includes warnings that are not intended for end-users to use - for example it includes the experimental -Wunsafe-buffer-usage flag which only makes sense when attempting to use a safe subset of C++.

See https://quuxplusone.github.io/blog/2018/12/06/dont-use-weverything/ for a more in-depth explanation of the problems with this flag.