### PR TITLE
Features required to support raytracing pipeline

### DIFF
--- a/samples/config_helper_vulkan.cc
+++ b/samples/config_helper_vulkan.cc
@@ -662,7 +662,9 @@ ConfigHelperVulkan::ConfigHelperVulkan()
       buffer_device_address_feature_(
           VkPhysicalDeviceBufferDeviceAddressFeatures()),
       ray_tracing_pipeline_feature_(
-          VkPhysicalDeviceRayTracingPipelineFeaturesKHR()) {}
+          VkPhysicalDeviceRayTracingPipelineFeaturesKHR()),
+      descriptor_indexing_feature_(
+          VkPhysicalDeviceDescriptorIndexingFeatures()) {}
 
 ConfigHelperVulkan::~ConfigHelperVulkan() {
   if (vulkan_device_)

--- a/samples/config_helper_vulkan.cc
+++ b/samples/config_helper_vulkan.cc
@@ -814,6 +814,14 @@ amber::Result ConfigHelperVulkan::CheckVulkanPhysicalDeviceRequirements(
       supports_buffer_device_address_ = true;
     else if (ext == "VK_KHR_ray_tracing_pipeline")
       supports_ray_tracing_pipeline_ = true;
+    else if (ext == VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME)
+      supports_descriptor_indexing_ = true;
+    else if (ext == VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME)
+      supports_deferred_host_operations_ = true;
+    else if (ext == VK_KHR_SPIRV_1_4_EXTENSION_NAME)
+      supports_spirv_1_4_ = true;
+    else if (ext == VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME)
+      supports_shader_float_controls_ = true;
   }
 
   VkPhysicalDeviceFeatures required_vulkan_features =
@@ -834,6 +842,8 @@ amber::Result ConfigHelperVulkan::CheckVulkanPhysicalDeviceRequirements(
         {};
     VkPhysicalDeviceRayTracingPipelineFeaturesKHR
         ray_tracing_pipeline_features = {};
+    VkPhysicalDeviceDescriptorIndexingFeatures descriptor_indexing_features =
+        {};
     void* next_ptr = nullptr;
 
     if (supports_subgroup_size_control_) {
@@ -888,6 +898,13 @@ amber::Result ConfigHelperVulkan::CheckVulkanPhysicalDeviceRequirements(
           VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR;
       ray_tracing_pipeline_features.pNext = next_ptr;
       next_ptr = &ray_tracing_pipeline_features;
+    }
+
+    if (supports_descriptor_indexing_) {
+      descriptor_indexing_features.sType =
+          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
+      descriptor_indexing_feature_.pNext = next_ptr;
+      next_ptr = &descriptor_indexing_features;
     }
 
     VkPhysicalDeviceFeatures2KHR features2 = VkPhysicalDeviceFeatures2KHR();
@@ -1145,6 +1162,24 @@ amber::Result ConfigHelperVulkan::CreateDeviceWithFeatures2(
       supports_ray_tracing_pipeline_, ray_tracing_pipeline_feature_,
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR,
       VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+
+  init_feature(
+      supports_descriptor_indexing_, descriptor_indexing_feature_,
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT,
+      VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
+
+  // These extensions are required to support the raytracing pipeline.
+  if (supports_deferred_host_operations_) {
+    exts.push_back(VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME);
+  }
+
+  if (supports_spirv_1_4_) {
+    exts.push_back(VK_KHR_SPIRV_1_4_EXTENSION_NAME);
+  }
+
+  if (supports_shader_float_controls_) {
+    exts.push_back(VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME);
+  }
 
   available_features2_.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR;
   available_features2_.pNext = pnext;

--- a/samples/config_helper_vulkan.h
+++ b/samples/config_helper_vulkan.h
@@ -122,6 +122,10 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
   bool supports_acceleration_structure_ = false;
   bool supports_buffer_device_address_ = false;
   bool supports_ray_tracing_pipeline_ = false;
+  bool supports_descriptor_indexing_ = false;
+  bool supports_deferred_host_operations_ = false;
+  bool supports_spirv_1_4_ = false;
+  bool supports_shader_float_controls_ = false;
   VkPhysicalDeviceFeatures available_features_;
   VkPhysicalDeviceFeatures2KHR available_features2_;
   VkPhysicalDeviceVariablePointerFeaturesKHR variable_pointers_feature_;
@@ -135,6 +139,7 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
       acceleration_structure_feature_;
   VkPhysicalDeviceBufferDeviceAddressFeatures buffer_device_address_feature_;
   VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_pipeline_feature_;
+  VkPhysicalDeviceDescriptorIndexingFeatures descriptor_indexing_feature_;
 };
 
 }  // namespace sample


### PR DESCRIPTION
Due to recent changes, if a devices supports the raytracing pipeline it will be enabled.

crbug.com/385316823

This causes errors (see below)
 
C:\Users\super\amber\build>amber.exe
[ERROR] validation layer (Validation):
Validation Error: [ VUID-vkCreateDevice-ppEnabledExtensionNames-01387 ] Object 0: handle = 0x18be6cfcbc0, type = VK_OBJECT_TYPE_INSTANCE; | MessageID = 0x12537a2c | vkCreateDevice(): pCreateInfo->ppEnabledExtensionNames[6] Missing extensions required by the device extension VK_KHR_acceleration_structure: VK_EXT_descriptor_indexing, VK_KHR_deferred_host_operations.
The Vulkan spec states: All required device extensions for each extension in the VkDeviceCreateInfo::ppEnabledExtensionNames list must also be present in that list (https://vulkan.lunarg.com/doc/view/1.3.296.0/windows/1.3-extensions/vkspec.html#VUID-vkCreateDevice-ppEnabledExtensionNames-01387)
[ERROR] validation layer (Validation):
Validation Error: [ VUID-vkCreateDevice-ppEnabledExtensionNames-01387 ] Object 0: handle = 0x18be6cfcbc0, type = VK_OBJECT_TYPE_INSTANCE; | MessageID = 0x12537a2c | vkCreateDevice(): pCreateInfo->ppEnabledExtensionNames[8] Missing extension required by the device extension VK_KHR_ray_tracing_pipeline: VK_KHR_spirv_1_4.
The Vulkan spec states: All required device extensions for each extension in the VkDeviceCreateInfo::ppEnabledExtensionNames list must also be present in that list (https://vulkan.lunarg.com/doc/view/1.3.296.0/windows/1.3-extensions/vkspec.html#VUID-vkCreateDevice-ppEnabledExtensionNames-01387)

Summary: 0 pass, 0 fail

C:\Users\super\amber\build>amber.exe -v 1.2
[ERROR] validation layer (Validation):
Validation Error: [ VUID-vkCreateDevice-ppEnabledExtensionNames-01387 ] Object 0: handle = 0x2e1ad725290, type = VK_OBJECT_TYPE_INSTANCE; | MessageID = 0x12537a2c | vkCreateDevice(): pCreateInfo->ppEnabledExtensionNames[6] Missing extension required by the device extension VK_KHR_acceleration_structure: VK_KHR_deferred_host_operations.
The Vulkan spec states: All required device extensions for each extension in the VkDeviceCreateInfo::ppEnabledExtensionNames list must also be present in that list (https://vulkan.lunarg.com/doc/view/1.3.296.0/windows/1.3-extensions/vkspec.html#VUID-vkCreateDevice-ppEnabledExtensionNames-01387)


