### PR TITLE
license-checker.cfg: ignore .spv files

### DIFF
--- a/license-checker.cfg
+++ b/license-checker.cfg
@@ -16,6 +16,7 @@
                 "**.gitignore",
                 "**.md",
                 "**.png",
+                "**.spv",
 
                 "build/**",
                 "third_party/*/**",


### PR DESCRIPTION
They are SPIR-V binaries.

This should allow #1056 to land