### PR TITLE
Add geometry flags support

### DIFF
--- a/src/acceleration_structure.h
+++ b/src/acceleration_structure.h
@@ -49,6 +49,9 @@ class Geometry {
   void SetData(std::vector<float>& data) { data_.swap(data); }
   std::vector<float>& GetData() { return data_; }
 
+  void SetFlags(uint32_t flags) { flags_ = flags; }
+  uint32_t GetFlags() { return flags_; }
+
   size_t getVertexCount() const {
     return data_.size() / 3;  // Three floats to define vertex
   }
@@ -65,6 +68,7 @@ class Geometry {
  private:
   GeometryType type_ = GeometryType::kUnknown;
   std::vector<float> data_;
+  uint32_t flags_ = 0u;
 };
 
 class BLAS {

--- a/src/amberscript/parser.h
+++ b/src/amberscript/parser.h
@@ -102,6 +102,7 @@ class Parser : public amber::Parser {
   Result ParseBLAS();
   Result ParseBLASTriangle(BLAS* blas);
   Result ParseBLASAABB(BLAS* blas);
+  Result ParseGeometryFlags(uint32_t* flags);
   Result ParseTLAS();
   Result ParseBLASInstance(TLAS* tlas);
   Result ParseBLASInstanceTransform(BLASInstance* instance);

--- a/src/amberscript/parser_raytracing_test.cc
+++ b/src/amberscript/parser_raytracing_test.cc
@@ -195,6 +195,33 @@ ACCELERATION_STRUCTURE BOTTOM_LEVEL blas_name
   EXPECT_EQ("3: Unexpected data type", r.Error());
 }
 
+TEST_F(AmberScriptParserTest, RayTracingBlasTriangleGeometryFlags) {
+  {
+    std::string in = R"(
+ACCELERATION_STRUCTURE BOTTOM_LEVEL blas_name
+  GEOMETRY TRIANGLES
+    FLAGS OPAQUE NO_DUPLICATE_ANY_HIT NO_SUCH_FLAG
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("4: Unknown flag: NO_SUCH_FLAG", r.Error());
+  }
+  {
+    std::string in = R"(
+ACCELERATION_STRUCTURE BOTTOM_LEVEL blas_name
+  GEOMETRY TRIANGLES
+    FLAGS 1
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("4: Identifier expected", r.Error());
+  }
+}
+
 TEST_F(AmberScriptParserTest, RayTracingBlasAABBEmpty) {
   std::string in = R"(
 ACCELERATION_STRUCTURE BOTTOM_LEVEL blas_name
@@ -247,6 +274,33 @@ ACCELERATION_STRUCTURE BOTTOM_LEVEL blas_name
   Result r = parser.Parse(in);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("3: Unexpected data type", r.Error());
+}
+
+TEST_F(AmberScriptParserTest, RayTracingBlasAABBGeometryFlags) {
+  {
+    std::string in = R"(
+ACCELERATION_STRUCTURE BOTTOM_LEVEL blas_name
+  GEOMETRY AABBS
+    FLAGS OPAQUE NO_DUPLICATE_ANY_HIT NO_SUCH_FLAG
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("4: Unknown flag: NO_SUCH_FLAG", r.Error());
+  }
+  {
+    std::string in = R"(
+ACCELERATION_STRUCTURE BOTTOM_LEVEL blas_name
+  GEOMETRY AABBS
+    FLAGS 1
+)";
+
+    Parser parser;
+    Result r = parser.Parse(in);
+    ASSERT_FALSE(r.IsSuccess());
+    EXPECT_EQ("4: Identifier expected", r.Error());
+  }
 }
 
 TEST_F(AmberScriptParserTest, RayTracingTlasName) {

--- a/src/vulkan/blas.cc
+++ b/src/vulkan/blas.cc
@@ -91,7 +91,7 @@ Result BLAS::CreateBLAS(amber::BLAS* blas) {
             nullptr,
             geometryType,
             geometry,
-            0u,
+            VkGeometryFlagsKHR(geometryData->GetFlags())
         };
     const VkAccelerationStructureBuildRangeInfoKHR
         accelerationStructureBuildRangeInfosKHR = {
@@ -209,6 +209,8 @@ Result BLAS::CreateBLAS(amber::BLAS* blas) {
       } else {
         assert(false && "unknown geometry type");
       }
+      accelerationStructureGeometriesKHR_[geometryNdx].flags =
+          VkGeometryFlagsKHR(geometries[geometryNdx]->GetFlags());
     }
   }
 


### PR DESCRIPTION
Extend acceleration structure geometries (both AABBs and traingles) with support of flags.