### PR TITLE
rollers: Khronos repos now use 'main' instead of 'master

### DIFF
--- a/tools/roll-all
+++ b/tools/roll-all
@@ -18,13 +18,10 @@
 # to main
 cpplint=1
 dxc=1
-glslang=1
 googletest=1
 json=1
 lodepng=1
 swiftshader=1
-vulkan_loader=1
-vulkan_validationlayers=1
 
 # This script assumes it's parent directory is the repo root.
 repo_path=$(dirname "$0")/..


### PR DESCRIPTION
Fixes: #1014
Change-Id: Ie0759ffd503d853eb4f0acc74d94deedbaf7ffb9