### PR TITLE
include missing <cstdint>

### DIFF
--- a/include/amber/recipe.h
+++ b/include/amber/recipe.h
@@ -15,6 +15,7 @@
 #ifndef AMBER_RECIPE_H_
 #define AMBER_RECIPE_H_
 
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>

--- a/include/amber/shader_info.h
+++ b/include/amber/shader_info.h
@@ -15,6 +15,7 @@
 #ifndef AMBER_SHADER_INFO_H_
 #define AMBER_SHADER_INFO_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/descriptor_set_and_binding_parser.h
+++ b/src/descriptor_set_and_binding_parser.h
@@ -15,6 +15,7 @@
 #ifndef SRC_DESCRIPTOR_SET_AND_BINDING_PARSER_H_
 #define SRC_DESCRIPTOR_SET_AND_BINDING_PARSER_H_
 
+#include <cstdint>
 #include <string>
 
 #include "amber/result.h"


### PR DESCRIPTION
gcc-13 exposed errors like below due to it removing indirect includes of these headers in libstdc++ [1]

../git/external/amber/src/include/amber/shader_info.h:60:15: error: 'uint32_t' was not declared in this scope
   60 |   std::vector<uint32_t> shader_data;
      |               ^~~~~~~~

[1] https://www.gnu.org/software/gcc/gcc-13/porting_to.html

Signed-off-by: Khem Raj <raj.khem@gmail.com>