### PR TITLE
android build: update to API level 24

### DIFF
--- a/kokoro/android/build.sh
+++ b/kokoro/android/build.sh
@@ -21,8 +21,8 @@ BUILD_TYPE="Release"
 
 export ANDROID_NDK="$BUILD_ROOT/android-ndk-r25b"
 ANDROID_STL="c++_static"
-ANDROID_PLATFORM="android-14"
-ANDROID_ABI="armeabi-v7a with NEON"
+ANDROID_PLATFORM="android-24"
+ANDROID_ABI="armeabi-v7a"
 
 TOOLCHAIN_PATH="$ANDROID_NDK/build/cmake/android.toolchain.cmake"
 


### PR DESCRIPTION
Vulkan was introduced in Amber API level 24, so there's no point in testing API level 14.
Also, NDKs drop support for very old API levels.

BUG=285134453

Change-Id: I45a1c7a56806feecba25428e921665c3fb4dde1c