### PR TITLE
Add DEVICE_PROPERTY support

### DIFF
--- a/include/amber/amber_vulkan.h
+++ b/include/amber/amber_vulkan.h
@@ -49,6 +49,17 @@ struct VulkanEngineConfig : public EngineConfig {
   /// the extension is not enabled, |available_features| will be used.
   VkPhysicalDeviceFeatures2KHR available_features2;
 
+  /// Physical device properties available for |physical_device|. The
+  /// |available_properties| will be ignored if
+  /// VK_KHR_get_physical_device_properties2 is enabled, |available_properties2|
+  /// will be used in that case.
+  VkPhysicalDeviceProperties available_properties;
+
+  /// Physical device properties for |physical_device|.The |available_properties2|
+  /// will only be used if VK_KHR_get_physical_device_properties2 is enabled. If
+  /// the extension is not enabled, |available_properties| will be used.
+  VkPhysicalDeviceProperties2KHR available_properties2;
+
   /// Instance extensions available.
   std::vector<std::string> available_instance_extensions;
 

--- a/include/amber/recipe.h
+++ b/include/amber/recipe.h
@@ -35,6 +35,9 @@ class RecipeImpl {
   /// Returns required features in the given recipe.
   virtual std::vector<std::string> GetRequiredFeatures() const = 0;
 
+  /// Returns required features in the given recipe.
+  virtual std::vector<std::string> GetRequiredProperties() const = 0;
+
   /// Returns required device extensions in the given recipe.
   virtual std::vector<std::string> GetRequiredDeviceExtensions() const = 0;
 

--- a/src/amber.cc
+++ b/src/amber.cc
@@ -133,6 +133,7 @@ Result CreateEngineAndCheckRequirements(const Recipe* recipe,
   // much else.  Refactor this if they end up doing to much here.
   Result r =
       engine->Initialize(opts->config, delegate, script->GetRequiredFeatures(),
+                         script->GetRequiredProperties(),
                          script->GetRequiredInstanceExtensions(),
                          script->GetRequiredDeviceExtensions());
   if (!r.IsSuccess())

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -304,6 +304,8 @@ Result Parser::Parse(const std::string& data) {
       r = ParseDeviceFeature();
     } else if (tok == "DEVICE_EXTENSION") {
       r = ParseDeviceExtension();
+    } else if (tok == "DEVICE_PROPERTY") {
+      r = ParseDeviceProperty();
     } else if (tok == "IMAGE") {
       r = ParseImage();
     } else if (tok == "INSTANCE_EXTENSION") {
@@ -3419,6 +3421,20 @@ Result Parser::ParseDeviceFeature() {
   script_->AddRequiredFeature(token->AsString());
 
   return ValidateEndOfStatement("DEVICE_FEATURE command");
+}
+
+Result Parser::ParseDeviceProperty() {
+  auto token = tokenizer_->NextToken();
+  if (token->IsEOS() || token->IsEOL())
+    return Result("missing feature name for DEVICE_PROPERTY command");
+  if (!token->IsIdentifier())
+    return Result("invalid feature name for DEVICE_PROPERTY command");
+  if (!script_->IsKnownProperty(token->AsString()))
+    return Result("unknown feature name for DEVICE_PROPERTY command");
+
+  script_->AddRequiredProperty(token->AsString());
+
+  return ValidateEndOfStatement("DEVICE_PROPERTY command");
 }
 
 Result Parser::ParseRepeat() {

--- a/src/amberscript/parser.h
+++ b/src/amberscript/parser.h
@@ -84,6 +84,7 @@ class Parser : public amber::Parser {
   Result ParseCopy();
   Result ParseDeviceFeature();
   Result ParseDeviceExtension();
+  Result ParseDeviceProperty();
   Result ParseInstanceExtension();
   Result ParseRepeat();
   Result ParseSet();

--- a/src/engine.h
+++ b/src/engine.h
@@ -70,6 +70,7 @@ class Engine {
       EngineConfig* config,
       Delegate* delegate,
       const std::vector<std::string>& features,
+      const std::vector<std::string>& properties,
       const std::vector<std::string>& instance_extensions,
       const std::vector<std::string>& device_extensions) = 0;
 

--- a/src/script.cc
+++ b/src/script.cc
@@ -133,6 +133,24 @@ bool Script::IsKnownFeature(const std::string& name) const {
              "ShaderSubgroupExtendedTypesFeatures.shaderSubgroupExtendedTypes";
 }
 
+bool Script::IsKnownProperty(const std::string& name) const {
+  return name == "FloatControls.shaderSignedZeroInfNanPreserveFloat16" ||
+      name == "FloatControls.shaderSignedZeroInfNanPreserveFloat32" ||
+      name == "FloatControls.shaderSignedZeroInfNanPreserveFloat64" ||
+      name == "FloatControls.shaderDenormPreserveFloat16" ||
+      name == "FloatControls.shaderDenormPreserveFloat32" ||
+      name == "FloatControls.shaderDenormPreserveFloat64" ||
+      name == "FloatControls.shaderDenormFlushToZeroFloat16" ||
+      name == "FloatControls.shaderDenormFlushToZeroFloat32" ||
+      name == "FloatControls.shaderDenormFlushToZeroFloat64" ||
+      name == "FloatControls.shaderRoundingModeRTEFloat16" ||
+      name == "FloatControls.shaderRoundingModeRTEFloat32" ||
+      name == "FloatControls.shaderRoundingModeRTEFloat64" ||
+      name == "FloatControls.shaderRoundingModeRTZFloat16" ||
+      name == "FloatControls.shaderRoundingModeRTZFloat32" ||
+      name == "FloatControls.shaderRoundingModeRTZFloat64";
+}
+
 type::Type* Script::ParseType(const std::string& str) {
   auto type = GetType(str);
   if (type)

--- a/src/script.h
+++ b/src/script.h
@@ -43,6 +43,7 @@ class Script : public RecipeImpl {
   ~Script() override;
 
   bool IsKnownFeature(const std::string& name) const;
+  bool IsKnownProperty(const std::string& name) const;
 
   /// Retrieves information on the shaders in the given script.
   std::vector<ShaderInfo> GetShaderInfo() const override;
@@ -50,6 +51,10 @@ class Script : public RecipeImpl {
   /// Returns required features in the given recipe.
   std::vector<std::string> GetRequiredFeatures() const override {
     return engine_info_.required_features;
+  }
+
+  std::vector<std::string> GetRequiredProperties() const override {
+    return engine_info_.required_properties;
   }
 
   /// Returns required device extensions in the given recipe.
@@ -161,11 +166,24 @@ class Script : public RecipeImpl {
     engine_info_.required_features.push_back(feature);
   }
 
+  /// Adds |prop| to the list of properties that must be supported by the
+  /// engine.
+  void AddRequiredProperty(const std::string& prop) {
+    engine_info_.required_properties.push_back(prop);
+  }
+
   /// Checks if |feature| is in required features
   bool IsRequiredFeature(const std::string& feature) const {
     return std::find(engine_info_.required_features.begin(),
                      engine_info_.required_features.end(),
                      feature) != engine_info_.required_features.end();
+  }
+
+  /// Checks if |prop| is in required features
+  bool IsRequiredProperty(const std::string& prop) const {
+    return std::find(engine_info_.required_properties.begin(),
+                     engine_info_.required_properties.end(),
+                     prop) != engine_info_.required_properties.end();
   }
 
   /// Adds |ext| to the list of device extensions that must be supported.
@@ -252,6 +270,7 @@ class Script : public RecipeImpl {
  private:
   struct {
     std::vector<std::string> required_features;
+    std::vector<std::string> required_properties;
     std::vector<std::string> required_device_extensions;
     std::vector<std::string> required_instance_extensions;
   } engine_info_;

--- a/src/vulkan/device.cc
+++ b/src/vulkan/device.cc
@@ -444,9 +444,12 @@ Result Device::Initialize(
     PFN_vkGetInstanceProcAddr getInstanceProcAddr,
     Delegate* delegate,
     const std::vector<std::string>& required_features,
+    const std::vector<std::string>& required_properties,
     const std::vector<std::string>& required_device_extensions,
     const VkPhysicalDeviceFeatures& available_features,
     const VkPhysicalDeviceFeatures2KHR& available_features2,
+    const VkPhysicalDeviceProperties& available_properties,
+    const VkPhysicalDeviceProperties2KHR& available_properties2,
     const std::vector<std::string>& available_extensions) {
   Result r = LoadVulkanPointers(getInstanceProcAddr, delegate);
   if (!r.IsSuccess())
@@ -709,6 +712,66 @@ Result Device::Initialize(
     return Result(
         "Vulkan: Device::Initialize given physical device does not support "
         "required extensions");
+  }
+
+  VkPhysicalDeviceVulkan12Properties* vulkan12_props_ptrs = nullptr;
+  VkPhysicalDeviceFloatControlsProperties* fc_props_ptrs = nullptr;
+
+  ptr = available_properties2.pNext;
+  while (ptr != nullptr) {
+    BaseOutStructure* s = static_cast<BaseOutStructure*>(ptr);
+    switch (s->sType) {
+      case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES:
+        vulkan12_props_ptrs =
+            static_cast<VkPhysicalDeviceVulkan12Properties*>(ptr);
+        break;
+      case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES_KHR:
+        fc_props_ptrs =
+            static_cast<VkPhysicalDeviceFloatControlsPropertiesKHR*>(ptr);
+        break;
+      default:
+        break;
+    }
+    ptr = s->pNext;
+  }
+
+#define CHECK_FLOAT_CONTROL_PROPERTY(R, P, NAME, S1, S2) \
+  if (R == -1 && P == #NAME) \
+    R = ((S1 && S1->NAME) || (S2 && S2->NAME)) ? 1 : 0;
+
+  for (const std::string& prop : required_properties) {
+    const size_t dot_pos = prop.find('.');
+    const size_t dot_found = dot_pos != std::string::npos;
+    const std::string prefix = dot_found ? prop.substr(0, dot_pos) : "";
+    const std::string name = dot_found ? prop.substr(dot_pos + 1) : prop;
+    int supported = -1;
+
+    if (supported == -1 && prefix == "FloatControls") {
+      if (fc_props_ptrs == nullptr && vulkan12_props_ptrs == nullptr)
+        return Result(
+            "Vulkan: Device::Initialize given physical device does not support "
+            "required float control properties");
+
+      CHECK_FLOAT_CONTROL_PROPERTY(supported, name, shaderSignedZeroInfNanPreserveFloat16, fc_props_ptrs, vulkan12_props_ptrs);
+      CHECK_FLOAT_CONTROL_PROPERTY(supported, name, shaderSignedZeroInfNanPreserveFloat32, fc_props_ptrs, vulkan12_props_ptrs);
+      CHECK_FLOAT_CONTROL_PROPERTY(supported, name, shaderSignedZeroInfNanPreserveFloat64, fc_props_ptrs, vulkan12_props_ptrs);
+      CHECK_FLOAT_CONTROL_PROPERTY(supported, name, shaderDenormPreserveFloat16, fc_props_ptrs, vulkan12_props_ptrs);
+      CHECK_FLOAT_CONTROL_PROPERTY(supported, name, shaderDenormPreserveFloat32, fc_props_ptrs, vulkan12_props_ptrs);
+      CHECK_FLOAT_CONTROL_PROPERTY(supported, name, shaderDenormPreserveFloat64, fc_props_ptrs, vulkan12_props_ptrs);
+      CHECK_FLOAT_CONTROL_PROPERTY(supported, name, shaderDenormFlushToZeroFloat16, fc_props_ptrs, vulkan12_props_ptrs);
+      CHECK_FLOAT_CONTROL_PROPERTY(supported, name, shaderDenormFlushToZeroFloat32, fc_props_ptrs, vulkan12_props_ptrs);
+      CHECK_FLOAT_CONTROL_PROPERTY(supported, name, shaderDenormFlushToZeroFloat64, fc_props_ptrs, vulkan12_props_ptrs);
+      CHECK_FLOAT_CONTROL_PROPERTY(supported, name, shaderRoundingModeRTEFloat16, fc_props_ptrs, vulkan12_props_ptrs);
+      CHECK_FLOAT_CONTROL_PROPERTY(supported, name, shaderRoundingModeRTEFloat32, fc_props_ptrs, vulkan12_props_ptrs);
+      CHECK_FLOAT_CONTROL_PROPERTY(supported, name, shaderRoundingModeRTEFloat64, fc_props_ptrs, vulkan12_props_ptrs);
+      CHECK_FLOAT_CONTROL_PROPERTY(supported, name, shaderRoundingModeRTZFloat16, fc_props_ptrs, vulkan12_props_ptrs);
+      CHECK_FLOAT_CONTROL_PROPERTY(supported, name, shaderRoundingModeRTZFloat32, fc_props_ptrs, vulkan12_props_ptrs);
+      CHECK_FLOAT_CONTROL_PROPERTY(supported, name, shaderRoundingModeRTZFloat64, fc_props_ptrs, vulkan12_props_ptrs);
+    }
+
+    if (supported == -1)
+      return Result(
+          "Vulkan: Device::Initialize property not handled " + prop);
   }
 
   ptrs_.vkGetPhysicalDeviceMemoryProperties(physical_device_,

--- a/src/vulkan/device.h
+++ b/src/vulkan/device.h
@@ -47,9 +47,12 @@ class Device {
   Result Initialize(PFN_vkGetInstanceProcAddr getInstanceProcAddr,
                     Delegate* delegate,
                     const std::vector<std::string>& required_features,
+                    const std::vector<std::string>& required_properties,
                     const std::vector<std::string>& required_device_extensions,
                     const VkPhysicalDeviceFeatures& available_features,
                     const VkPhysicalDeviceFeatures2KHR& available_features2,
+                    const VkPhysicalDeviceProperties& available_properties,
+                    const VkPhysicalDeviceProperties2KHR& available_properties2,
                     const std::vector<std::string>& available_extensions);
 
   /// Returns true if |format| and the |buffer|s buffer type combination is

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -92,6 +92,7 @@ Result EngineVulkan::Initialize(
     EngineConfig* config,
     Delegate* delegate,
     const std::vector<std::string>& features,
+    const std::vector<std::string>& properties,
     const std::vector<std::string>& instance_extensions,
     const std::vector<std::string>& device_extensions) {
   if (device_)
@@ -118,9 +119,10 @@ Result EngineVulkan::Initialize(
                                vk_config->queue);
 
   Result r = device_->Initialize(
-      vk_config->vkGetInstanceProcAddr, delegate, features, device_extensions,
-      vk_config->available_features, vk_config->available_features2,
-      vk_config->available_device_extensions);
+      vk_config->vkGetInstanceProcAddr, delegate, features, properties,
+      device_extensions, vk_config->available_features,
+      vk_config->available_features2, vk_config->available_properties,
+      vk_config->available_properties2, vk_config->available_device_extensions);
   if (!r.IsSuccess())
     return r;
 

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -45,6 +45,7 @@ class EngineVulkan : public Engine {
   Result Initialize(EngineConfig* config,
                     Delegate* delegate,
                     const std::vector<std::string>& features,
+                    const std::vector<std::string>& properties,
                     const std::vector<std::string>& instance_extensions,
                     const std::vector<std::string>& device_extensions) override;
   Result CreatePipeline(amber::Pipeline* type) override;


### PR DESCRIPTION
For certain cases device properties need to be checked same way as device features.
For example VK_KHR_shader_float_controls extension have a set of fields (DenormPreserve) that are available in VkPhysicalDeviceFloatControlsProperties.
Amber does not allow these to be checked and also does not have appropriate syntax for checking properties.
This pull request adds both.