### PR TITLE
Added support for the Vulkan performance pipeline runtime layer

### DIFF
--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -282,7 +282,7 @@ bool ParseArgs(const std::vector<std::string>& args, Options* opts) {
       opts->log_execute_calls = true;
     } else if (arg == "--disable-spirv-val") {
       opts->disable_spirv_validation = true;
-    } else if(arg == "--enable-runtime-layer") {
+    } else if (arg == "--enable-runtime-layer") {
       opts->enable_pipeline_runtime_layer = true;
     } else if (arg.size() > 0 && arg[0] == '-') {
       std::cerr << "Unrecognized option " << arg << std::endl;

--- a/samples/amber.cc
+++ b/samples/amber.cc
@@ -68,6 +68,7 @@ struct Options {
   bool log_graphics_calls_time = false;
   bool log_execute_calls = false;
   bool disable_spirv_validation = false;
+  bool enable_pipeline_runtime_layer = false;
   std::string shader_filename;
   amber::EngineType engine = amber::kEngineTypeVulkan;
   std::string spv_env;
@@ -103,6 +104,7 @@ const char kUsage[] = R"(Usage: amber [options] SCRIPT [SCRIPTS...]
   --log-graphics-calls-time -- Log timing of graphics API calls timing (Vulkan only).
   --log-execute-calls       -- Log each execute call before run.
   --disable-spirv-val       -- Disable SPIR-V validation.
+  --enable-runtime-layer    -- Enable pipeline runtime layer.
   -h                        -- This help text.
 )";
 
@@ -280,6 +282,8 @@ bool ParseArgs(const std::vector<std::string>& args, Options* opts) {
       opts->log_execute_calls = true;
     } else if (arg == "--disable-spirv-val") {
       opts->disable_spirv_validation = true;
+    } else if(arg == "--enable-runtime-layer") {
+      opts->enable_pipeline_runtime_layer = true;
     } else if (arg.size() > 0 && arg[0] == '-') {
       std::cerr << "Unrecognized option " << arg << std::endl;
       return false;
@@ -567,7 +571,8 @@ int main(int argc, const char** argv) {
                                required_instance_extensions.end()),
       std::vector<std::string>(required_device_extensions.begin(),
                                required_device_extensions.end()),
-      options.disable_validation_layer, options.show_version_info, &config);
+      options.disable_validation_layer, options.enable_pipeline_runtime_layer,
+      options.show_version_info, &config);
 
   if (!r.IsSuccess()) {
     std::cout << r.Error() << std::endl;

--- a/samples/config_helper.cc
+++ b/samples/config_helper.cc
@@ -45,6 +45,7 @@ amber::Result ConfigHelper::CreateConfig(
     const std::vector<std::string>& required_instance_extensions,
     const std::vector<std::string>& required_device_extensions,
     bool disable_validation_layer,
+    bool enable_pipeline_runtime_layer,
     bool show_version_info,
     std::unique_ptr<amber::EngineConfig>* config) {
   switch (engine) {
@@ -70,7 +71,7 @@ amber::Result ConfigHelper::CreateConfig(
   return impl_->CreateConfig(
       engine_major, engine_minor, selected_device, required_features,
       required_instance_extensions, required_device_extensions,
-      disable_validation_layer, show_version_info, config);
+      disable_validation_layer, enable_pipeline_runtime_layer, show_version_info, config);
 }
 
 }  // namespace sample

--- a/samples/config_helper.cc
+++ b/samples/config_helper.cc
@@ -71,7 +71,8 @@ amber::Result ConfigHelper::CreateConfig(
   return impl_->CreateConfig(
       engine_major, engine_minor, selected_device, required_features,
       required_instance_extensions, required_device_extensions,
-      disable_validation_layer, enable_pipeline_runtime_layer, show_version_info, config);
+      disable_validation_layer, enable_pipeline_runtime_layer,
+      show_version_info, config);
 }
 
 }  // namespace sample

--- a/samples/config_helper.h
+++ b/samples/config_helper.h
@@ -40,6 +40,7 @@ class ConfigHelperImpl {
       const std::vector<std::string>& required_instance_extensions,
       const std::vector<std::string>& required_device_extensions,
       bool disable_validation_layer,
+      bool enable_pipeline_runtime_layer,
       bool show_version_info,
       std::unique_ptr<amber::EngineConfig>* config) = 0;
 };
@@ -64,6 +65,7 @@ class ConfigHelper {
       const std::vector<std::string>& required_instance_extensions,
       const std::vector<std::string>& required_device_extensions,
       bool disable_validation_layer,
+      bool enable_pipeline_runtime_layer,
       bool show_version_info,
       std::unique_ptr<amber::EngineConfig>* config);
 

--- a/samples/config_helper_dawn.cc
+++ b/samples/config_helper_dawn.cc
@@ -57,6 +57,7 @@ amber::Result ConfigHelperDawn::CreateConfig(
     const std::vector<std::string>&,
     bool,
     bool,
+    bool,
     std::unique_ptr<amber::EngineConfig>* config) {
   // Set procedure table and error callback.
   DawnProcTable backendProcs = dawn_native::GetProcs();

--- a/samples/config_helper_dawn.h
+++ b/samples/config_helper_dawn.h
@@ -44,6 +44,7 @@ class ConfigHelperDawn : public ConfigHelperImpl {
       const std::vector<std::string>& required_instance_extensions,
       const std::vector<std::string>& required_device_extensions,
       bool disable_validation_layer,
+      bool enable_pipeline_runtime_layer,
       bool show_version_info,
       std::unique_ptr<amber::EngineConfig>* config) override;
 

--- a/samples/config_helper_vulkan.cc
+++ b/samples/config_helper_vulkan.cc
@@ -708,7 +708,8 @@ amber::Result ConfigHelperVulkan::CreateVulkanInstance(
   }
 
   instance_info.enabledLayerCount = static_cast<uint32_t>(layer_names.size());
-  instance_info.ppEnabledLayerNames = instance_info.enabledLayerCount > 0 ? layer_names.data() : nullptr;
+  instance_info.ppEnabledLayerNames =
+      instance_info.enabledLayerCount > 0 ? layer_names.data() : nullptr;
 
   available_instance_extensions_ = GetAvailableInstanceExtensions();
   if (!required_extensions.empty()) {
@@ -741,7 +742,8 @@ amber::Result ConfigHelperVulkan::CreateVulkanInstance(
       static_cast<uint32_t>(required_extensions_in_char.size());
   instance_info.ppEnabledExtensionNames = required_extensions_in_char.data();
 
-  const VkResult result = vkCreateInstance(&instance_info, nullptr, &vulkan_instance_);
+  const VkResult result =
+      vkCreateInstance(&instance_info, nullptr, &vulkan_instance_);
   if (result != VK_SUCCESS) {
     std::stringstream error_message;
     error_message << "Unable to create vulkan instance (code=" << result << ")";
@@ -819,7 +821,7 @@ amber::Result ConfigHelperVulkan::CheckVulkanPhysicalDeviceRequirements(
                                            : nullptr;
 
     shader_subgroup_extended_types_features.sType =
-    // NOLINTNEXTLINE(whitespace/line_length)
+        // NOLINTNEXTLINE(whitespace/line_length)
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES;
     shader_subgroup_extended_types_features.pNext = &variable_pointers_features;
 
@@ -1244,10 +1246,9 @@ amber::Result ConfigHelperVulkan::CreateConfig(
     bool enable_pipeline_runtime_layer,
     bool show_version_info,
     std::unique_ptr<amber::EngineConfig>* cfg_holder) {
-  amber::Result r = CreateVulkanInstance(engine_major, engine_minor,
-                                         required_instance_extensions,
-                                         disable_validation_layer,
-                                         enable_pipeline_runtime_layer);
+  amber::Result r = CreateVulkanInstance(
+      engine_major, engine_minor, required_instance_extensions,
+      disable_validation_layer, enable_pipeline_runtime_layer);
   if (!r.IsSuccess())
     return r;
 

--- a/samples/config_helper_vulkan.cc
+++ b/samples/config_helper_vulkan.cc
@@ -44,6 +44,8 @@ const char* const kRequiredValidationLayers[] = {
 const size_t kNumberOfRequiredValidationLayers =
     sizeof(kRequiredValidationLayers) / sizeof(const char*);
 
+const char kPipelineRuntimeLayerName[] = "VK_LAYER_STADIA_pipeline_runtime";
+
 const char kVariablePointers[] = "VariablePointerFeatures.variablePointers";
 const char kVariablePointersStorageBuffer[] =
     "VariablePointerFeatures.variablePointersStorageBuffer";
@@ -672,7 +674,8 @@ amber::Result ConfigHelperVulkan::CreateVulkanInstance(
     uint32_t engine_major,
     uint32_t engine_minor,
     std::vector<std::string> required_extensions,
-    bool disable_validation_layer) {
+    bool disable_validation_layer,
+    bool enable_pipeline_runtime_layer) {
   VkApplicationInfo app_info = VkApplicationInfo();
   app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
 
@@ -685,6 +688,8 @@ amber::Result ConfigHelperVulkan::CreateVulkanInstance(
   instance_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
   instance_info.pApplicationInfo = &app_info;
 
+  std::vector<const char*> layer_names;
+
   if (!disable_validation_layer) {
     if (!AreAllValidationLayersSupported())
       return amber::Result("Sample: not all validation layers are supported");
@@ -692,11 +697,18 @@ amber::Result ConfigHelperVulkan::CreateVulkanInstance(
       return amber::Result(
           "Sample: extensions of validation layers are not supported");
     }
-    instance_info.enabledLayerCount = kNumberOfRequiredValidationLayers;
-    instance_info.ppEnabledLayerNames = kRequiredValidationLayers;
-
+    for (size_t i = 0; i < kNumberOfRequiredValidationLayers; ++i) {
+      layer_names.push_back(kRequiredValidationLayers[i]);
+    }
     required_extensions.push_back(kExtensionForValidationLayer);
   }
+
+  if (enable_pipeline_runtime_layer) {
+    layer_names.push_back(kPipelineRuntimeLayerName);
+  }
+
+  instance_info.enabledLayerCount = static_cast<uint32_t>(layer_names.size());
+  instance_info.ppEnabledLayerNames = instance_info.enabledLayerCount > 0 ? layer_names.data() : nullptr;
 
   available_instance_extensions_ = GetAvailableInstanceExtensions();
   if (!required_extensions.empty()) {
@@ -729,9 +741,11 @@ amber::Result ConfigHelperVulkan::CreateVulkanInstance(
       static_cast<uint32_t>(required_extensions_in_char.size());
   instance_info.ppEnabledExtensionNames = required_extensions_in_char.data();
 
-  if (vkCreateInstance(&instance_info, nullptr, &vulkan_instance_) !=
-      VK_SUCCESS) {
-    return amber::Result("Unable to create vulkan instance");
+  const VkResult result = vkCreateInstance(&instance_info, nullptr, &vulkan_instance_);
+  if (result != VK_SUCCESS) {
+    std::stringstream error_message;
+    error_message << "Unable to create vulkan instance (code=" << result << ")";
+    return amber::Result(error_message.str());
   }
   return {};
 }
@@ -1227,11 +1241,13 @@ amber::Result ConfigHelperVulkan::CreateConfig(
     const std::vector<std::string>& required_instance_extensions,
     const std::vector<std::string>& required_device_extensions,
     bool disable_validation_layer,
+    bool enable_pipeline_runtime_layer,
     bool show_version_info,
     std::unique_ptr<amber::EngineConfig>* cfg_holder) {
   amber::Result r = CreateVulkanInstance(engine_major, engine_minor,
                                          required_instance_extensions,
-                                         disable_validation_layer);
+                                         disable_validation_layer,
+                                         enable_pipeline_runtime_layer);
   if (!r.IsSuccess())
     return r;
 

--- a/samples/config_helper_vulkan.h
+++ b/samples/config_helper_vulkan.h
@@ -49,6 +49,7 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
       const std::vector<std::string>& required_instance_extensions,
       const std::vector<std::string>& required_device_extensions,
       bool disable_validation_layer,
+      bool enable_pipeline_runtime_layer,
       bool show_version_info,
       std::unique_ptr<amber::EngineConfig>* config) override;
 
@@ -58,7 +59,8 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
       uint32_t engine_major,
       uint32_t engine_minor,
       std::vector<std::string> required_instance_extensions,
-      bool disable_validation_layer);
+      bool disable_validation_layer,
+      bool enable_pipeline_runtime_layer);
 
   /// Create |vulkan_callback_| that reports validation layer errors
   /// via debugCallback() function in config_helper_vulkan.cc.


### PR DESCRIPTION
Added support for the Vulkan performance pipeline runtime layer

Contrary to the validation layer, this is an opt-in layer.
Opt-in is achieved by passing --enable-runtime-layer to the CLI.