### PR TITLE
Fix Vulkan extension checking

### DIFF
--- a/samples/config_helper_vulkan.cc
+++ b/samples/config_helper_vulkan.cc
@@ -987,7 +987,7 @@ amber::Result ConfigHelperVulkan::CheckVulkanPhysicalDeviceRequirements(
     if (supports_descriptor_indexing_) {
       descriptor_indexing_features.sType =
           VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
-      descriptor_indexing_feature_.pNext = next_ptr;
+      descriptor_indexing_features.pNext = next_ptr;
       next_ptr = &descriptor_indexing_features;
     }
 


### PR DESCRIPTION
The wrong copy of the descriptor indexing struct was being added to the extension chain meaning that everything else was discarded.