### PR TITLE
Print error result on `vkWaitForFences` failure

### DIFF
--- a/src/vulkan/command_buffer.cc
+++ b/src/vulkan/command_buffer.cc
@@ -15,6 +15,7 @@
 #include "src/vulkan/command_buffer.h"
 
 #include <cassert>
+#include <string>
 
 #include "src/vulkan/command_pool.h"
 #include "src/vulkan/device.h"

--- a/src/vulkan/command_buffer.cc
+++ b/src/vulkan/command_buffer.cc
@@ -97,8 +97,24 @@ Result CommandBuffer::SubmitAndReset(uint32_t timeout_ms) {
       static_cast<uint64_t>(timeout_ms) * 1000ULL * 1000ULL /* nanosecond */);
   if (r == VK_TIMEOUT)
     return Result("Vulkan::Calling vkWaitForFences Timeout");
-  if (r != VK_SUCCESS)
-    return Result("Vulkan::Calling vkWaitForFences Fail");
+  if (r != VK_SUCCESS) {
+    std::string result_str;
+    switch (r) {
+      case VK_ERROR_OUT_OF_HOST_MEMORY:
+        result_str = "OUT_OF_HOST_MEMORY";
+        break;
+      case VK_ERROR_OUT_OF_DEVICE_MEMORY:
+        result_str = "OUT_OF_DEVICE_MEMORY";
+        break;
+      case VK_ERROR_DEVICE_LOST:
+        result_str = "DEVICE_LOST";
+        break;
+      default:
+        result_str = "<UNEXPECTED RESULT>";
+        break;
+    }
+    return Result("Vulkan::Calling vkWaitForFences Fail (" + result_str + ")");
+  }
 
   if (device_->GetPtrs()->vkResetCommandBuffer(command_, 0) != VK_SUCCESS)
     return Result("Vulkan::Calling vkResetCommandBuffer Fail");


### PR DESCRIPTION
This makes it easier to tell why this vulkan function did not succeed.