### PR TITLE
Add ray tracing pipeline library support

### DIFF
--- a/docs/amber_script.md
+++ b/docs/amber_script.md
@@ -62,7 +62,9 @@ with:
  * `SubgroupSupportedStages.geometry`
  * `SubgroupSupportedStages.fragment`
  * `SubgroupSupportedStages.compute`
-
+ * `RayTracingPipelineFeaturesKHR.rayTracingPipeline`
+ * `AccelerationStructureFeaturesKHR.accelerationStructure`
+ * `BufferDeviceAddressFeatures.bufferDeviceAddress`
 
 Extensions can be enabled with the `DEVICE_EXTENSION` and `INSTANCE_EXTENSION`
 commands.
@@ -416,6 +418,7 @@ A bottom level acceleration structure consisting of triangle geometries is defin
   # Bottom level acceleration structure consisting of triangles
   ACCELERATION_STRUCTURE BOTTOM_LEVEL {name_of_bottom_level_acceleration_structure}
     {GEOMETRY TRIANGLES
+      [FLAGS <geometry_flags>]
       {x0 y0 z0
        x1 y1 z1
        x2 y2 z2}+
@@ -429,12 +432,17 @@ A bottom level acceleration structure consisting of axis aligned bounding boxes 
   # Bottom level acceleration structure consisting of AABBs
   ACCELERATION_STRUCTURE BOTTOM_LEVEL {name_of_bottom_level_acceleration_structure}
     {GEOMETRY AABBS
+      [FLAGS <geometry_flags>]
       {x0 y0 z0 x1 y1 z1}+
     END}+
   END
 ```
 
 Each coordinate |x{n}|, |y{n}|, and |z{n}| should be floating point values.
+
+FLAGS is a space separated list of following geometry flags:
+ * OPAQUE
+ * NO_DUPLICATE_ANY_HIT
 
 #### Top Level
 
@@ -588,6 +596,58 @@ Generally a program needs three shader binding tables:
  * hit shader binding table containing one or more hit shader groups
 
 Shader binding tables for call shaders are optional.
+
+Ray tracing pipelines support pipeline libraries. To declare pipeline as pipeline library
+pipeline should declare library specifying LIBRARY in FLAGS:
+
+```groovy
+  # Declare this pipeline as a library
+  FLAGS LIBRARY
+```
+
+or multiline version:
+
+```groovy
+  # Declare this pipeline as a library
+  FLAGS
+    LIBRARY
+  END
+```
+
+Ray tracing pipeline can include one or more pipeline libraries:
+
+```groovy
+  # Specify list of libraries to use
+  USE_LIBRARY {library_name_1} [{library_name_2} [...]]
+```
+
+Ray tracing pipelines that declare and use pipeline libraries should declare
+maximum ray payload size and maximum ray hit attribute size:
+```groovy
+  # Define maximum ray payload size
+  MAX_RAY_PAYLOAD_SIZE <max_ray_payload_size>
+  # Define maximum ray hit attribute size
+  MAX_RAY_HIT_ATTRIBUTE_SIZE <max_ray_hit_attribute_size>
+```
+
+Default for both maximum ray payload size and maximum ray hit attribute size is zero.
+Specification requires that all pipeline libraries used within pipeline and pipeline using
+libraries itself have same value.
+
+List of used libraries must preceed shader group (SHADER_GROUP) or shader binding tables
+(SHADER_BINDING_TABLE) declarations. Pipeline can be a library and use other pipelines as a libraries.
+
+Ray tracing pipelines can declare maximum ray recursion depth:
+
+```groovy
+  # Define maximum ray recursion depth
+  MAX_RAY_RECURSION_DEPTH <max_ray_recursion_depth>
+```
+
+If the MAX_RAY_RECURSION_DEPTH is not specified, then maximum ray recursion depth is set to 1.
+
+If some pipeline library is used within this pipeline (via USE_LIBRARY keyword), then
+shader binding table can use shader groups from any of used libraries.
 
 #### Compare operations
  * `never`

--- a/docs/amber_script.md
+++ b/docs/amber_script.md
@@ -597,8 +597,8 @@ Generally a program needs three shader binding tables:
 
 Shader binding tables for call shaders are optional.
 
-Ray tracing pipelines support pipeline libraries. To declare pipeline as pipeline library
-pipeline should declare library specifying LIBRARY in FLAGS:
+Ray tracing pipelines support pipeline libraries. To declare a pipeline as a pipeline library
+the pipeline should declare itself a library by specifying `LIBRARY` in `FLAGS`:
 
 ```groovy
   # Declare this pipeline as a library
@@ -614,6 +614,10 @@ or multiline version:
   END
 ```
 
+Pipeline `FLAGS` can contain:
+
+ * `LIBRARY`
+
 Ray tracing pipeline can include one or more pipeline libraries:
 
 ```groovy
@@ -622,7 +626,7 @@ Ray tracing pipeline can include one or more pipeline libraries:
 ```
 
 Ray tracing pipelines that declare and use pipeline libraries should declare
-maximum ray payload size and maximum ray hit attribute size:
+the maximum ray payload size and the maximum ray hit attribute size:
 ```groovy
   # Define maximum ray payload size
   MAX_RAY_PAYLOAD_SIZE <max_ray_payload_size>
@@ -631,13 +635,13 @@ maximum ray payload size and maximum ray hit attribute size:
 ```
 
 Default for both maximum ray payload size and maximum ray hit attribute size is zero.
-Specification requires that all pipeline libraries used within pipeline and pipeline using
-libraries itself have same value.
+If there is a pipeline which uses a pipeline library then the `MAX_RAY_PAYLOAD_SIZE` and `MAX_RAY_HIT_ATTRIBUTE_SIZE`
+values must be the same between the pipeline and all the pipeline libraries used.
 
-List of used libraries must preceed shader group (SHADER_GROUP) or shader binding tables
-(SHADER_BINDING_TABLE) declarations. Pipeline can be a library and use other pipelines as a libraries.
+Used libraries must precede shader group `SHADER_GROUP` and shader binding tables
+`SHADER_BINDING_TABLE` declarations. A pipeline can be a library and use other pipelines as a libraries.
 
-Ray tracing pipelines can declare maximum ray recursion depth:
+Ray tracing pipelines can declare a maximum ray recursion depth:
 
 ```groovy
   # Define maximum ray recursion depth
@@ -646,8 +650,8 @@ Ray tracing pipelines can declare maximum ray recursion depth:
 
 If the MAX_RAY_RECURSION_DEPTH is not specified, then maximum ray recursion depth is set to 1.
 
-If some pipeline library is used within this pipeline (via USE_LIBRARY keyword), then
-shader binding table can use shader groups from any of used libraries.
+If a pipeline library is used within this pipeline (via `USE_LIBRARY` keyword), then the
+shader binding table can use shader groups from any of the used libraries.
 
 #### Compare operations
  * `never`

--- a/include/amber/shader_info.h
+++ b/include/amber/shader_info.h
@@ -48,6 +48,13 @@ enum ShaderType {
   kShaderTypeMulti,
 };
 
+inline bool isRayTracingShaderType(ShaderType type)
+{
+  return type == kShaderTypeRayGeneration || type == kShaderTypeAnyHit ||
+         type == kShaderTypeClosestHit || type == kShaderTypeMiss ||
+         type == kShaderTypeIntersection || type == kShaderTypeCall;
+}
+
 /// Stores information for a shader.
 struct ShaderInfo {
   /// The format of the shader.

--- a/include/amber/shader_info.h
+++ b/include/amber/shader_info.h
@@ -48,8 +48,7 @@ enum ShaderType {
   kShaderTypeMulti,
 };
 
-inline bool isRayTracingShaderType(ShaderType type)
-{
+inline bool isRayTracingShaderType(ShaderType type) {
   return type == kShaderTypeRayGeneration || type == kShaderTypeAnyHit ||
          type == kShaderTypeClosestHit || type == kShaderTypeMiss ||
          type == kShaderTypeIntersection || type == kShaderTypeCall;

--- a/src/acceleration_structure.h
+++ b/src/acceleration_structure.h
@@ -195,6 +195,23 @@ class ShaderGroup {
     return closestHitShader_ != nullptr || anyHitShader_ != nullptr ||
            intersectionShader_ != nullptr;
   }
+  Shader* GetShaderByType(ShaderType type) const {
+    switch (type) {
+      case kShaderTypeRayGeneration:
+      case kShaderTypeMiss:
+      case kShaderTypeCall:
+        return generalShader_;
+      case kShaderTypeAnyHit:
+        return anyHitShader_;
+      case kShaderTypeClosestHit:
+        return closestHitShader_;
+      case kShaderTypeIntersection:
+        return intersectionShader_;
+      default:
+        assert(0 && "Unsupported shader type");
+        return nullptr;
+    }
+  }
 
  private:
   std::string name_;
@@ -209,21 +226,21 @@ class SBTRecord {
   SBTRecord();
   ~SBTRecord();
 
-  void SetUsedShaderGroupName(const std::string& shader_group_name,
-                              uint32_t pipeline_index) {
+  void SetUsedShaderGroupName(const std::string& shader_group_name) {
     used_shader_group_name_ = shader_group_name;
-    pipeline_index_ = pipeline_index;
   }
   std::string GetUsedShaderGroupName() const { return used_shader_group_name_; }
-  uint32_t GetUsedShaderGroupPipelineIndex() const { return pipeline_index_; }
 
   void SetCount(const uint32_t count) { count_ = count; }
   uint32_t GetCount() const { return count_; }
 
+  void SetIndex(const uint32_t index) { index_ = index; }
+  uint32_t GetIndex() const { return index_; }
+
  private:
   std::string used_shader_group_name_;
   uint32_t count_ = 1;
-  uint32_t pipeline_index_ = static_cast<uint32_t>(-1);
+  uint32_t index_ = static_cast<uint32_t>(-1);
 };
 
 class SBT {

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -4365,7 +4365,8 @@ Result Parser::ParseSBT(Pipeline* pipeline) {
     ShaderGroup* shader_group = script_->FindShaderGroup(pipeline, tok, &index);
 
     if (shader_group == nullptr)
-      return Result("Shader group not found neither in pipeline, nor in libraries");
+      return Result(
+          "Shader group not found neither in pipeline, nor in libraries");
 
     std::unique_ptr<SBTRecord> sbtrecord = MakeUnique<SBTRecord>();
 

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -4479,11 +4479,11 @@ Result Parser::ParseFlags(Pipeline* pipeline) {
     if (token->IsEOS())
       return Result("END command missing");
 
-    if (token->IsInteger())
+    if (token->IsInteger()) {
       flags |= token->AsInt32();
-    else if (token->IsHex())
+    } else if (token->IsHex()) {
       flags |= uint32_t(token->AsHex());
-    else if (token->IsIdentifier()) {
+    } else if (token->IsIdentifier()) {
       if (token->AsString() == "END")
         break;
       else if (token->AsString() == "LIBRARY")

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -698,7 +698,7 @@ Result Parser::ParsePipelineBody(const std::string& cmd_name,
       for (const auto& record : sbt->GetSBTRecords()) {
         const std::string group_name = record->GetUsedShaderGroupName();
         const uint32_t group_index = pipeline->GetShaderGroupIndex(group_name);
-        assert(group_index != -1);
+        assert(group_index != static_cast<uint32_t>(-1));
         record->SetIndex(group_index);
       }
     }
@@ -4404,7 +4404,7 @@ Result Parser::ParseSBT(Pipeline* pipeline) {
 
     sbtrecord->SetUsedShaderGroupName(tok);
     sbtrecord->SetCount(1);
-    sbtrecord->SetIndex(-1);
+    sbtrecord->SetIndex(static_cast<uint32_t>(-1));
 
     sbt->AddSBTRecord(std::move(sbtrecord));
   }
@@ -4421,7 +4421,7 @@ Result Parser::ParseMaxRayPayloadSize(Pipeline* pipeline) {
   if (!token->IsInteger())
     return Result("Ray payload size expects an integer");
 
-  pipeline->SetMaxPipelineRayPayloadSize(token->AsInt32());
+  pipeline->SetMaxPipelineRayPayloadSize(token->AsUint32());
 
   return {};
 }
@@ -4435,7 +4435,7 @@ Result Parser::ParseMaxRayHitAttributeSize(Pipeline* pipeline) {
   if (!token->IsInteger())
     return Result("Ray hit attribute size expects an integer");
 
-  pipeline->SetMaxPipelineRayHitAttributeSize(token->AsInt32());
+  pipeline->SetMaxPipelineRayHitAttributeSize(token->AsUint32());
 
   return {};
 }
@@ -4449,7 +4449,7 @@ Result Parser::ParseMaxRayRecursionDepth(Pipeline* pipeline) {
   if (!token->IsInteger())
     return Result("Ray recursion depth expects an integer");
 
-  pipeline->SetMaxPipelineRayRecursionDepth(token->AsInt32());
+  pipeline->SetMaxPipelineRayRecursionDepth(token->AsUint32());
 
   return {};
 }
@@ -4480,7 +4480,7 @@ Result Parser::ParseFlags(Pipeline* pipeline) {
       return Result("END command missing");
 
     if (token->IsInteger()) {
-      flags |= token->AsInt32();
+      flags |= token->AsUint32();
     } else if (token->IsHex()) {
       flags |= uint32_t(token->AsHex());
     } else if (token->IsIdentifier()) {

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -4509,11 +4509,11 @@ Result Parser::ParseUseLibrary(Pipeline* pipeline) {
     return Result("Use library is allowed only for ray tracing pipeline");
 
   if (!pipeline->GetShaderGroups().empty())
-    return Result("USE_LIBRARY should preceed any SHADER_GROUP declarations");
+    return Result("USE_LIBRARY should precede any SHADER_GROUP declarations");
 
   if (!pipeline->GetSBTs().empty())
     return Result(
-        "USE_LIBRARY should preceed any SHADER_BINDING_TABLE declarations");
+        "USE_LIBRARY should precede any SHADER_BINDING_TABLE declarations");
 
   while (true) {
     auto token = tokenizer_->NextToken();

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -2086,7 +2086,7 @@ Result Parser::ParsePipelineShaderGroup(Pipeline* pipeline) {
       add_shader_to_pipeline = false;
     }
 
-    if (add_shader_to_pipeline){
+    if (add_shader_to_pipeline) {
       Result r = pipeline->AddShader(shader, shader->GetType());
       if (!r.IsSuccess())
         return r;
@@ -4129,7 +4129,7 @@ Result Parser::ParseBLASAABB(BLAS* blas) {
     } else if (token->IsDouble()) {
       g.push_back(token->AsFloat());
     } else if (token->IsInteger()) {
-      g.push_back(float(token->AsInt64()));
+      g.push_back(static_cast<float>(token->AsInt64()));
     } else {
       return Result("Unexpected data type");
     }
@@ -4490,8 +4490,9 @@ Result Parser::ParseFlags(Pipeline* pipeline) {
         flags |= VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
       else
         return Result("Unknown flag: " + token->AsString());
-    } else
+    } else {
       r = Result("Identifier expected");
+    }
 
     if (!r.IsSuccess())
       return r;
@@ -4530,8 +4531,9 @@ Result Parser::ParseUseLibrary(Pipeline* pipeline) {
         return Result("Pipeline not found: " + tok);
 
       pipeline->AddPipelineLibrary(use_pipeline);
-    } else
+    } else {
       return Result("Unexpected data type");
+    }
   }
 
   return {};

--- a/src/amberscript/parser.h
+++ b/src/amberscript/parser.h
@@ -107,6 +107,11 @@ class Parser : public amber::Parser {
   Result ParseBLASInstanceTransform(BLASInstance* instance);
   Result ParseBLASInstanceFlags(BLASInstance* instance);
   Result ParseSBT(Pipeline* pipeline);
+  Result ParseMaxRayPayloadSize(Pipeline* pipeline);
+  Result ParseMaxRayHitAttributeSize(Pipeline* pipeline);
+  Result ParseMaxRayRecursionDepth(Pipeline* pipeline);
+  Result ParseFlags(Pipeline* pipeline);
+  Result ParseUseLibrary(Pipeline* pipeline);
   Result ParseTolerances(std::vector<Probe::Tolerance>* tolerances);
 
   /// Parses a set of values out of the token stream. |name| is the name of the

--- a/src/amberscript/parser_raytracing_test.cc
+++ b/src/amberscript/parser_raytracing_test.cc
@@ -765,8 +765,7 @@ END
 
   Parser parser;
   Result r = parser.Parse(in);
-  ASSERT_FALSE(r.IsSuccess());
-  EXPECT_EQ("4: No shaders in shader group defined", r.Error());
+  ASSERT_TRUE(r.IsSuccess());
 }
 
 TEST_F(AmberScriptParserTest, RayTracingPipelineBindShaderGroupNoShaderName) {

--- a/src/amberscript/parser_raytracing_test.cc
+++ b/src/amberscript/parser_raytracing_test.cc
@@ -1293,5 +1293,281 @@ RUN my_rtpipeline CALL sbt1 CALL sbt1
   EXPECT_EQ("14: CALL shader binding table can specified only once", r.Error());
 }
 
+TEST_F(AmberScriptParserTest, RayTracingPipelineMaxRaypayloadSize) {
+  {
+    std::string in = R"(
+PIPELINE compute my_pipeline
+  MAX_RAY_PAYLOAD_SIZE 16
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ(
+        "3: Ray payload size parameter is allowed only for ray tracing "
+        "pipeline",
+        r.Error());
+  }
+  {
+    std::string in = R"(
+PIPELINE graphics my_pipeline
+  MAX_RAY_PAYLOAD_SIZE 16
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ(
+        "3: Ray payload size parameter is allowed only for ray tracing "
+        "pipeline",
+        r.Error());
+  }
+  {
+    std::string in = R"(
+PIPELINE raytracing my_pipeline
+  MAX_RAY_PAYLOAD_SIZE a
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("3: Ray payload size expects an integer", r.Error());
+  }
+}
+
+TEST_F(AmberScriptParserTest, RayTracingPipelineMaxRayHitAttributeSize) {
+  {
+    std::string in = R"(
+PIPELINE compute my_pipeline
+  MAX_RAY_HIT_ATTRIBUTE_SIZE 16
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ(
+        "3: Ray hit attribute size is allowed only for ray tracing pipeline",
+        r.Error());
+  }
+  {
+    std::string in = R"(
+PIPELINE graphics my_pipeline
+  MAX_RAY_HIT_ATTRIBUTE_SIZE 16
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ(
+        "3: Ray hit attribute size is allowed only for ray tracing pipeline",
+        r.Error());
+  }
+  {
+    std::string in = R"(
+PIPELINE raytracing my_pipeline
+  MAX_RAY_HIT_ATTRIBUTE_SIZE a
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("3: Ray hit attribute size expects an integer", r.Error());
+  }
+}
+
+TEST_F(AmberScriptParserTest, RayTracingPipelineMaxRecursionDepthSize) {
+  {
+    std::string in = R"(
+PIPELINE compute my_pipeline
+  MAX_RAY_RECURSION_DEPTH 1
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("3: Ray recursion depth is allowed only for ray tracing pipeline",
+              r.Error());
+  }
+  {
+    std::string in = R"(
+PIPELINE graphics my_pipeline
+  MAX_RAY_RECURSION_DEPTH 1
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("3: Ray recursion depth is allowed only for ray tracing pipeline",
+              r.Error());
+  }
+  {
+    std::string in = R"(
+PIPELINE raytracing my_pipeline
+  MAX_RAY_RECURSION_DEPTH a
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("3: Ray recursion depth expects an integer", r.Error());
+  }
+}
+
+TEST_F(AmberScriptParserTest, RayTracingPipelineFlags) {
+  {
+    std::string in = R"(
+PIPELINE compute my_pipeline
+  FLAGS LIBRARY
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("3: Flags are allowed only for ray tracing pipeline", r.Error());
+  }
+  {
+    std::string in = R"(
+PIPELINE graphics my_pipeline
+  FLAGS LIBRARY
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("3: Flags are allowed only for ray tracing pipeline", r.Error());
+  }
+  {
+    std::string in = R"(
+PIPELINE raytracing my_pipeline
+  FLAGS
+    LIBRARY
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("5: END command missing", r.Error());
+  }
+  {
+    std::string in = R"(
+PIPELINE raytracing my_pipeline
+  FLAGS UNKNOWN_FLAG
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("3: Unknown flag: UNKNOWN_FLAG", r.Error());
+  }
+  {
+    std::string in = R"(
+PIPELINE raytracing my_pipeline
+  FLAGS 1.0
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("3: Identifier expected", r.Error());
+  }
+}
+
+TEST_F(AmberScriptParserTest, RayTracingPipelineUseLibrary) {
+  {
+    std::string in = R"(
+PIPELINE raytracing base_pipeline_lib
+  FLAGS LIBRARY
+END
+
+PIPELINE compute my_pipeline
+  USE_LIBRARY base_pipeline_lib
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("7: Use library is allowed only for ray tracing pipeline",
+              r.Error());
+  }
+  {
+    std::string in = R"(
+PIPELINE raytracing base_pipeline_lib
+  FLAGS LIBRARY
+END
+
+PIPELINE graphics my_pipeline
+  USE_LIBRARY base_pipeline_lib
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("7: Use library is allowed only for ray tracing pipeline",
+              r.Error());
+  }
+  {
+    std::string in = R"(
+PIPELINE raytracing my_pipeline
+  USE_LIBRARY base_pipeline_lib
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("3: Pipeline not found: base_pipeline_lib", r.Error());
+  }
+  {
+    std::string in = R"(
+PIPELINE raytracing my_pipeline
+  SHADER_GROUP g1
+  USE_LIBRARY base_pipeline_lib
+END
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("4: USE_LIBRARY should preceed any SHADER_GROUP declarations",
+              r.Error());
+  }
+  {
+    std::string in = R"(
+PIPELINE raytracing my_pipeline
+  SHADER_BINDING_TABLE sbt1
+  END
+  USE_LIBRARY base_pipeline_lib
+END
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ(
+        "5: USE_LIBRARY should preceed any SHADER_BINDING_TABLE declarations",
+        r.Error());
+  }
+  {
+    std::string in = R"(
+PIPELINE raytracing my_pipeline
+  USE_LIBRARY)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("3: EOL expected", r.Error());
+  }
+  {
+    std::string in = R"(
+PIPELINE raytracing my_pipeline
+  USE_LIBRARY 1
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("3: Unexpected data type", r.Error());
+  }
+}
+
 }  // namespace amberscript
 }  // namespace amber

--- a/src/amberscript/parser_raytracing_test.cc
+++ b/src/amberscript/parser_raytracing_test.cc
@@ -1526,7 +1526,7 @@ END
     Parser parser;
     Result r = parser.Parse(in);
     ASSERT_FALSE(r.IsSuccess());
-    EXPECT_EQ("4: USE_LIBRARY should preceed any SHADER_GROUP declarations",
+    EXPECT_EQ("4: USE_LIBRARY should precede any SHADER_GROUP declarations",
               r.Error());
   }
   {
@@ -1542,7 +1542,7 @@ END
     Result r = parser.Parse(in);
     ASSERT_FALSE(r.IsSuccess());
     EXPECT_EQ(
-        "5: USE_LIBRARY should preceed any SHADER_BINDING_TABLE declarations",
+        "5: USE_LIBRARY should precede any SHADER_BINDING_TABLE declarations",
         r.Error());
   }
   {

--- a/src/amberscript/parser_raytracing_test.cc
+++ b/src/amberscript/parser_raytracing_test.cc
@@ -1518,36 +1518,6 @@ PIPELINE raytracing my_pipeline
   {
     std::string in = R"(
 PIPELINE raytracing my_pipeline
-  SHADER_GROUP g1
-  USE_LIBRARY base_pipeline_lib
-END
-)";
-
-    Parser parser;
-    Result r = parser.Parse(in);
-    ASSERT_FALSE(r.IsSuccess());
-    EXPECT_EQ("4: USE_LIBRARY should precede any SHADER_GROUP declarations",
-              r.Error());
-  }
-  {
-    std::string in = R"(
-PIPELINE raytracing my_pipeline
-  SHADER_BINDING_TABLE sbt1
-  END
-  USE_LIBRARY base_pipeline_lib
-END
-)";
-
-    Parser parser;
-    Result r = parser.Parse(in);
-    ASSERT_FALSE(r.IsSuccess());
-    EXPECT_EQ(
-        "5: USE_LIBRARY should precede any SHADER_BINDING_TABLE declarations",
-        r.Error());
-  }
-  {
-    std::string in = R"(
-PIPELINE raytracing my_pipeline
   USE_LIBRARY)";
 
     Parser parser;

--- a/src/command.h
+++ b/src/command.h
@@ -750,8 +750,8 @@ class RayTracingCommand : public PipelineCommand {
   void SetZ(uint32_t z) { z_ = z; }
   uint32_t GetZ() const { return z_; }
 
-  void SetRayGenSBTName(const std::string& name) { rgen_sbt_name_ = name; }
-  std::string GetRayGenSBTName() const { return rgen_sbt_name_; }
+  void SetRGenSBTName(const std::string& name) { rgen_sbt_name_ = name; }
+  std::string GetRGenSBTName() const { return rgen_sbt_name_; }
 
   void SetMissSBTName(const std::string& name) { miss_sbt_name_ = name; }
   std::string GetMissSBTName() const { return miss_sbt_name_; }

--- a/src/command.h
+++ b/src/command.h
@@ -751,7 +751,7 @@ class RayTracingCommand : public PipelineCommand {
   uint32_t GetZ() const { return z_; }
 
   void SetRGenSBTName(const std::string& name) { rgen_sbt_name_ = name; }
-  std::string GetRGenSBTName() const { return rgen_sbt_name_; }
+  std::string GetRayGenSBTName() const { return rgen_sbt_name_; }
 
   void SetMissSBTName(const std::string& name) { miss_sbt_name_ = name; }
   std::string GetMissSBTName() const { return miss_sbt_name_; }

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -508,13 +508,15 @@ class Pipeline {
   /// Remembers number of shader belonging to this pipeline without
   /// libraries addition.
   void SetNonLibShadersCount() {
-    assert(non_lib_shader_count_ == -1);  // Should be set only once
+    assert(non_lib_shader_count_ ==
+           static_cast<size_t>(-1));  // Should be set only once
     non_lib_shader_count_ = shaders_.size();
   }
   /// Returns number of shaders belonging to this pipeline without
   /// libraries addition.
   size_t GetNonLibShadersCount() {
-    assert(non_lib_shader_count_ != -1);  // Should be set before usage
+    assert(non_lib_shader_count_ !=
+           static_cast<size_t>(-1));  // Should be set before usage
     return non_lib_shader_count_;
   }
 

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -496,8 +496,7 @@ class Pipeline {
   /// Returns number of shader groups belonging to this pipeline without
   /// libraries addition.
   size_t GetNonLibShaderGroupCount() {
-    assert(non_lib_shader_groups_count_ ==
-           static_cast<size_t>(-1));  // Should be set only once
+    assert(non_lib_shader_groups_count_ != static_cast<size_t>(-1));
     return non_lib_shader_groups_count_;
   }
   /// Retrieves a list of all Shader Groups. Might include library additions
@@ -515,8 +514,7 @@ class Pipeline {
   /// Returns number of shaders belonging to this pipeline without
   /// libraries addition.
   size_t GetNonLibShadersCount() {
-    assert(non_lib_shader_count_ !=
-           static_cast<size_t>(-1));  // Should be set before usage
+    assert(non_lib_shader_count_ != static_cast<size_t>(-1));
     return non_lib_shader_count_;
   }
 

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -489,13 +489,15 @@ class Pipeline {
   /// Remembers number of shader groups belonging to this pipeline without
   /// libraries addition.
   void SetNonLibShaderGroupCount() {
-    assert(non_lib_shader_groups_count_ == -1); // Should be set only once
+    assert(non_lib_shader_groups_count_ ==
+           static_cast<size_t>(-1));  // Should be set only once
     non_lib_shader_groups_count_ = shader_groups_.size();
   }
   /// Returns number of shader groups belonging to this pipeline without
   /// libraries addition.
   size_t GetNonLibShaderGroupCount() {
-    assert(non_lib_shader_groups_count_ != -1);  // Should be set before usage
+    assert(non_lib_shader_groups_count_ ==
+           static_cast<size_t>(-1));  // Should be set only once
     return non_lib_shader_groups_count_;
   }
   /// Retrieves a list of all Shader Groups. Might include library additions
@@ -630,8 +632,8 @@ class Pipeline {
   std::unique_ptr<Buffer> opencl_push_constants_;
 
   std::map<std::string, ShaderGroup*> name_to_shader_group_;
-  size_t non_lib_shader_groups_count_ = -1;
-  size_t non_lib_shader_count_ = -1;
+  size_t non_lib_shader_groups_count_ = static_cast <size_t>(-1);
+  size_t non_lib_shader_count_ = static_cast<size_t>(-1);
   std::vector<std::shared_ptr<ShaderGroup>> shader_groups_;
   std::map<std::string, SBT*> name_to_sbt_;
   std::vector<std::unique_ptr<SBT>> sbts_;

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -279,10 +279,8 @@ class Pipeline {
   /// Designed to support libraries
   Result AddShaders(const std::vector<ShaderInfo>& lib_shaders) {
     shaders_.reserve(shaders_.size() + lib_shaders.size());
-
-    for (auto lib_shader : lib_shaders) {
-      shaders_.push_back(std::move(lib_shader));
-    }
+    shaders_.insert(std::end(shaders_), std::begin(lib_shaders),
+                    std::end(lib_shaders));
 
     return {};
   }

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -454,22 +454,14 @@ class Pipeline {
     return {};
   }
 
-  /// Adds |lib_groups| to the list of known to pipeline shader groups.
-  /// Designed to support pipeline libraries.
-  Result AddShaderGroups(
-      const std::vector<std::shared_ptr<ShaderGroup>>& lib_groups) {
-    shader_groups_.reserve(shader_groups_.size() + lib_groups.size());
-
-    for (auto lib_group : lib_groups)
-      AddShaderGroup(lib_group);
-
-    return {};
-  }
-
   /// Retrieves the Shader Group with |name|, |nullptr| if not found.
   ShaderGroup* GetShaderGroup(const std::string& name) const {
     auto it = name_to_shader_group_.find(name);
     return it == name_to_shader_group_.end() ? nullptr : it->second;
+  }
+  /// Retrieves a Shader Group at given |index|.
+  ShaderGroup* GetShaderGroupByIndex(uint32_t index) const {
+    return shader_groups_[index].get();
   }
   /// Retreives index of shader group specified by |name|
   uint32_t GetShaderGroupIndex(const std::string& name) const {
@@ -480,40 +472,12 @@ class Pipeline {
         return static_cast<uint32_t>(i);
       }
     }
-    assert(0 && "GetShaderGroupIndex called too early");
 
     return static_cast<uint32_t>(-1);
   }
-  /// Remembers number of shader groups belonging to this pipeline without
-  /// libraries addition.
-  void SetNonLibShaderGroupCount() {
-    assert(non_lib_shader_groups_count_ ==
-           static_cast<size_t>(-1));  // Should be set only once
-    non_lib_shader_groups_count_ = shader_groups_.size();
-  }
-  /// Returns number of shader groups belonging to this pipeline without
-  /// libraries addition.
-  size_t GetNonLibShaderGroupCount() {
-    assert(non_lib_shader_groups_count_ != static_cast<size_t>(-1));
-    return non_lib_shader_groups_count_;
-  }
-  /// Retrieves a list of all Shader Groups. Might include library additions
+  /// Retrieves a list of all Shader Groups.
   const std::vector<std::shared_ptr<ShaderGroup>>& GetShaderGroups() const {
     return shader_groups_;
-  }
-
-  /// Remembers number of shader belonging to this pipeline without
-  /// libraries addition.
-  void SetNonLibShadersCount() {
-    assert(non_lib_shader_count_ ==
-           static_cast<size_t>(-1));  // Should be set only once
-    non_lib_shader_count_ = shaders_.size();
-  }
-  /// Returns number of shaders belonging to this pipeline without
-  /// libraries addition.
-  size_t GetNonLibShadersCount() {
-    assert(non_lib_shader_count_ != static_cast<size_t>(-1));
-    return non_lib_shader_count_;
   }
 
   /// Updates the descriptor set and binding info for the OpenCL-C kernel bound
@@ -630,8 +594,6 @@ class Pipeline {
   std::unique_ptr<Buffer> opencl_push_constants_;
 
   std::map<std::string, ShaderGroup*> name_to_shader_group_;
-  size_t non_lib_shader_groups_count_ = static_cast <size_t>(-1);
-  size_t non_lib_shader_count_ = static_cast<size_t>(-1);
   std::vector<std::shared_ptr<ShaderGroup>> shader_groups_;
   std::map<std::string, SBT*> name_to_sbt_;
   std::vector<std::unique_ptr<SBT>> sbts_;

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -837,7 +837,7 @@ Result EngineVulkan::DoTraceRays(const RayTracingCommand* command) {
   std::vector<VkPipeline> libs;
 
   if (!pipeline->GetPipelineLibraries().empty()) {
-    Result r = InitDependendLibraries(pipeline, libs);
+    Result r = InitDependendLibraries(pipeline, &libs);
     if (!r.IsSuccess())
       return r;
   }

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -795,7 +795,7 @@ Result EngineVulkan::DoCompute(const ComputeCommand* command) {
 }
 
 Result EngineVulkan::InitDependendLibraries(amber::Pipeline* pipeline,
-                                            std::vector<VkPipeline>& libs) {
+                                            std::vector<VkPipeline>* libs) {
   for (auto& p : pipeline->GetPipelineLibraries()) {
     for (auto& s : pipeline_map_) {
       amber::Pipeline* sub_pipeline = s.first;
@@ -805,7 +805,7 @@ Result EngineVulkan::InitDependendLibraries(amber::Pipeline* pipeline,
         std::vector<VkPipeline> sub_libs;
 
         if (!sub_pipeline->GetPipelineLibraries().empty()) {
-          Result r = InitDependendLibraries(sub_pipeline, sub_libs);
+          Result r = InitDependendLibraries(sub_pipeline, &sub_libs);
 
           if (!r.IsSuccess())
             return r;
@@ -818,7 +818,7 @@ Result EngineVulkan::InitDependendLibraries(amber::Pipeline* pipeline,
               sub_pipeline->GetMaxPipelineRayRecursionDepth());
         }
 
-        libs.push_back(vk_sub_pipeline->GetVkPipeline());
+        libs->push_back(vk_sub_pipeline->GetVkPipeline());
 
         break;
       }

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -163,11 +163,8 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
   // Create the pipeline data early so we can access them as needed.
   pipeline_map_[pipeline] = PipelineInfo();
   auto& info = pipeline_map_[pipeline];
-  const size_t shader_count = pipeline->IsRayTracing()
-                                  ? pipeline->GetNonLibShadersCount()
-                                  : pipeline->GetShaders().size();
 
-  for (size_t i = 0; i < shader_count; i++) {
+  for (size_t i = 0; i < pipeline->GetShaders().size(); i++) {
     Result r = SetShader(pipeline, pipeline->GetShaders()[i], i);
     if (!r.IsSuccess())
       return r;
@@ -524,8 +521,8 @@ Result EngineVulkan::GetVkShaderStageInfo(
 Result EngineVulkan::GetVkShaderGroupInfo(
     amber::Pipeline* pipeline,
     std::vector<VkRayTracingShaderGroupCreateInfoKHR>* out) {
-  const size_t shader_group_count = pipeline->GetNonLibShaderGroupCount();
   auto& groups = pipeline->GetShaderGroups();
+  const size_t shader_group_count = groups.size();
 
   out->clear();
   out->reserve(shader_group_count);
@@ -842,7 +839,7 @@ Result EngineVulkan::DoTraceRays(const RayTracingCommand* command) {
       return r;
   }
 
-  amber::SBT* rSBT = pipeline->GetSBT(command->GetRGenSBTName());
+  amber::SBT* rSBT = pipeline->GetSBT(command->GetRayGenSBTName());
   amber::SBT* mSBT = pipeline->GetSBT(command->GetMissSBTName());
   amber::SBT* hSBT = pipeline->GetSBT(command->GetHitsSBTName());
   amber::SBT* cSBT = pipeline->GetSBT(command->GetCallSBTName());

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -163,8 +163,11 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
   // Create the pipeline data early so we can access them as needed.
   pipeline_map_[pipeline] = PipelineInfo();
   auto& info = pipeline_map_[pipeline];
+  const size_t shader_count = pipeline->IsRayTracing()
+                                  ? pipeline->GetNonLibShadersCount()
+                                  : pipeline->GetShaders().size();
 
-  for (size_t i = 0; i < pipeline->GetShaders().size(); i++) {
+  for (size_t i = 0; i < shader_count; i++) {
     Result r = SetShader(pipeline, pipeline->GetShaders()[i], i);
     if (!r.IsSuccess())
       return r;
@@ -202,7 +205,8 @@ Result EngineVulkan::CreatePipeline(amber::Pipeline* pipeline) {
 
     vk_pipeline = MakeUnique<RayTracingPipeline>(
         device_.get(), &blases_, &tlases_, engine_data.fence_timeout_ms,
-        engine_data.pipeline_runtime_layer_enabled, stage_create_info);
+        engine_data.pipeline_runtime_layer_enabled, stage_create_info,
+        pipeline->GetCreateFlags());
     r = vk_pipeline->AsRayTracingPipeline()->Initialize(
         pool_.get(), shader_group_create_info);
   } else if (pipeline->GetType() == PipelineType::kCompute) {
@@ -520,13 +524,15 @@ Result EngineVulkan::GetVkShaderStageInfo(
 Result EngineVulkan::GetVkShaderGroupInfo(
     amber::Pipeline* pipeline,
     std::vector<VkRayTracingShaderGroupCreateInfoKHR>* out) {
-  auto shaders = pipeline->GetShaders();
+  const size_t shader_group_count = pipeline->GetNonLibShaderGroupCount();
+  auto& groups = pipeline->GetShaderGroups();
 
   out->clear();
-  out->reserve(pipeline->GetShaderGroups().size());
+  out->reserve(shader_group_count);
 
-  for (auto& g : pipeline->GetShaderGroups()) {
+  for (size_t i = 0; i < shader_group_count; ++i) {
     Result r;
+    auto& g = groups[i];
     ShaderGroup* sg = g.get();
 
     if (sg == nullptr)
@@ -788,21 +794,64 @@ Result EngineVulkan::DoCompute(const ComputeCommand* command) {
       command->GetX(), command->GetY(), command->GetZ());
 }
 
+Result EngineVulkan::InitDependendLibraries(amber::Pipeline* pipeline,
+                                            std::vector<VkPipeline>& libs) {
+  for (auto& p : pipeline->GetPipelineLibraries()) {
+    for (auto& s : pipeline_map_) {
+      amber::Pipeline* sub_pipeline = s.first;
+      Pipeline* vk_sub_pipeline = pipeline_map_[sub_pipeline].vk_pipeline.get();
+
+      if (sub_pipeline == p) {
+        std::vector<VkPipeline> sub_libs;
+
+        if (!sub_pipeline->GetPipelineLibraries().empty()) {
+          Result r = InitDependendLibraries(sub_pipeline, sub_libs);
+
+          if (!r.IsSuccess())
+            return r;
+        }
+
+        if (vk_sub_pipeline->GetVkPipeline() == VK_NULL_HANDLE) {
+          vk_sub_pipeline->AsRayTracingPipeline()->InitLibrary(
+              sub_libs, sub_pipeline->GetMaxPipelineRayPayloadSize(),
+              sub_pipeline->GetMaxPipelineRayHitAttributeSize(),
+              sub_pipeline->GetMaxPipelineRayRecursionDepth());
+        }
+
+        libs.push_back(vk_sub_pipeline->GetVkPipeline());
+
+        break;
+      }
+    }
+  }
+
+  return {};
+}
+
 Result EngineVulkan::DoTraceRays(const RayTracingCommand* command) {
   auto& info = pipeline_map_[command->GetPipeline()];
   if (!info.vk_pipeline->IsRayTracing())
     return Result("Vulkan: RayTracing called for non-RayTracing pipeline.");
 
   amber::Pipeline* pipeline = command->GetPipeline();
+  std::vector<VkPipeline> libs;
 
-  amber::SBT* rSBT = pipeline->GetSBT(command->GetRayGenSBTName());
+  if (!pipeline->GetPipelineLibraries().empty()) {
+    Result r = InitDependendLibraries(pipeline, libs);
+    if (!r.IsSuccess())
+      return r;
+  }
+
+  amber::SBT* rSBT = pipeline->GetSBT(command->GetRGenSBTName());
   amber::SBT* mSBT = pipeline->GetSBT(command->GetMissSBTName());
   amber::SBT* hSBT = pipeline->GetSBT(command->GetHitsSBTName());
   amber::SBT* cSBT = pipeline->GetSBT(command->GetCallSBTName());
 
   return info.vk_pipeline->AsRayTracingPipeline()->TraceRays(
-      rSBT, mSBT, hSBT, cSBT, command->GetX(), command->GetY(),
-      command->GetZ());
+      rSBT, mSBT, hSBT, cSBT, command->GetX(), command->GetY(), command->GetZ(),
+      pipeline->GetMaxPipelineRayPayloadSize(),
+      pipeline->GetMaxPipelineRayHitAttributeSize(),
+      pipeline->GetMaxPipelineRayRecursionDepth(), libs);
 }
 
 Result EngineVulkan::DoEntryPoint(const EntryPointCommand* command) {

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -105,7 +105,7 @@ class EngineVulkan : public Engine {
       std::vector<VkRayTracingShaderGroupCreateInfoKHR>* out);
 
   Result InitDependendLibraries(amber::Pipeline* pipeline,
-                                std::vector<VkPipeline>& libs);
+                                std::vector<VkPipeline>* libs);
 
   std::unique_ptr<Device> device_;
   std::unique_ptr<CommandPool> pool_;

--- a/src/vulkan/engine_vulkan.h
+++ b/src/vulkan/engine_vulkan.h
@@ -104,6 +104,9 @@ class EngineVulkan : public Engine {
       amber::Pipeline* pipeline,
       std::vector<VkRayTracingShaderGroupCreateInfoKHR>* out);
 
+  Result InitDependendLibraries(amber::Pipeline* pipeline,
+                                std::vector<VkPipeline>& libs);
+
   std::unique_ptr<Device> device_;
   std::unique_ptr<CommandPool> pool_;
 

--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -44,12 +44,14 @@ Pipeline::Pipeline(
     Device* device,
     uint32_t fence_timeout_ms,
     bool pipeline_runtime_layer_enabled,
-    const std::vector<VkPipelineShaderStageCreateInfo>& shader_stage_info)
+    const std::vector<VkPipelineShaderStageCreateInfo>& shader_stage_info,
+    VkPipelineCreateFlags create_flags)
     : device_(device),
       pipeline_type_(type),
       shader_stage_info_(shader_stage_info),
       fence_timeout_ms_(fence_timeout_ms),
-      pipeline_runtime_layer_enabled_(pipeline_runtime_layer_enabled) {}
+      pipeline_runtime_layer_enabled_(pipeline_runtime_layer_enabled),
+      create_flags_(create_flags) {}
 
 Pipeline::~Pipeline() {
   // Command must be reset before we destroy descriptors or we get a validation
@@ -69,6 +71,18 @@ Pipeline::~Pipeline() {
       device_->GetPtrs()->vkDestroyDescriptorPool(device_->GetVkDevice(),
                                                   info.pool, nullptr);
     }
+  }
+
+  if (pipeline_layout_ != VK_NULL_HANDLE) {
+    device_->GetPtrs()->vkDestroyPipelineLayout(device_->GetVkDevice(),
+                                                pipeline_layout_, nullptr);
+    pipeline_layout_ = VK_NULL_HANDLE;
+  }
+
+  if (pipeline_ != VK_NULL_HANDLE) {
+    device_->GetPtrs()->vkDestroyPipeline(device_->GetVkDevice(), pipeline_,
+                                          nullptr);
+    pipeline_ = VK_NULL_HANDLE;
   }
 }
 

--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -50,8 +50,8 @@ Pipeline::Pipeline(
       pipeline_type_(type),
       shader_stage_info_(shader_stage_info),
       fence_timeout_ms_(fence_timeout_ms),
-      pipeline_runtime_layer_enabled_(pipeline_runtime_layer_enabled),
-      create_flags_(create_flags) {}
+      create_flags_(create_flags),
+      pipeline_runtime_layer_enabled_(pipeline_runtime_layer_enabled) {}
 
 Pipeline::~Pipeline() {
   // Command must be reset before we destroy descriptors or we get a validation

--- a/src/vulkan/pipeline.cc
+++ b/src/vulkan/pipeline.cc
@@ -47,10 +47,10 @@ Pipeline::Pipeline(
     const std::vector<VkPipelineShaderStageCreateInfo>& shader_stage_info,
     VkPipelineCreateFlags create_flags)
     : device_(device),
+      create_flags_(create_flags),
       pipeline_type_(type),
       shader_stage_info_(shader_stage_info),
       fence_timeout_ms_(fence_timeout_ms),
-      create_flags_(create_flags),
       pipeline_runtime_layer_enabled_(pipeline_runtime_layer_enabled) {}
 
 Pipeline::~Pipeline() {

--- a/src/vulkan/pipeline.h
+++ b/src/vulkan/pipeline.h
@@ -81,6 +81,8 @@ class Pipeline {
   Device* GetDevice() const { return device_; }
   virtual BlasesMap* GetBlases() { return nullptr; }
   virtual TlasesMap* GetTlases() { return nullptr; }
+  VkPipelineLayout GetVkPipelineLayout() const { return pipeline_layout_; }
+  VkPipeline GetVkPipeline() const { return pipeline_; }
 
  protected:
   Pipeline(
@@ -88,7 +90,8 @@ class Pipeline {
       Device* device,
       uint32_t fence_timeout_ms,
       bool    pipeline_runtime_layer_enabled,
-      const std::vector<VkPipelineShaderStageCreateInfo>& shader_stage_info);
+      const std::vector<VkPipelineShaderStageCreateInfo>& shader_stage_info,
+      VkPipelineCreateFlags create_flags = 0);
 
   /// Initializes the pipeline.
   Result Initialize(CommandPool* pool);
@@ -115,6 +118,20 @@ class Pipeline {
        const { return pipeline_runtime_layer_enabled_; }
 
   Result CreateVkPipelineLayout(VkPipelineLayout* pipeline_layout);
+
+  void SetVkPipelineLayout(VkPipelineLayout pipeline_layout) {
+    assert(pipeline_layout_ == VK_NULL_HANDLE);
+    pipeline_layout_ = pipeline_layout;
+  }
+
+  void SetVkPipeline(VkPipeline pipeline) {
+    assert(pipeline_ == VK_NULL_HANDLE);
+    pipeline_ = pipeline;
+  }
+
+  VkPipelineCreateFlags create_flags_ = 0;
+  VkPipeline pipeline_ = VK_NULL_HANDLE;
+  VkPipelineLayout pipeline_layout_ = VK_NULL_HANDLE;
 
   Device* device_ = nullptr;
   std::unique_ptr<CommandBuffer> command_;

--- a/src/vulkan/pipeline.h
+++ b/src/vulkan/pipeline.h
@@ -129,12 +129,12 @@ class Pipeline {
     pipeline_ = pipeline;
   }
 
-  VkPipelineCreateFlags create_flags_ = 0;
   VkPipeline pipeline_ = VK_NULL_HANDLE;
   VkPipelineLayout pipeline_layout_ = VK_NULL_HANDLE;
 
   Device* device_ = nullptr;
   std::unique_ptr<CommandBuffer> command_;
+  VkPipelineCreateFlags create_flags_ = 0;
 
  private:
   struct DescriptorSetInfo {

--- a/src/vulkan/raytracing_pipeline.h
+++ b/src/vulkan/raytracing_pipeline.h
@@ -35,7 +35,8 @@ class RayTracingPipeline : public Pipeline {
       TlasesMap* tlases,
       uint32_t fence_timeout_ms,
       bool pipeline_runtime_layer_enabled,
-      const std::vector<VkPipelineShaderStageCreateInfo>& shader_stage_info);
+      const std::vector<VkPipelineShaderStageCreateInfo>& shader_stage_info,
+      VkPipelineCreateFlags create_flags);
   ~RayTracingPipeline() override;
 
   Result AddTLASDescriptor(const TLASCommand* cmd);
@@ -48,20 +49,33 @@ class RayTracingPipeline : public Pipeline {
                             amber::SBT* aSBT,
                             VkStridedDeviceAddressRegionKHR* region);
 
+  Result InitLibrary(const std::vector<VkPipeline>& lib,
+                     uint32_t maxPipelineRayPayloadSize,
+                     uint32_t maxPipelineRayHitAttributeSize,
+                     uint32_t maxPipelineRayRecursionDepth);
+
   Result TraceRays(amber::SBT* rSBT,
                    amber::SBT* mSBT,
                    amber::SBT* hSBT,
                    amber::SBT* cSBT,
                    uint32_t x,
                    uint32_t y,
-                   uint32_t z);
+                   uint32_t z,
+                   uint32_t maxPipelineRayPayloadSize,
+                   uint32_t maxPipelineRayHitAttributeSize,
+                   uint32_t maxPipelineRayRecursionDepth,
+                   const std::vector<VkPipeline>& lib);
 
   BlasesMap* GetBlases() override { return blases_; }
   TlasesMap* GetTlases() override { return tlases_; }
 
  private:
   Result CreateVkRayTracingPipeline(const VkPipelineLayout& pipeline_layout,
-                                    VkPipeline* pipeline);
+                                    VkPipeline* pipeline,
+                                    const std::vector<VkPipeline>& libs,
+                                    uint32_t maxPipelineRayPayloadSize,
+                                    uint32_t maxPipelineRayHitAttributeSize,
+                                    uint32_t maxPipelineRayRecursionDepth);
 
   std::vector<VkRayTracingShaderGroupCreateInfoKHR> shader_group_create_info_;
   BlasesMap* blases_;

--- a/src/vulkan/sbt.cc
+++ b/src/vulkan/sbt.cc
@@ -46,7 +46,7 @@ Result SBT::Create(amber::SBT* sbt, VkPipeline pipeline) {
 
   size_t start = 0;
   for (auto& x : sbt->GetSBTRecords()) {
-    const uint32_t index = x->GetUsedShaderGroupPipelineIndex();
+    const uint32_t index = x->GetIndex();
     const uint32_t count = x->GetCount();
     if (index != static_cast<uint32_t>(-1)) {
       VkResult vr = device_->GetPtrs()->vkGetRayTracingShaderGroupHandlesKHR(
@@ -57,7 +57,7 @@ Result SBT::Create(amber::SBT* sbt, VkPipeline pipeline) {
         return Result("vkGetRayTracingShaderGroupHandlesKHR has failed");
     }
 
-    start += x->GetCount();
+    start += count;
   }
 
   memcpy(buffer_->HostAccessibleMemoryPtr(), handles.data(), handles.size());


### PR DESCRIPTION
Extend ray tracing support in Amber with Pipeline Library support.
Also add:
 * include support as well
 * null shader groups support
 * geometry flags support