### PR TITLE
kokoro: on mac, download and use cmake 3.30.2

### DIFF
--- a/kokoro/scripts/macos/build.sh
+++ b/kokoro/scripts/macos/build.sh
@@ -28,6 +28,13 @@ unzip -q ninja-mac.zip
 chmod +x ninja
 export PATH="$PWD:$PATH"
 
+# Get Cmake (required for Kokoro Apple Silicon images)
+CMAKE_VER=3.30.2
+wget -q https://github.com/Kitware/CMake/releases/download/v$CMAKE_VER/cmake-$CMAKE_VER-macos-universal.tar.gz
+tar xf cmake-$CMAKE_VER-macos-universal.tar.gz
+chmod +x cmake-$CMAKE_VER-macos-universal/CMake.app/Contents/bin/*
+export PATH="$PWD/cmake-$CMAKE_VER-macos-universal/CMake.app/Contents/bin:$PATH"
+
 echo $(date): $(cmake --version)
 
 DEPS_ARGS=""


### PR DESCRIPTION
This is needed before upgrading to the Kokoro Apple Silicon images.