### PR TITLE
Group members of ConfigHelperVulkan.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,12 +222,15 @@ function(amber_default_compile_options TARGET)
       target_compile_options(${TARGET} PRIVATE -fno-rtti)
     endif()
 
-    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
+        "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
       target_compile_options(${TARGET} PRIVATE
         -Wno-c++98-compat
         -Wno-c++98-compat-pedantic
         -Wno-format-pedantic
         -Wno-unknown-warning-option
+
+        -Wno-switch-default
       )
       if (NOT ${AMBER_DISABLE_WEVERYTHING})
         target_compile_options(${TARGET} PRIVATE -Weverything)

--- a/samples/config_helper_vulkan.h
+++ b/samples/config_helper_vulkan.h
@@ -103,45 +103,51 @@ class ConfigHelperVulkan : public ConfigHelperImpl {
   /// Writes information related to the vulkan instance to stdout.
   void DumpPhysicalDeviceInfo();
 
-  VkInstance vulkan_instance_ = VK_NULL_HANDLE;
-  VkDebugReportCallbackEXT vulkan_callback_ = VK_NULL_HANDLE;
-  VkPhysicalDevice vulkan_physical_device_ = VK_NULL_HANDLE;
-  std::vector<std::string> available_instance_extensions_;
-  std::vector<std::string> available_device_extensions_;
-  uint32_t vulkan_queue_family_index_ = std::numeric_limits<uint32_t>::max();
-  VkQueue vulkan_queue_ = VK_NULL_HANDLE;
-  VkDevice vulkan_device_ = VK_NULL_HANDLE;
+  struct {
+    VkInstance instance = VK_NULL_HANDLE;
+    VkDebugReportCallbackEXT debug_cb = VK_NULL_HANDLE;
+    VkPhysicalDevice physical_device = VK_NULL_HANDLE;
+    std::vector<std::string> available_instance_extensions;
+    std::vector<std::string> available_device_extensions;
+    uint32_t queue_family_index = std::numeric_limits<uint32_t>::max();
+    VkQueue queue = VK_NULL_HANDLE;
+    VkDevice device = VK_NULL_HANDLE;
+  } vk_;
 
-  bool supports_get_physical_device_properties2_ = false;
-  bool supports_variable_pointers_ = false;
-  bool supports_shader_float16_int8_ = false;
-  bool supports_shader_8bit_storage_ = false;
-  bool supports_shader_16bit_storage_ = false;
-  bool supports_subgroup_size_control_ = false;
-  bool supports_depth_clamp_zero_one_ = false;
-  bool supports_shader_subgroup_extended_types_ = false;
-  bool supports_acceleration_structure_ = false;
-  bool supports_buffer_device_address_ = false;
-  bool supports_ray_tracing_pipeline_ = false;
-  bool supports_descriptor_indexing_ = false;
-  bool supports_deferred_host_operations_ = false;
-  bool supports_spirv_1_4_ = false;
-  bool supports_shader_float_controls_ = false;
-  VkPhysicalDeviceFeatures available_features_;
-  VkPhysicalDeviceFeatures2KHR available_features2_;
-  VkPhysicalDeviceVariablePointerFeaturesKHR variable_pointers_feature_;
-  VkPhysicalDeviceFloat16Int8FeaturesKHR float16_int8_feature_;
-  VkPhysicalDevice8BitStorageFeaturesKHR storage_8bit_feature_;
-  VkPhysicalDevice16BitStorageFeaturesKHR storage_16bit_feature_;
-  VkPhysicalDeviceSubgroupSizeControlFeaturesEXT subgroup_size_control_feature_;
-  VkPhysicalDeviceDepthClampZeroOneFeaturesEXT depth_clamp_zero_one_feature_;
-  VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
-      shader_subgroup_extended_types_feature_;
-  VkPhysicalDeviceAccelerationStructureFeaturesKHR
-      acceleration_structure_feature_;
-  VkPhysicalDeviceBufferDeviceAddressFeatures buffer_device_address_feature_;
-  VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_pipeline_feature_;
-  VkPhysicalDeviceDescriptorIndexingFeatures descriptor_indexing_feature_;
+  struct {
+    bool get_physical_device_properties2 = false;
+    bool variable_pointers = false;
+    bool shader_float16_int8 = false;
+    bool shader_8bit_storage = false;
+    bool shader_16bit_storage = false;
+    bool subgroup_size_control = false;
+    bool depth_clamp_zero_one = false;
+    bool shader_subgroup_extended_types = false;
+    bool acceleration_structure = false;
+    bool buffer_device_address = false;
+    bool ray_tracing_pipeline = false;
+    bool descriptor_indexing = false;
+    bool deferred_host_operations = false;
+    bool spirv_1_4 = false;
+    bool shader_float_controls = false;
+  } supports_;
+
+  struct {
+    VkPhysicalDeviceFeatures device{};
+    VkPhysicalDeviceFeatures2KHR features2{};
+    VkPhysicalDeviceVariablePointerFeaturesKHR variable_pointers{};
+    VkPhysicalDeviceFloat16Int8FeaturesKHR float16_int8{};
+    VkPhysicalDevice8BitStorageFeaturesKHR storage_8bit{};
+    VkPhysicalDevice16BitStorageFeaturesKHR storage_16bit{};
+    VkPhysicalDeviceSubgroupSizeControlFeaturesEXT subgroup_size_control{};
+    VkPhysicalDeviceDepthClampZeroOneFeaturesEXT depth_clamp_zero_one{};
+    VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
+        shader_subgroup_extended_types{};
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR acceleration_structure{};
+    VkPhysicalDeviceBufferDeviceAddressFeatures buffer_device_address{};
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_pipeline{};
+    VkPhysicalDeviceDescriptorIndexingFeatures descriptor_indexing{};
+  } features_;
 };
 
 }  // namespace sample


### PR DESCRIPTION
Move the various members into separate structures to a) group them and b) make the names more distinct from other versions used in the helper.

This adds a `vk_` group for all the vulkan objects, a `supports_` struct for all the booleans and a `features_` struct for all the feature objects.