### PR TITLE
amber: Add support for QNX.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,7 +112,7 @@ if (${AMBER_ENABLE_SHADERC})
   target_link_libraries(libamber shaderc SPIRV)
 endif()
 
-if (NOT MSVC AND NOT ANDROID)
+if (NOT MSVC AND NOT ANDROID AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "QNX")
   target_link_libraries(libamber pthread)
 endif()
 

--- a/src/platform.h
+++ b/src/platform.h
@@ -30,6 +30,9 @@ namespace amber {
 #define AMBER_PLATFORM_POSIX 1
 #elif defined(__Fuchsia__)
 #define AMBER_PLATFORM_POSIX 1
+#elif defined(__QNX__)
+#define AMBER_PLATFORM_QNX 1
+#define AMBER_PLATFORM_POSIX 1
 #else
 #error "Unknown platform."
 #endif
@@ -52,6 +55,10 @@ namespace amber {
 
 #if !defined(AMBER_PLATFORM_POSIX)
 #define AMBER_PLATFORM_POSIX 0
+#endif
+
+#if !defined(AMBER_PLATFORM_QNX)
+#define AMBER_PLATFORM_QNX 0
 #endif
 
 }  // namespace amber


### PR DESCRIPTION
This change adds support for enabling amber to be built for QNX platforms.

1. Update CMakeLists.txt to not link with pthread on QNX platforms as pthread is implemented as part of libc on QNX and a separate pthread library does not exist on QNX.

2. Update src/platform.h to recognize __QNX__ as a supported platform