### PR TITLE
Fixup acceleration structure and raytracing flags.

### DIFF
--- a/samples/config_helper_vulkan.cc
+++ b/samples/config_helper_vulkan.cc
@@ -920,7 +920,7 @@ amber::Result ConfigHelperVulkan::CheckVulkanPhysicalDeviceRequirements(
     vkGetPhysicalDeviceFeatures2KHR(physical_device, &features2);
     available_features_ = features2.features;
 
-    // Just having the feature does not necessarily mean that the feature is available. We have to
+    // Just having the extension does not necessarily mean that the feature is available. We have to
     // check the features structure for specific flags.
     if (supports_acceleration_structure_) {
       supports_acceleration_structure_ = acceleration_structure_features.accelerationStructure;

--- a/samples/config_helper_vulkan.cc
+++ b/samples/config_helper_vulkan.cc
@@ -920,6 +920,15 @@ amber::Result ConfigHelperVulkan::CheckVulkanPhysicalDeviceRequirements(
     vkGetPhysicalDeviceFeatures2KHR(physical_device, &features2);
     available_features_ = features2.features;
 
+    // Just having the feature does not necessarily mean that the feature is available. We have to
+    // check the features structure for specific flags.
+    if (supports_acceleration_structure_) {
+      supports_acceleration_structure_ = acceleration_structure_features.accelerationStructure;
+    }
+    if (supports_ray_tracing_pipeline_) {
+      supports_ray_tracing_pipeline_ = ray_tracing_pipeline_features.rayTracingPipeline;
+    }
+
     std::vector<std::string> required_features1;
     for (const auto& feature : required_features) {
       // No dot means this is a features1 feature.

--- a/samples/config_helper_vulkan.cc
+++ b/samples/config_helper_vulkan.cc
@@ -920,13 +920,15 @@ amber::Result ConfigHelperVulkan::CheckVulkanPhysicalDeviceRequirements(
     vkGetPhysicalDeviceFeatures2KHR(physical_device, &features2);
     available_features_ = features2.features;
 
-    // Just having the extension does not necessarily mean that the feature is available. We have to
-    // check the features structure for specific flags.
+    // Just having the extension does not necessarily mean that the feature is
+    // available. We have to check the features structure for specific flags.
     if (supports_acceleration_structure_) {
-      supports_acceleration_structure_ = acceleration_structure_features.accelerationStructure;
+      supports_acceleration_structure_ =
+          acceleration_structure_features.accelerationStructure;
     }
     if (supports_ray_tracing_pipeline_) {
-      supports_ray_tracing_pipeline_ = ray_tracing_pipeline_features.rayTracingPipeline;
+      supports_ray_tracing_pipeline_ =
+          ray_tracing_pipeline_features.rayTracingPipeline;
     }
 
     std::vector<std::string> required_features1;


### PR DESCRIPTION
When determining if acceleration structures and ray tracing are supported it isn't enough to just check for the device extension. Both of these extensions maybe available, then the features contain a flag which determines if it is implemented. So, if we've got the features, we need to additionally check the flag and reset our internal tracking based on the implementation flag.

Change-Id: I09b04007a47e5b5bec34c7ed910949401ca18a3b