### PR TITLE
Minor fix for amber internal vk config

### DIFF
--- a/samples/config_helper_vulkan.cc
+++ b/samples/config_helper_vulkan.cc
@@ -1128,6 +1128,7 @@ amber::Result ConfigHelperVulkan::CreateDeviceWithFeatures2(
     if (next_ptr != nullptr) {
       *next_ptr = &variable_pointers_feature_.pNext;
     }
+    next_ptr = &variable_pointers_feature_.pNext;
     exts.push_back(VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME);
   }
 

--- a/tests/cases/float16.amber
+++ b/tests/cases/float16.amber
@@ -18,6 +18,7 @@ DEVICE_EXTENSION VK_KHR_16bit_storage
 DEVICE_EXTENSION VK_KHR_storage_buffer_storage_class
 DEVICE_FEATURE Float16Int8Features.shaderFloat16
 DEVICE_FEATURE Storage16BitFeatures.storageBuffer16BitAccess
+DEVICE_FEATURE Storage16BitFeatures.uniformAndStorageBuffer16BitAccess
 
 SHADER compute f16 GLSL
 #version 450


### PR DESCRIPTION
The main fix here is that the next_ptr must be updated if you have variable_pointers_feature_

Secondary fix is that the "float16" test case actually needs "uniformAndStorageBuffer16BitAccess" feature. 

[1]
https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDevice16BitStorageFeatures.html