### PR TITLE
Change 'pixes' to 'pixels' in vk_script.md

### DIFF
--- a/docs/vk_script.md
+++ b/docs/vk_script.md
@@ -182,7 +182,7 @@ specified then the `a` parameter is dis-allowed.
 ### Probe
  * `[relative] probe [rect] (rgb|rgba) (_x_, _y_[, _width_, _height_]) (_r_, _g_, _b_[, _a_])`
 
-Probes a portion of the window to verify the pixes are of color r,g,b and
+Probes a portion of the window to verify the pixels are of color r,g,b and
 optionally a. If `rgba` is specifed then the `a` parameter is required. If
 `rgb` is specified then the `a` parameter is dis-allowed. If `rect` is specified
 then `width` and `height` are required. If `rect` is not specified then `width`


### PR DESCRIPTION
Typo in vk_script.md, Changed to 'pixes' to 'pixels'.