### PR TITLE
Disable draw_polygon_mode.amber with swiftshader

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -84,6 +84,8 @@ SUPPRESSIONS_SWIFTSHADER = [
   "tessellation_isolines.amber",
   # 8 bit indices not supported
   "draw_indexed_uint8.amber",
+  # Intermittent failures (https://github.com/google/amber/issues/1019).
+  "draw_polygon_mode.amber",
 ]
 
 OPENCL_CASES = [


### PR DESCRIPTION
The test fails intermittenly and is creating noise. Disabling the test
until https://github.com/google/amber/issues/1019 is fixed.
