### PR TITLE
set cmake_minimum_required to 3.22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.22)
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 cmake_minimum_required(VERSION 3.22)
+cmake_policy(SET CMP0091 OLD) # Assume old-style selection of MSVC runtime
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()


### PR DESCRIPTION
That's the cmake verion included in Ubuntu 2022.04

Change-Id: I5d6da0d33c86eae5020bba1b9a8805fc8d7e7868