### PR TITLE
Reproduction for webgpu cts atomic operation failure on mobile gpus (mali, adreno)

### DIFF
--- a/tests/cases/compute_workgroup_atomic.amber
+++ b/tests/cases/compute_workgroup_atomic.amber
@@ -46,7 +46,7 @@ void main() {
 }
 END
 
-BUFFER buf_uint DATA_TYPE uint32 SIZE 1024 FILL 123
+BUFFER buf_uint DATA_TYPE uint32 SIZE 16 FILL 123
 
 PIPELINE compute pipeline
   ATTACH workgroup_shared_atomic

--- a/tests/cases/compute_workgroup_atomic.amber
+++ b/tests/cases/compute_workgroup_atomic.amber
@@ -30,20 +30,17 @@ layout(set = 0, binding = 0) buffer block1 {
 shared uint wg_shared;
 
 void main() {
-    // These 'memoryBarrierShared' should not be required but do not
-    // impact the test result.
-
-    memoryBarrierShared();
-    barrier();
     if( gl_LocalInvocationID.x == 0){
       atomicExchange(wg_shared, 7);
     }
-    memoryBarrierShared();
+
     barrier();
     atomicAdd(wg_shared,1);
-    memoryBarrierShared();
     barrier();
-    if( gl_LocalInvocationID.x == 0) {
+
+    // If you make this condition on the last thread (idx 2)
+    // the test will work on the mali gpu
+    if(gl_LocalInvocationID.x == 0) {
       ssbo_write[0] = atomicExchange(wg_shared,0);
     }
 }

--- a/tests/cases/compute_workgroup_atomic.amber
+++ b/tests/cases/compute_workgroup_atomic.amber
@@ -1,0 +1,61 @@
+#!amber
+# Copyright 2024 The Amber Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# The purpose of this test is to check the behavior of workgroup atomics 
+# on the android devices given the CTS failures for webgpu
+# See: crbug.com/42241359
+
+SHADER compute workgroup_shared_atomic GLSL
+#version 430
+
+layout(local_size_x = 3, local_size_y = 1, local_size_z = 1) in;
+
+layout(set = 0, binding = 0) buffer block1 {
+  uint ssbo_write[];
+};
+
+shared uint wg_shared;
+
+void main() {
+    // These 'memoryBarrierShared' should not be required but do not
+    // impact the test result.
+
+    memoryBarrierShared();
+    barrier();
+    if( gl_LocalInvocationID.x == 0){
+      atomicExchange(wg_shared, 7);
+    }
+    memoryBarrierShared();
+    barrier();
+    atomicAdd(wg_shared,1);
+    memoryBarrierShared();
+    barrier();
+    if( gl_LocalInvocationID.x == 0) {
+      ssbo_write[0] = atomicExchange(wg_shared,0);
+    }
+}
+END
+
+BUFFER buf_uint DATA_TYPE uint32 SIZE 1024 FILL 123
+
+PIPELINE compute pipeline
+  ATTACH workgroup_shared_atomic
+  BIND BUFFER buf_uint AS storage DESCRIPTOR_SET 0 BINDING 0
+END
+
+RUN pipeline 1 1 1
+
+EXPECT buf_uint IDX 0 EQ  10


### PR DESCRIPTION
This very simple amber file demonstrates a repo of the bug in webgpu CTS atomicAdd

This test was manually run on a mali (pixel 6) and it outputs the value 8 rather than 10.
Incorrect behavior appears to be that the shader is only executed on one thread (instead of 3).

crbug.com/42241359