### PR TITLE
Ignore readability/fn_size

### DIFF
--- a/tools/run-lint.sh
+++ b/tools/run-lint.sh
@@ -15,6 +15,6 @@
 
 set -e  # fail on error
 
-FILTERS=-build/header_guard
+FILTERS=-build/header_guard,-readability/fn_size
 ./third_party/cpplint/cpplint.py  --filter "$FILTERS" `find src samples -type f`
 ./third_party/cpplint/cpplint.py  --filter "$FILTERS" --root include `find ./include -type f`


### PR DESCRIPTION
This check is not useful in Amber, remove it.

Change-Id: I4069c2d05d70baaffe8c85d6a8fd363a77d40a6c