### PR TITLE
Change ShaderFormat and ShaderType into enum classes.

### DIFF
--- a/include/amber/shader_info.h
+++ b/include/amber/shader_info.h
@@ -22,37 +22,37 @@
 
 namespace amber {
 
-enum ShaderFormat {
-  kShaderFormatDefault = 0,
-  kShaderFormatText,
-  kShaderFormatGlsl,
-  kShaderFormatHlsl,
-  kShaderFormatSpirvAsm,
-  kShaderFormatSpirvHex,
-  kShaderFormatSpirvBin,
-  kShaderFormatOpenCLC,
+enum class ShaderFormat : uint8_t {
+  kDefault = 0,
+  kText,
+  kGlsl,
+  kHlsl,
+  kSpirvAsm,
+  kSpirvHex,
+  kSpirvBin,
+  kOpenCLC,
 };
 
-enum ShaderType {
-  kShaderTypeCompute = 0,
-  kShaderTypeGeometry,
-  kShaderTypeFragment,
-  kShaderTypeVertex,
-  kShaderTypeTessellationControl,
-  kShaderTypeTessellationEvaluation,
-  kShaderTypeRayGeneration,
-  kShaderTypeAnyHit,
-  kShaderTypeClosestHit,
-  kShaderTypeMiss,
-  kShaderTypeIntersection,
-  kShaderTypeCall,
-  kShaderTypeMulti,
+enum class ShaderType : uint8_t {
+  kCompute = 0,
+  kGeometry,
+  kFragment,
+  kVertex,
+  kTessellationControl,
+  kTessellationEvaluation,
+  kRayGeneration,
+  kAnyHit,
+  kClosestHit,
+  kMiss,
+  kIntersection,
+  kCall,
+  kMulti,
 };
 
 inline bool isRayTracingShaderType(ShaderType type) {
-  return type == kShaderTypeRayGeneration || type == kShaderTypeAnyHit ||
-         type == kShaderTypeClosestHit || type == kShaderTypeMiss ||
-         type == kShaderTypeIntersection || type == kShaderTypeCall;
+  return type == ShaderType::kRayGeneration || type == ShaderType::kAnyHit ||
+         type == ShaderType::kClosestHit || type == ShaderType::kMiss ||
+         type == ShaderType::kIntersection || type == ShaderType::kCall;
 }
 
 /// Stores information for a shader.

--- a/src/acceleration_structure.h
+++ b/src/acceleration_structure.h
@@ -201,15 +201,15 @@ class ShaderGroup {
   }
   Shader* GetShaderByType(ShaderType type) const {
     switch (type) {
-      case kShaderTypeRayGeneration:
-      case kShaderTypeMiss:
-      case kShaderTypeCall:
+      case ShaderType::kRayGeneration:
+      case ShaderType::kMiss:
+      case ShaderType::kCall:
         return generalShader_;
-      case kShaderTypeAnyHit:
+      case ShaderType::kAnyHit:
         return anyHitShader_;
-      case kShaderTypeClosestHit:
+      case ShaderType::kClosestHit:
         return closestHitShader_;
-      case kShaderTypeIntersection:
+      case ShaderType::kIntersection:
         return intersectionShader_;
       default:
         assert(0 && "Unsupported shader type");

--- a/src/amberscript/parser.cc
+++ b/src/amberscript/parser.cc
@@ -454,31 +454,31 @@ Result Parser::ToShaderType(const std::string& str, ShaderType* type) {
   assert(type);
 
   if (str == "vertex") {
-    *type = kShaderTypeVertex;
+    *type = ShaderType::kVertex;
   } else if (str == "fragment") {
-    *type = kShaderTypeFragment;
+    *type = ShaderType::kFragment;
   } else if (str == "geometry") {
-    *type = kShaderTypeGeometry;
+    *type = ShaderType::kGeometry;
   } else if (str == "tessellation_evaluation") {
-    *type = kShaderTypeTessellationEvaluation;
+    *type = ShaderType::kTessellationEvaluation;
   } else if (str == "tessellation_control") {
-    *type = kShaderTypeTessellationControl;
+    *type = ShaderType::kTessellationControl;
   } else if (str == "compute") {
-    *type = kShaderTypeCompute;
+    *type = ShaderType::kCompute;
   } else if (str == "ray_generation") {
-    *type = kShaderTypeRayGeneration;
+    *type = ShaderType::kRayGeneration;
   } else if (str == "any_hit") {
-    *type = kShaderTypeAnyHit;
+    *type = ShaderType::kAnyHit;
   } else if (str == "closest_hit") {
-    *type = kShaderTypeClosestHit;
+    *type = ShaderType::kClosestHit;
   } else if (str == "miss") {
-    *type = kShaderTypeMiss;
+    *type = ShaderType::kMiss;
   } else if (str == "intersection") {
-    *type = kShaderTypeIntersection;
+    *type = ShaderType::kIntersection;
   } else if (str == "callable") {
-    *type = kShaderTypeCall;
+    *type = ShaderType::kCall;
   } else if (str == "multi") {
-    *type = kShaderTypeMulti;
+    *type = ShaderType::kMulti;
   } else {
     return Result("unknown shader type: " + str);
   }
@@ -489,17 +489,17 @@ Result Parser::ToShaderFormat(const std::string& str, ShaderFormat* fmt) {
   assert(fmt);
 
   if (str == "GLSL") {
-    *fmt = kShaderFormatGlsl;
+    *fmt = ShaderFormat::kGlsl;
   } else if (str == "HLSL") {
-    *fmt = kShaderFormatHlsl;
+    *fmt = ShaderFormat::kHlsl;
   } else if (str == "SPIRV-ASM") {
-    *fmt = kShaderFormatSpirvAsm;
+    *fmt = ShaderFormat::kSpirvAsm;
   } else if (str == "SPIRV-HEX") {
-    *fmt = kShaderFormatSpirvHex;
+    *fmt = ShaderFormat::kSpirvHex;
   } else if (str == "SPIRV-BIN") {
-    *fmt = kShaderFormatSpirvBin;
+    *fmt = ShaderFormat::kSpirvBin;
   } else if (str == "OPENCL-C") {
-    *fmt = kShaderFormatOpenCLC;
+    *fmt = ShaderFormat::kOpenCLC;
   } else {
     return Result("unknown shader format: " + str);
   }
@@ -536,7 +536,7 @@ Result Parser::ParseShaderBlock() {
     return Result("invalid token when looking for shader type");
   }
 
-  ShaderType type = kShaderTypeVertex;
+  ShaderType type = ShaderType::kVertex;
   Result r = ToShaderType(token->AsString(), &type);
   if (!r.IsSuccess()) {
     return r;
@@ -558,12 +558,12 @@ Result Parser::ParseShaderBlock() {
 
   std::string fmt = token->AsString();
   if (fmt == "PASSTHROUGH") {
-    if (type != kShaderTypeVertex) {
+    if (type != ShaderType::kVertex) {
       return Result(
           "invalid shader type for PASSTHROUGH. Only vertex "
           "PASSTHROUGH allowed");
     }
-    shader->SetFormat(kShaderFormatSpirvAsm);
+    shader->SetFormat(ShaderFormat::kSpirvAsm);
     shader->SetData(kPassThroughShader);
     shader->SetTargetEnv("spv1.0");
 
@@ -575,7 +575,7 @@ Result Parser::ParseShaderBlock() {
     return ValidateEndOfStatement("SHADER PASSTHROUGH");
   }
 
-  ShaderFormat format = kShaderFormatGlsl;
+  ShaderFormat format = ShaderFormat::kGlsl;
   r = ToShaderFormat(fmt, &format);
   if (!r.IsSuccess()) {
     return r;
@@ -792,7 +792,7 @@ Result Parser::ParsePipelineAttach(Pipeline* pipeline) {
 
   token = tokenizer_->NextToken();
   if (token->IsEOL() || token->IsEOS()) {
-    if (shader->GetType() == kShaderTypeMulti) {
+    if (shader->GetType() == ShaderType::kMulti) {
       return Result("multi shader ATTACH requires TYPE");
     }
 
@@ -833,7 +833,7 @@ Result Parser::ParsePipelineAttach(Pipeline* pipeline) {
     return Result("unknown ATTACH parameter: " + type);
   }
 
-  if (shader->GetType() == ShaderType::kShaderTypeMulti && !set_shader_type) {
+  if (shader->GetType() == ShaderType::kMulti && !set_shader_type) {
     return Result("ATTACH missing TYPE for multi shader");
   }
 
@@ -987,7 +987,7 @@ Result Parser::ParsePipelineShaderCompileOptions(Pipeline* pipeline) {
     return Result("unknown shader in COMPILE_OPTIONS command");
   }
 
-  if (shader->GetFormat() != kShaderFormatOpenCLC) {
+  if (shader->GetFormat() != ShaderFormat::kOpenCLC) {
     return Result("COMPILE_OPTIONS currently only supports OPENCL-C shaders");
   }
 
@@ -1817,7 +1817,7 @@ Result Parser::ParsePipelineIndexData(Pipeline* pipeline) {
 Result Parser::ParsePipelineSet(Pipeline* pipeline) {
   if (pipeline->GetShaders().empty() ||
       pipeline->GetShaders()[0].GetShader()->GetFormat() !=
-          kShaderFormatOpenCLC) {
+          ShaderFormat::kOpenCLC) {
     return Result("SET can only be used with OPENCL-C shaders");
   }
 
@@ -2365,9 +2365,9 @@ Result Parser::ParsePipelineShaderGroup(Pipeline* pipeline) {
     }
 
     switch (shader->GetType()) {
-      case kShaderTypeRayGeneration:
-      case kShaderTypeMiss:
-      case kShaderTypeCall: {
+      case ShaderType::kRayGeneration:
+      case ShaderType::kMiss:
+      case ShaderType::kCall: {
         if (group->IsHitGroup()) {
           return Result("Hit group cannot contain general shaders");
         }
@@ -2377,7 +2377,7 @@ Result Parser::ParsePipelineShaderGroup(Pipeline* pipeline) {
         group->SetGeneralShader(shader);
         break;
       }
-      case kShaderTypeAnyHit: {
+      case ShaderType::kAnyHit: {
         if (group->IsGeneralGroup()) {
           return Result("General group cannot contain any hit shaders");
         }
@@ -2387,7 +2387,7 @@ Result Parser::ParsePipelineShaderGroup(Pipeline* pipeline) {
         group->SetAnyHitShader(shader);
         break;
       }
-      case kShaderTypeClosestHit: {
+      case ShaderType::kClosestHit: {
         if (group->IsGeneralGroup()) {
           return Result("General group cannot contain closest hit shaders");
         }
@@ -2397,7 +2397,7 @@ Result Parser::ParsePipelineShaderGroup(Pipeline* pipeline) {
         group->SetClosestHitShader(shader);
         break;
       }
-      case kShaderTypeIntersection: {
+      case ShaderType::kIntersection: {
         if (group->IsGeneralGroup()) {
           return Result("General group cannot contain intersection shaders");
         }
@@ -4519,9 +4519,9 @@ Result Parser::ParseSampler() {
 }
 
 bool Parser::IsRayTracingShader(ShaderType type) {
-  return type == kShaderTypeRayGeneration || type == kShaderTypeAnyHit ||
-         type == kShaderTypeClosestHit || type == kShaderTypeMiss ||
-         type == kShaderTypeIntersection || type == kShaderTypeCall;
+  return type == ShaderType::kRayGeneration || type == ShaderType::kAnyHit ||
+         type == ShaderType::kClosestHit || type == ShaderType::kMiss ||
+         type == ShaderType::kIntersection || type == ShaderType::kCall;
 }
 
 Result Parser::ParseAS() {

--- a/src/amberscript/parser_attach_test.cc
+++ b/src/amberscript/parser_attach_test.cc
@@ -130,14 +130,14 @@ INSTANTIATE_TEST_SUITE_P(
     AmberScriptParserPipelineAttachTests,
     AmberScriptParserPipelineAttachTest,
     testing::Values(
-        ShaderTypeData{"vertex", kShaderTypeVertex},
-        ShaderTypeData{"fragment", kShaderTypeFragment},
-        ShaderTypeData{"geometry", kShaderTypeGeometry},
+        ShaderTypeData{"vertex", ShaderType::kVertex},
+        ShaderTypeData{"fragment", ShaderType::kFragment},
+        ShaderTypeData{"geometry", ShaderType::kGeometry},
         ShaderTypeData{"tessellation_evaluation",
-                       kShaderTypeTessellationEvaluation},
+                       ShaderType::kTessellationEvaluation},
         ShaderTypeData{
             "tessellation_control",
-            kShaderTypeTessellationControl}));  // NOLINT(whitespace/parens)
+            ShaderType::kTessellationControl}));  // NOLINT(whitespace/parens)
 
 TEST_F(AmberScriptParserTest, PipelineEntryPoint) {
   std::string in = R"(
@@ -165,11 +165,11 @@ END
   ASSERT_EQ(2U, shaders.size());
 
   ASSERT_TRUE(shaders[0].GetShader() != nullptr);
-  EXPECT_EQ(kShaderTypeVertex, shaders[0].GetShader()->GetType());
+  EXPECT_EQ(ShaderType::kVertex, shaders[0].GetShader()->GetType());
   EXPECT_EQ("green", shaders[0].GetEntryPoint());
 
   ASSERT_TRUE(shaders[1].GetShader() != nullptr);
-  EXPECT_EQ(kShaderTypeFragment, shaders[1].GetShader()->GetType());
+  EXPECT_EQ(ShaderType::kFragment, shaders[1].GetShader()->GetType());
   EXPECT_EQ("main", shaders[1].GetEntryPoint());
 }
 
@@ -240,8 +240,8 @@ END)";
   ASSERT_EQ(1U, shaders.size());
 
   ASSERT_TRUE(shaders[0].GetShader() != nullptr);
-  EXPECT_EQ(kShaderTypeMulti, shaders[0].GetShader()->GetType());
-  EXPECT_EQ(kShaderTypeCompute, shaders[0].GetShaderType());
+  EXPECT_EQ(ShaderType::kMulti, shaders[0].GetShader()->GetType());
+  EXPECT_EQ(ShaderType::kCompute, shaders[0].GetShaderType());
   EXPECT_EQ("my_entry_point", shaders[0].GetEntryPoint());
 }
 

--- a/src/amberscript/parser_pipeline_test.cc
+++ b/src/amberscript/parser_pipeline_test.cc
@@ -52,13 +52,13 @@ END
 
   ASSERT_TRUE(shaders[0].GetShader() != nullptr);
   EXPECT_EQ("my_shader", shaders[0].GetShader()->GetName());
-  EXPECT_EQ(kShaderTypeVertex, shaders[0].GetShader()->GetType());
+  EXPECT_EQ(ShaderType::kVertex, shaders[0].GetShader()->GetType());
   EXPECT_EQ(static_cast<uint32_t>(0),
             shaders[0].GetShaderOptimizations().size());
 
   ASSERT_TRUE(shaders[1].GetShader() != nullptr);
   EXPECT_EQ("my_fragment", shaders[1].GetShader()->GetName());
-  EXPECT_EQ(kShaderTypeFragment, shaders[1].GetShader()->GetType());
+  EXPECT_EQ(ShaderType::kFragment, shaders[1].GetShader()->GetType());
   EXPECT_EQ(static_cast<uint32_t>(0),
             shaders[1].GetShaderOptimizations().size());
 

--- a/src/amberscript/parser_shader_opt_test.cc
+++ b/src/amberscript/parser_shader_opt_test.cc
@@ -61,17 +61,17 @@ END
   ASSERT_EQ(3U, shaders.size());
 
   ASSERT_TRUE(shaders[0].GetShader() != nullptr);
-  EXPECT_EQ(kShaderTypeVertex, shaders[0].GetShader()->GetType());
+  EXPECT_EQ(ShaderType::kVertex, shaders[0].GetShader()->GetType());
   std::vector<std::string> my_shader_opts = {"opt1", "opt_second"};
   EXPECT_EQ(my_shader_opts, shaders[0].GetShaderOptimizations());
 
   ASSERT_TRUE(shaders[1].GetShader() != nullptr);
-  EXPECT_EQ(kShaderTypeFragment, shaders[1].GetShader()->GetType());
+  EXPECT_EQ(ShaderType::kFragment, shaders[1].GetShader()->GetType());
   std::vector<std::string> my_fragment_opts = {"another_optimization", "third"};
   EXPECT_EQ(my_fragment_opts, shaders[1].GetShaderOptimizations());
 
   ASSERT_TRUE(shaders[2].GetShader() != nullptr);
-  EXPECT_EQ(kShaderTypeGeometry, shaders[2].GetShader()->GetType());
+  EXPECT_EQ(ShaderType::kGeometry, shaders[2].GetShader()->GetType());
   std::vector<std::string> my_geom_opts = {};
   EXPECT_EQ(my_geom_opts, shaders[2].GetShaderOptimizations());
 }

--- a/src/amberscript/parser_shader_test.cc
+++ b/src/amberscript/parser_shader_test.cc
@@ -34,8 +34,8 @@ TEST_F(AmberScriptParserTest, ShaderPassThrough) {
 
   const auto* shader = shaders[0].get();
   EXPECT_EQ("my_shader1", shader->GetName());
-  EXPECT_EQ(kShaderTypeVertex, shader->GetType());
-  EXPECT_EQ(kShaderFormatSpirvAsm, shader->GetFormat());
+  EXPECT_EQ(ShaderType::kVertex, shader->GetType());
+  EXPECT_EQ(ShaderFormat::kSpirvAsm, shader->GetFormat());
   EXPECT_EQ(kPassThroughShader, shader->GetData());
 }
 
@@ -145,8 +145,8 @@ SHADER geometry shader_name GLSL
 
   const auto* shader = shaders[0].get();
   EXPECT_EQ("shader_name", shader->GetName());
-  EXPECT_EQ(kShaderTypeGeometry, shader->GetType());
-  EXPECT_EQ(kShaderFormatGlsl, shader->GetFormat());
+  EXPECT_EQ(ShaderType::kGeometry, shader->GetType());
+  EXPECT_EQ(ShaderFormat::kGlsl, shader->GetFormat());
   EXPECT_EQ(shader_result, shader->GetData());
 }
 
@@ -363,22 +363,23 @@ void main() {
   const auto* shader = shaders[0].get();
   EXPECT_EQ("my_shader", shader->GetName());
   EXPECT_EQ(test_data.type, shader->GetType());
-  EXPECT_EQ(kShaderFormatGlsl, shader->GetFormat());
+  EXPECT_EQ(ShaderFormat::kGlsl, shader->GetFormat());
   EXPECT_EQ(shader_result, shader->GetData());
 }
 INSTANTIATE_TEST_SUITE_P(
     AmberScriptParserTestsShaderType,
     AmberScriptParserShaderTypeTest,
-    testing::Values(
-        ShaderTypeData{"vertex", kShaderTypeVertex},
-        ShaderTypeData{"fragment", kShaderTypeFragment},
-        ShaderTypeData{"geometry", kShaderTypeGeometry},
-        ShaderTypeData{"tessellation_evaluation",
-                       kShaderTypeTessellationEvaluation},
-        ShaderTypeData{"tessellation_control", kShaderTypeTessellationControl},
-        ShaderTypeData{"compute", kShaderTypeCompute},
-        ShaderTypeData{"multi",
-                       kShaderTypeMulti}));  // NOLINT(whitespace/parens)
+    testing::Values(ShaderTypeData{"vertex", ShaderType::kVertex},
+                    ShaderTypeData{"fragment", ShaderType::kFragment},
+                    ShaderTypeData{"geometry", ShaderType::kGeometry},
+                    ShaderTypeData{"tessellation_evaluation",
+                                   ShaderType::kTessellationEvaluation},
+                    ShaderTypeData{"tessellation_control",
+                                   ShaderType::kTessellationControl},
+                    ShaderTypeData{"compute", ShaderType::kCompute},
+                    ShaderTypeData{
+                        "multi",
+                        ShaderType::kMulti}));  // NOLINT(whitespace/parens)
 
 struct ShaderFormatData {
   const char* name;
@@ -408,7 +409,7 @@ TEST_P(AmberScriptParserShaderFormatTest, ShaderFormats) {
 
   const auto* shader = shaders[0].get();
   EXPECT_EQ("my_shader", shader->GetName());
-  EXPECT_EQ(kShaderTypeVertex, shader->GetType());
+  EXPECT_EQ(ShaderType::kVertex, shader->GetType());
   EXPECT_EQ(test_data.format, shader->GetFormat());
   EXPECT_EQ(shader_result, shader->GetData());
 }
@@ -416,11 +417,12 @@ TEST_P(AmberScriptParserShaderFormatTest, ShaderFormats) {
 INSTANTIATE_TEST_SUITE_P(
     AmberScriptParserTestsShaderFormat,
     AmberScriptParserShaderFormatTest,
-    testing::Values(ShaderFormatData{"GLSL", kShaderFormatGlsl},
-                    ShaderFormatData{"SPIRV-ASM", kShaderFormatSpirvAsm},
-                    ShaderFormatData{
-                        "SPIRV-HEX",
-                        kShaderFormatSpirvHex}));  // NOLINT(whitespace/parens)
+    testing::Values(
+        ShaderFormatData{"GLSL", ShaderFormat::kGlsl},
+        ShaderFormatData{"SPIRV-ASM", ShaderFormat::kSpirvAsm},
+        ShaderFormatData{
+            "SPIRV-HEX",
+            ShaderFormat::kSpirvHex}));  // NOLINT(whitespace/parens)
 
 TEST_F(AmberScriptParserTest, DuplicateShaderName) {
   std::string in = R"(

--- a/src/command.h
+++ b/src/command.h
@@ -697,7 +697,7 @@ class EntryPointCommand : public PipelineCommand {
   std::string ToString() const override { return "EntryPointCommand"; }
 
  private:
-  ShaderType shader_type_ = kShaderTypeVertex;
+  ShaderType shader_type_ = ShaderType::kVertex;
   std::string entry_point_name_;
 };
 

--- a/src/dawn/engine_dawn.cc
+++ b/src/dawn/engine_dawn.cc
@@ -827,7 +827,7 @@ Result EngineDawn::CreatePipeline(::amber::Pipeline* pipeline) {
 
   switch (pipeline->GetType()) {
     case PipelineType::kCompute: {
-      auto& module = module_for_type[kShaderTypeCompute];
+      auto& module = module_for_type[ShaderType::kCompute];
       if (!module) {
         return Result("Dawn::CreatePipeline: no compute shader provided");
       }
@@ -844,8 +844,8 @@ Result EngineDawn::CreatePipeline(::amber::Pipeline* pipeline) {
 
     case PipelineType::kGraphics: {
       // TODO(dneto): Handle other shader types as well.  They are optional.
-      auto& vs = module_for_type[kShaderTypeVertex];
-      auto& fs = module_for_type[kShaderTypeFragment];
+      auto& vs = module_for_type[ShaderType::kVertex];
+      auto& fs = module_for_type[ShaderType::kFragment];
       if (!vs) {
         return Result(
             "Dawn::CreatePipeline: no vertex shader provided for graphics "
@@ -987,9 +987,9 @@ Result DawnPipelineHelper::CreateRenderPipelineDescriptor(
 
   // Lookup shaders' entrypoints
   for (const auto& shader_info : render_pipeline.pipeline->GetShaders()) {
-    if (shader_info.GetShaderType() == kShaderTypeVertex) {
+    if (shader_info.GetShaderType() == ShaderType::kVertex) {
       vertexEntryPoint = shader_info.GetEntryPoint();
-    } else if (shader_info.GetShaderType() == kShaderTypeFragment) {
+    } else if (shader_info.GetShaderType() == ShaderType::kFragment) {
       fragmentEntryPoint = shader_info.GetEntryPoint();
     } else {
       return Result(

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -93,11 +93,11 @@ Result Pipeline::AddShader(Shader* shader, ShaderType shader_type) {
   }
 
   if (pipeline_type_ == PipelineType::kCompute &&
-      shader_type != kShaderTypeCompute) {
+      shader_type != ShaderType::kCompute) {
     return Result("only compute shaders allowed in a compute pipeline");
   }
   if (pipeline_type_ == PipelineType::kGraphics &&
-      shader_type == kShaderTypeCompute) {
+      shader_type == ShaderType::kCompute) {
     return Result("can not add a compute shader to a graphics pipeline");
   }
 
@@ -332,7 +332,7 @@ Result Pipeline::ValidateGraphics() const {
   bool found_vertex = false;
   for (const auto& info : shaders_) {
     const auto* s = info.GetShader();
-    if (s->GetType() == kShaderTypeVertex) {
+    if (s->GetType() == ShaderType::kVertex) {
       found_vertex = true;
       break;
     }
@@ -716,7 +716,7 @@ void Pipeline::ClearSamplers(uint32_t descriptor_set, uint32_t binding) {
 
 Result Pipeline::UpdateOpenCLBufferBindings() {
   if (!IsCompute() || GetShaders().empty() ||
-      GetShaders()[0].GetShader()->GetFormat() != kShaderFormatOpenCLC) {
+      GetShaders()[0].GetShader()->GetFormat() != ShaderFormat::kOpenCLC) {
     return {};
   }
 
@@ -818,7 +818,7 @@ Result Pipeline::UpdateOpenCLBufferBindings() {
 
 Result Pipeline::GenerateOpenCLPodBuffers() {
   if (!IsCompute() || GetShaders().empty() ||
-      GetShaders()[0].GetShader()->GetFormat() != kShaderFormatOpenCLC) {
+      GetShaders()[0].GetShader()->GetFormat() != ShaderFormat::kOpenCLC) {
     return {};
   }
 
@@ -1055,7 +1055,7 @@ Result Pipeline::GenerateOpenCLLiteralSamplers() {
 
 Result Pipeline::GenerateOpenCLPushConstants() {
   if (!IsCompute() || GetShaders().empty() ||
-      GetShaders()[0].GetShader()->GetFormat() != kShaderFormatOpenCLC) {
+      GetShaders()[0].GetShader()->GetFormat() != ShaderFormat::kOpenCLC) {
     return {};
   }
 

--- a/src/pipeline_test.cc
+++ b/src/pipeline_test.cc
@@ -56,14 +56,14 @@ class PipelineTest : public testing::Test {
 };
 
 TEST_F(PipelineTest, AddShader) {
-  Shader v(kShaderTypeVertex);
-  Shader f(kShaderTypeFragment);
+  Shader v(ShaderType::kVertex);
+  Shader f(ShaderType::kFragment);
 
   Pipeline p(PipelineType::kGraphics);
-  Result r = p.AddShader(&v, kShaderTypeVertex);
+  Result r = p.AddShader(&v, ShaderType::kVertex);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  r = p.AddShader(&f, kShaderTypeFragment);
+  r = p.AddShader(&f, ShaderType::kFragment);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
   const auto& shaders = p.GetShaders();
@@ -75,23 +75,23 @@ TEST_F(PipelineTest, AddShader) {
 
 TEST_F(PipelineTest, MissingShader) {
   Pipeline p(PipelineType::kGraphics);
-  Result r = p.AddShader(nullptr, kShaderTypeVertex);
+  Result r = p.AddShader(nullptr, ShaderType::kVertex);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("shader can not be null when attached to pipeline", r.Error());
 }
 
 TEST_F(PipelineTest, DuplicateShaders) {
-  Shader v(kShaderTypeVertex);
-  Shader f(kShaderTypeFragment);
+  Shader v(ShaderType::kVertex);
+  Shader f(ShaderType::kFragment);
 
   Pipeline p(PipelineType::kGraphics);
-  Result r = p.AddShader(&v, kShaderTypeVertex);
+  Result r = p.AddShader(&v, ShaderType::kVertex);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  r = p.AddShader(&f, kShaderTypeFragment);
+  r = p.AddShader(&f, ShaderType::kFragment);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  r = p.AddShader(&v, kShaderTypeVertex);
+  r = p.AddShader(&v, ShaderType::kVertex);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("can not add duplicate shader to pipeline", r.Error());
 }
@@ -113,31 +113,31 @@ INSTANTIATE_TEST_SUITE_P(
     AmberScriptPipelineComputePipelineTests,
     AmberScriptPipelineComputePipelineTest,
     testing::Values(
-        ShaderTypeData{kShaderTypeVertex},
-        ShaderTypeData{kShaderTypeFragment},
-        ShaderTypeData{kShaderTypeGeometry},
-        ShaderTypeData{kShaderTypeTessellationEvaluation},
+        ShaderTypeData{ShaderType::kVertex},
+        ShaderTypeData{ShaderType::kFragment},
+        ShaderTypeData{ShaderType::kGeometry},
+        ShaderTypeData{ShaderType::kTessellationEvaluation},
         ShaderTypeData{
-            kShaderTypeTessellationControl}));  // NOLINT(whitespace/parens)
+            ShaderType::kTessellationControl}));  // NOLINT(whitespace/parens)
 
 TEST_F(PipelineTest, SettingComputeShaderToGraphicsPipeline) {
-  Shader c(kShaderTypeCompute);
+  Shader c(ShaderType::kCompute);
 
   Pipeline p(PipelineType::kGraphics);
-  Result r = p.AddShader(&c, kShaderTypeCompute);
+  Result r = p.AddShader(&c, ShaderType::kCompute);
   ASSERT_FALSE(r.IsSuccess());
   EXPECT_EQ("can not add a compute shader to a graphics pipeline", r.Error());
 }
 
 TEST_F(PipelineTest, SetShaderOptimizations) {
-  Shader v(kShaderTypeVertex);
-  Shader f(kShaderTypeFragment);
+  Shader v(ShaderType::kVertex);
+  Shader f(ShaderType::kFragment);
 
   Pipeline p(PipelineType::kGraphics);
-  Result r = p.AddShader(&v, kShaderTypeVertex);
+  Result r = p.AddShader(&v, ShaderType::kVertex);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  r = p.AddShader(&f, kShaderTypeFragment);
+  r = p.AddShader(&f, ShaderType::kFragment);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
   std::vector<std::string> first = {"First", "Second"};
@@ -156,10 +156,10 @@ TEST_F(PipelineTest, SetShaderOptimizations) {
 }
 
 TEST_F(PipelineTest, DuplicateShaderOptimizations) {
-  Shader v(kShaderTypeVertex);
+  Shader v(ShaderType::kVertex);
 
   Pipeline p(PipelineType::kGraphics);
-  Result r = p.AddShader(&v, kShaderTypeVertex);
+  Result r = p.AddShader(&v, ShaderType::kVertex);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
   std::vector<std::string> data = {"One", "One"};
@@ -176,7 +176,7 @@ TEST_F(PipelineTest, SetOptimizationForMissingShader) {
 }
 
 TEST_F(PipelineTest, SetOptimizationForInvalidShader) {
-  Shader v(kShaderTypeVertex);
+  Shader v(ShaderType::kVertex);
   v.SetName("my_shader");
 
   Pipeline p(PipelineType::kGraphics);
@@ -195,21 +195,21 @@ TEST_F(PipelineTest, GraphicsPipelineRequiresColorAttachment) {
 }
 
 TEST_F(PipelineTest, GraphicsPipelineRequiresVertexAndFragmentShader) {
-  Shader v(kShaderTypeVertex);
-  Shader f(kShaderTypeFragment);
-  Shader g(kShaderTypeGeometry);
+  Shader v(ShaderType::kVertex);
+  Shader f(ShaderType::kFragment);
+  Shader g(ShaderType::kGeometry);
 
   Pipeline p(PipelineType::kGraphics);
   SetupColorAttachment(&p, 0);
   SetupDepthStencilAttachment(&p);
 
-  Result r = p.AddShader(&v, kShaderTypeVertex);
+  Result r = p.AddShader(&v, ShaderType::kVertex);
   EXPECT_TRUE(r.IsSuccess()) << r.Error();
 
-  r = p.AddShader(&g, kShaderTypeGeometry);
+  r = p.AddShader(&g, ShaderType::kGeometry);
   EXPECT_TRUE(r.IsSuccess()) << r.Error();
 
-  r = p.AddShader(&f, kShaderTypeFragment);
+  r = p.AddShader(&f, ShaderType::kFragment);
   EXPECT_TRUE(r.IsSuccess()) << r.Error();
 
   r = p.Validate();
@@ -217,17 +217,17 @@ TEST_F(PipelineTest, GraphicsPipelineRequiresVertexAndFragmentShader) {
 }
 
 TEST_F(PipelineTest, GraphicsPipelineMissingVertexShader) {
-  Shader f(kShaderTypeFragment);
-  Shader g(kShaderTypeGeometry);
+  Shader f(ShaderType::kFragment);
+  Shader g(ShaderType::kGeometry);
 
   Pipeline p(PipelineType::kGraphics);
   SetupColorAttachment(&p, 0);
   SetupDepthStencilAttachment(&p);
 
-  Result r = p.AddShader(&g, kShaderTypeGeometry);
+  Result r = p.AddShader(&g, ShaderType::kGeometry);
   EXPECT_TRUE(r.IsSuccess()) << r.Error();
 
-  r = p.AddShader(&f, kShaderTypeFragment);
+  r = p.AddShader(&f, ShaderType::kFragment);
   EXPECT_TRUE(r.IsSuccess()) << r.Error();
 
   r = p.Validate();
@@ -236,13 +236,13 @@ TEST_F(PipelineTest, GraphicsPipelineMissingVertexShader) {
 }
 
 TEST_F(PipelineTest, ComputePipelineRequiresComputeShader) {
-  Shader c(kShaderTypeCompute);
+  Shader c(ShaderType::kCompute);
 
   Pipeline p(PipelineType::kCompute);
   SetupColorAttachment(&p, 0);
   SetupDepthStencilAttachment(&p);
 
-  Result r = p.AddShader(&c, kShaderTypeCompute);
+  Result r = p.AddShader(&c, ShaderType::kCompute);
   EXPECT_TRUE(r.IsSuccess()) << r.Error();
 
   r = p.Validate();
@@ -272,7 +272,7 @@ TEST_F(PipelineTest, PipelineBufferWithoutFormat) {
 }
 
 TEST_F(PipelineTest, SetEntryPointForMissingShader) {
-  Shader c(kShaderTypeCompute);
+  Shader c(ShaderType::kCompute);
   c.SetName("my_shader");
 
   Pipeline p(PipelineType::kCompute);
@@ -289,9 +289,9 @@ TEST_F(PipelineTest, SetEntryPointForNullShader) {
 }
 
 TEST_F(PipelineTest, SetBlankEntryPoint) {
-  Shader c(kShaderTypeCompute);
+  Shader c(ShaderType::kCompute);
   Pipeline p(PipelineType::kCompute);
-  Result r = p.AddShader(&c, kShaderTypeCompute);
+  Result r = p.AddShader(&c, ShaderType::kCompute);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
   r = p.SetShaderEntryPoint(&c, "");
@@ -300,9 +300,9 @@ TEST_F(PipelineTest, SetBlankEntryPoint) {
 }
 
 TEST_F(PipelineTest, ShaderDefaultEntryPoint) {
-  Shader c(kShaderTypeCompute);
+  Shader c(ShaderType::kCompute);
   Pipeline p(PipelineType::kCompute);
-  Result r = p.AddShader(&c, kShaderTypeCompute);
+  Result r = p.AddShader(&c, ShaderType::kCompute);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
   const auto& shaders = p.GetShaders();
@@ -311,9 +311,9 @@ TEST_F(PipelineTest, ShaderDefaultEntryPoint) {
 }
 
 TEST_F(PipelineTest, SetShaderEntryPoint) {
-  Shader c(kShaderTypeCompute);
+  Shader c(ShaderType::kCompute);
   Pipeline p(PipelineType::kCompute);
-  Result r = p.AddShader(&c, kShaderTypeCompute);
+  Result r = p.AddShader(&c, ShaderType::kCompute);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
   r = p.SetShaderEntryPoint(&c, "my_main");
@@ -325,9 +325,9 @@ TEST_F(PipelineTest, SetShaderEntryPoint) {
 }
 
 TEST_F(PipelineTest, SetEntryPointMulitpleTimes) {
-  Shader c(kShaderTypeCompute);
+  Shader c(ShaderType::kCompute);
   Pipeline p(PipelineType::kCompute);
-  Result r = p.AddShader(&c, kShaderTypeCompute);
+  Result r = p.AddShader(&c, ShaderType::kCompute);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
   r = p.SetShaderEntryPoint(&c, "my_main");
@@ -347,10 +347,10 @@ TEST_F(PipelineTest, Clone) {
   SetupColorAttachment(&p, 0);
   SetupDepthStencilAttachment(&p);
 
-  Shader f(kShaderTypeFragment);
-  p.AddShader(&f, kShaderTypeFragment);
-  Shader v(kShaderTypeVertex);
-  p.AddShader(&v, kShaderTypeVertex);
+  Shader f(ShaderType::kFragment);
+  p.AddShader(&f, ShaderType::kFragment);
+  Shader v(ShaderType::kVertex);
+  p.AddShader(&v, ShaderType::kVertex);
   p.SetShaderEntryPoint(&v, "my_main");
 
   auto vtex_buf = MakeUnique<Buffer>();
@@ -380,8 +380,8 @@ TEST_F(PipelineTest, Clone) {
 
   auto shaders = clone->GetShaders();
   ASSERT_EQ(2U, shaders.size());
-  EXPECT_EQ(kShaderTypeFragment, shaders[0].GetShaderType());
-  EXPECT_EQ(kShaderTypeVertex, shaders[1].GetShaderType());
+  EXPECT_EQ(ShaderType::kFragment, shaders[0].GetShaderType());
+  EXPECT_EQ(ShaderType::kVertex, shaders[1].GetShaderType());
   EXPECT_EQ("my_main", shaders[1].GetEntryPoint());
 
   ASSERT_TRUE(clone->GetIndexBuffer() != nullptr);
@@ -417,9 +417,9 @@ TEST_F(PipelineTest, OpenCLUpdateBindings) {
   Pipeline p(PipelineType::kCompute);
   p.SetName("my_pipeline");
 
-  Shader cs(kShaderTypeCompute);
-  cs.SetFormat(kShaderFormatOpenCLC);
-  p.AddShader(&cs, kShaderTypeCompute);
+  Shader cs(ShaderType::kCompute);
+  cs.SetFormat(ShaderFormat::kOpenCLC);
+  p.AddShader(&cs, ShaderType::kCompute);
   p.SetShaderEntryPoint(&cs, "my_main");
 
   Pipeline::ShaderInfo::DescriptorMapEntry entry1;
@@ -462,9 +462,9 @@ TEST_F(PipelineTest, OpenCLUpdateBindingTypeMismatch) {
   Pipeline p(PipelineType::kCompute);
   p.SetName("my_pipeline");
 
-  Shader cs(kShaderTypeCompute);
-  cs.SetFormat(kShaderFormatOpenCLC);
-  p.AddShader(&cs, kShaderTypeCompute);
+  Shader cs(ShaderType::kCompute);
+  cs.SetFormat(ShaderFormat::kOpenCLC);
+  p.AddShader(&cs, ShaderType::kCompute);
   p.SetShaderEntryPoint(&cs, "my_main");
 
   Pipeline::ShaderInfo::DescriptorMapEntry entry1;
@@ -501,9 +501,9 @@ TEST_F(PipelineTest, OpenCLUpdateBindingImagesAndSamplers) {
   Pipeline p(PipelineType::kCompute);
   p.SetName("my_pipeline");
 
-  Shader cs(kShaderTypeCompute);
-  cs.SetFormat(kShaderFormatOpenCLC);
-  p.AddShader(&cs, kShaderTypeCompute);
+  Shader cs(ShaderType::kCompute);
+  cs.SetFormat(ShaderFormat::kOpenCLC);
+  p.AddShader(&cs, ShaderType::kCompute);
   p.SetShaderEntryPoint(&cs, "my_main");
 
   Pipeline::ShaderInfo::DescriptorMapEntry entry1;
@@ -551,9 +551,9 @@ TEST_F(PipelineTest, OpenCLGeneratePodBuffers) {
   Pipeline p(PipelineType::kCompute);
   p.SetName("my_pipeline");
 
-  Shader cs(kShaderTypeCompute);
-  cs.SetFormat(kShaderFormatOpenCLC);
-  p.AddShader(&cs, kShaderTypeCompute);
+  Shader cs(ShaderType::kCompute);
+  cs.SetFormat(ShaderFormat::kOpenCLC);
+  p.AddShader(&cs, ShaderType::kCompute);
   p.SetShaderEntryPoint(&cs, "my_main");
 
   // Descriptor map.
@@ -637,9 +637,9 @@ TEST_F(PipelineTest, OpenCLGeneratePodBuffersBadName) {
   Pipeline p(PipelineType::kCompute);
   p.SetName("my_pipeline");
 
-  Shader cs(kShaderTypeCompute);
-  cs.SetFormat(kShaderFormatOpenCLC);
-  p.AddShader(&cs, kShaderTypeCompute);
+  Shader cs(ShaderType::kCompute);
+  cs.SetFormat(ShaderFormat::kOpenCLC);
+  p.AddShader(&cs, ShaderType::kCompute);
   p.SetShaderEntryPoint(&cs, "my_main");
 
   // Descriptor map.
@@ -680,9 +680,9 @@ TEST_F(PipelineTest, OpenCLGeneratePodBuffersBadSize) {
   Pipeline p(PipelineType::kCompute);
   p.SetName("my_pipeline");
 
-  Shader cs(kShaderTypeCompute);
-  cs.SetFormat(kShaderFormatOpenCLC);
-  p.AddShader(&cs, kShaderTypeCompute);
+  Shader cs(ShaderType::kCompute);
+  cs.SetFormat(ShaderFormat::kOpenCLC);
+  p.AddShader(&cs, ShaderType::kCompute);
   p.SetShaderEntryPoint(&cs, "my_main");
 
   // Descriptor map.
@@ -721,9 +721,9 @@ TEST_F(PipelineTest, OpenCLClone) {
   Pipeline p(PipelineType::kCompute);
   p.SetName("my_pipeline");
 
-  Shader cs(kShaderTypeCompute);
-  cs.SetFormat(kShaderFormatOpenCLC);
-  p.AddShader(&cs, kShaderTypeCompute);
+  Shader cs(ShaderType::kCompute);
+  cs.SetFormat(ShaderFormat::kOpenCLC);
+  p.AddShader(&cs, ShaderType::kCompute);
   p.SetShaderEntryPoint(&cs, "my_main");
 
   // Descriptor map.
@@ -841,9 +841,9 @@ TEST_F(PipelineTest, OpenCLGeneratePushConstants) {
   Pipeline p(PipelineType::kCompute);
   p.SetName("my_pipeline");
 
-  Shader cs(kShaderTypeCompute);
-  cs.SetFormat(kShaderFormatOpenCLC);
-  p.AddShader(&cs, kShaderTypeCompute);
+  Shader cs(ShaderType::kCompute);
+  cs.SetFormat(ShaderFormat::kOpenCLC);
+  p.AddShader(&cs, ShaderType::kCompute);
   p.SetShaderEntryPoint(&cs, "my_main");
 
   Pipeline::ShaderInfo::PushConstant pc1;
@@ -876,9 +876,9 @@ TEST_F(PipelineTest, OpenCLPodPushConstants) {
   Pipeline p(PipelineType::kCompute);
   p.SetName("my_pipeline");
 
-  Shader cs(kShaderTypeCompute);
-  cs.SetFormat(kShaderFormatOpenCLC);
-  p.AddShader(&cs, kShaderTypeCompute);
+  Shader cs(ShaderType::kCompute);
+  cs.SetFormat(ShaderFormat::kOpenCLC);
+  p.AddShader(&cs, ShaderType::kCompute);
   p.SetShaderEntryPoint(&cs, "my_main");
 
   // Descriptor map.

--- a/src/script_test.cc
+++ b/src/script_test.cc
@@ -34,20 +34,20 @@ TEST_F(ScriptTest, GetShaderInfo) {
   Result r = s.AddPipeline(std::move(p));
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto shader = MakeUnique<Shader>(kShaderTypeVertex);
-  r = pipeline->AddShader(shader.get(), ShaderType::kShaderTypeVertex);
+  auto shader = MakeUnique<Shader>(ShaderType::kVertex);
+  r = pipeline->AddShader(shader.get(), ShaderType::kVertex);
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
   pipeline->SetShaderOptimizations(shader.get(), {"opt1", "opt2"});
 
   shader->SetName("Shader1");
-  shader->SetFormat(kShaderFormatGlsl);
+  shader->SetFormat(ShaderFormat::kGlsl);
   shader->SetData("This is my shader data");
   s.AddShader(std::move(shader));
 
-  shader = MakeUnique<Shader>(kShaderTypeFragment);
+  shader = MakeUnique<Shader>(ShaderType::kFragment);
   shader->SetName("Shader2");
-  shader->SetFormat(kShaderFormatSpirvAsm);
+  shader->SetFormat(ShaderFormat::kSpirvAsm);
   shader->SetData("More shader data");
   s.AddShader(std::move(shader));
 
@@ -55,16 +55,16 @@ TEST_F(ScriptTest, GetShaderInfo) {
   ASSERT_EQ(2U, info.size());
 
   EXPECT_EQ("my_pipeline-Shader1", info[0].shader_name);
-  EXPECT_EQ(kShaderFormatGlsl, info[0].format);
-  EXPECT_EQ(kShaderTypeVertex, info[0].type);
+  EXPECT_EQ(ShaderFormat::kGlsl, info[0].format);
+  EXPECT_EQ(ShaderType::kVertex, info[0].type);
   EXPECT_EQ("This is my shader data", info[0].shader_source);
   ASSERT_EQ(2u, info[0].optimizations.size());
   EXPECT_EQ("opt1", info[0].optimizations[0]);
   EXPECT_EQ("opt2", info[0].optimizations[1]);
 
   EXPECT_EQ("Shader2", info[1].shader_name);
-  EXPECT_EQ(kShaderFormatSpirvAsm, info[1].format);
-  EXPECT_EQ(kShaderTypeFragment, info[1].type);
+  EXPECT_EQ(ShaderFormat::kSpirvAsm, info[1].format);
+  EXPECT_EQ(ShaderType::kFragment, info[1].type);
   EXPECT_EQ("More shader data", info[1].shader_source);
   EXPECT_TRUE(info[1].optimizations.empty());
 }
@@ -76,7 +76,7 @@ TEST_F(ScriptTest, GetShaderInfoNoShaders) {
 }
 
 TEST_F(ScriptTest, AddShader) {
-  auto shader = MakeUnique<Shader>(kShaderTypeVertex);
+  auto shader = MakeUnique<Shader>(ShaderType::kVertex);
   shader->SetName("My Shader");
 
   Script s;
@@ -85,14 +85,14 @@ TEST_F(ScriptTest, AddShader) {
 }
 
 TEST_F(ScriptTest, AddDuplicateShader) {
-  auto shader1 = MakeUnique<Shader>(kShaderTypeVertex);
+  auto shader1 = MakeUnique<Shader>(ShaderType::kVertex);
   shader1->SetName("My Shader");
 
   Script s;
   Result r = s.AddShader(std::move(shader1));
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto shader2 = MakeUnique<Shader>(kShaderTypeFragment);
+  auto shader2 = MakeUnique<Shader>(ShaderType::kFragment);
   shader2->SetName("My Shader");
 
   r = s.AddShader(std::move(shader2));
@@ -101,7 +101,7 @@ TEST_F(ScriptTest, AddDuplicateShader) {
 }
 
 TEST_F(ScriptTest, GetShader) {
-  auto shader = MakeUnique<Shader>(kShaderTypeVertex);
+  auto shader = MakeUnique<Shader>(ShaderType::kVertex);
   shader->SetName("My Shader");
 
   auto* ptr = shader.get();
@@ -125,7 +125,7 @@ TEST_F(ScriptTest, GetShadersEmpty) {
 }
 
 TEST_F(ScriptTest, GetShaders) {
-  auto shader1 = MakeUnique<Shader>(kShaderTypeVertex);
+  auto shader1 = MakeUnique<Shader>(ShaderType::kVertex);
   shader1->SetName("My Shader");
 
   const auto* ptr1 = shader1.get();
@@ -134,7 +134,7 @@ TEST_F(ScriptTest, GetShaders) {
   Result r = s.AddShader(std::move(shader1));
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
 
-  auto shader2 = MakeUnique<Shader>(kShaderTypeFragment);
+  auto shader2 = MakeUnique<Shader>(ShaderType::kFragment);
   shader2->SetName("My Fragment");
 
   const auto* ptr2 = shader2.get();

--- a/src/shader_compiler_test.cc
+++ b/src/shader_compiler_test.cc
@@ -99,15 +99,15 @@ void main() {
   gl_Position = position;
 })";
 
-  Shader shader(kShaderTypeVertex);
+  Shader shader(ShaderType::kVertex);
   shader.SetName("TestShader");
-  shader.SetFormat(kShaderFormatGlsl);
+  shader.SetFormat(ShaderFormat::kGlsl);
   shader.SetData(contents);
 
   ShaderCompiler sc;
   Result r;
   std::vector<uint32_t> binary;
-  Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
+  Pipeline::ShaderInfo shader_info(&shader, ShaderType::kCompute);
   Pipeline pipeline(PipelineType::kCompute);
   std::tie(r, binary) = sc.Compile(&pipeline, &shader_info, ShaderMap());
   ASSERT_TRUE(r.IsSuccess()) << r.Error();
@@ -118,15 +118,15 @@ void main() {
 
 #if AMBER_ENABLE_SPIRV_TOOLS
 TEST_F(ShaderCompilerTest, CompilesSpirvAsm) {
-  Shader shader(kShaderTypeVertex);
+  Shader shader(ShaderType::kVertex);
   shader.SetName("TestShader");
-  shader.SetFormat(kShaderFormatSpirvAsm);
+  shader.SetFormat(ShaderFormat::kSpirvAsm);
   shader.SetData(kPassThroughShader);
 
   ShaderCompiler sc;
   Result r;
   std::vector<uint32_t> binary;
-  Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
+  Pipeline::ShaderInfo shader_info(&shader, ShaderType::kCompute);
   Pipeline pipeline(PipelineType::kCompute);
   std::tie(r, binary) = sc.Compile(&pipeline, &shader_info, ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
@@ -138,15 +138,15 @@ TEST_F(ShaderCompilerTest, InvalidSpirvHex) {
   std::string contents = kHexShader;
   contents[3] = '0';
 
-  Shader shader(kShaderTypeVertex);
+  Shader shader(ShaderType::kVertex);
   shader.SetName("BadTestShader");
-  shader.SetFormat(kShaderFormatSpirvHex);
+  shader.SetFormat(ShaderFormat::kSpirvHex);
   shader.SetData(contents);
 
   ShaderCompiler sc;
   Result r;
   std::vector<uint32_t> binary;
-  Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
+  Pipeline::ShaderInfo shader_info(&shader, ShaderType::kCompute);
   Pipeline pipeline(PipelineType::kCompute);
   std::tie(r, binary) = sc.Compile(&pipeline, &shader_info, ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
@@ -155,15 +155,15 @@ TEST_F(ShaderCompilerTest, InvalidSpirvHex) {
 }
 
 TEST_F(ShaderCompilerTest, InvalidHex) {
-  Shader shader(kShaderTypeVertex);
+  Shader shader(ShaderType::kVertex);
   shader.SetName("BadTestShader");
-  shader.SetFormat(kShaderFormatSpirvHex);
+  shader.SetFormat(ShaderFormat::kSpirvHex);
   shader.SetData("aaaaaaaaaa");
 
   ShaderCompiler sc;
   Result r;
   std::vector<uint32_t> binary;
-  Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
+  Pipeline::ShaderInfo shader_info(&shader, ShaderType::kCompute);
   Pipeline pipeline(PipelineType::kCompute);
   std::tie(r, binary) = sc.Compile(&pipeline, &shader_info, ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
@@ -204,13 +204,13 @@ OpReturn
 OpFunctionEnd
 )";
 
-  Shader shader(kShaderTypeCompute);
+  Shader shader(ShaderType::kCompute);
   shader.SetName("TestShader");
-  shader.SetFormat(kShaderFormatSpirvAsm);
+  shader.SetFormat(ShaderFormat::kSpirvAsm);
   shader.SetData(spirv);
 
-  Pipeline::ShaderInfo unoptimized(&shader, kShaderTypeCompute);
-  Pipeline::ShaderInfo optimized(&shader, kShaderTypeCompute);
+  Pipeline::ShaderInfo unoptimized(&shader, ShaderType::kCompute);
+  Pipeline::ShaderInfo optimized(&shader, ShaderType::kCompute);
   optimized.SetShaderOptimizations({"--eliminate-dead-code-aggressive"});
 
   ShaderCompiler sc;
@@ -228,15 +228,15 @@ OpFunctionEnd
 #endif  // AMBER_ENABLE_SPIRV_TOOLS
 
 TEST_F(ShaderCompilerTest, CompilesSpirvHex) {
-  Shader shader(kShaderTypeVertex);
+  Shader shader(ShaderType::kVertex);
   shader.SetName("TestShader");
-  shader.SetFormat(kShaderFormatSpirvHex);
+  shader.SetFormat(ShaderFormat::kSpirvHex);
   shader.SetData(kHexShader);
 
   ShaderCompiler sc;
   Result r;
   std::vector<uint32_t> binary;
-  Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
+  Pipeline::ShaderInfo shader_info(&shader, ShaderType::kCompute);
   Pipeline pipeline(PipelineType::kCompute);
   std::tie(r, binary) = sc.Compile(&pipeline, &shader_info, ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
@@ -247,15 +247,15 @@ TEST_F(ShaderCompilerTest, CompilesSpirvHex) {
 TEST_F(ShaderCompilerTest, FailsOnInvalidShader) {
   std::string contents = "Just Random\nText()\nThat doesn't work.";
 
-  Shader shader(kShaderTypeVertex);
+  Shader shader(ShaderType::kVertex);
   shader.SetName("BadTestShader");
-  shader.SetFormat(kShaderFormatGlsl);
+  shader.SetFormat(ShaderFormat::kGlsl);
   shader.SetData(contents);
 
   ShaderCompiler sc;
   Result r;
   std::vector<uint32_t> binary;
-  Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
+  Pipeline::ShaderInfo shader_info(&shader, ShaderType::kCompute);
   Pipeline pipeline(PipelineType::kCompute);
   std::tie(r, binary) = sc.Compile(&pipeline, &shader_info, ShaderMap());
   ASSERT_FALSE(r.IsSuccess());
@@ -268,9 +268,9 @@ TEST_F(ShaderCompilerTest, ReturnsCachedShader) {
 
   static const char kShaderName[] = "CachedShader";
   static const char kShaderNameWithPipeline[] = "pipeline-CachedShader";
-  Shader shader(kShaderTypeVertex);
+  Shader shader(ShaderType::kVertex);
   shader.SetName(kShaderName);
-  shader.SetFormat(kShaderFormatGlsl);
+  shader.SetFormat(ShaderFormat::kGlsl);
   shader.SetData(contents);
 
   std::vector<uint32_t> src_bytes = {1, 2, 3, 4, 5};
@@ -281,7 +281,7 @@ TEST_F(ShaderCompilerTest, ReturnsCachedShader) {
   ShaderCompiler sc;
   Result r;
   std::vector<uint32_t> binary;
-  Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
+  Pipeline::ShaderInfo shader_info(&shader, ShaderType::kCompute);
   Pipeline pipeline(PipelineType::kCompute);
   pipeline.SetName("pipeline");
   std::tie(r, binary) = sc.Compile(&pipeline, &shader_info, map);
@@ -295,9 +295,9 @@ TEST_F(ShaderCompilerTest, ReturnsCachedShader) {
 
 #if AMBER_ENABLE_CLSPV
 TEST_F(ShaderCompilerTest, ClspvCompile) {
-  Shader shader(kShaderTypeCompute);
+  Shader shader(ShaderType::kCompute);
   shader.SetName("TestShader");
-  shader.SetFormat(kShaderFormatOpenCLC);
+  shader.SetFormat(ShaderFormat::kOpenCLC);
   shader.SetData(R"(
 kernel void TestShader(global int* in, global int* out) {
   *out = *in;
@@ -307,7 +307,7 @@ kernel void TestShader(global int* in, global int* out) {
   ShaderCompiler sc;
   Result r;
   std::vector<uint32_t> binary;
-  Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
+  Pipeline::ShaderInfo shader_info(&shader, ShaderType::kCompute);
   Pipeline pipeline(PipelineType::kCompute);
   std::tie(r, binary) = sc.Compile(&pipeline, &shader_info, ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
@@ -316,10 +316,10 @@ kernel void TestShader(global int* in, global int* out) {
 }
 
 TEST_F(ShaderCompilerTest, ClspvDisallowCaching) {
-  Shader shader(kShaderTypeCompute);
+  Shader shader(ShaderType::kCompute);
   std::string name = "TestShader";
   shader.SetName(name);
-  shader.SetFormat(kShaderFormatOpenCLC);
+  shader.SetFormat(ShaderFormat::kOpenCLC);
   shader.SetData(R"(
 kernel void TestShader(global int* in, global int* out) {
   *out = *in;
@@ -334,7 +334,7 @@ kernel void TestShader(global int* in, global int* out) {
   ShaderCompiler sc;
   Result r;
   std::vector<uint32_t> binary;
-  Pipeline::ShaderInfo shader_info(&shader, kShaderTypeCompute);
+  Pipeline::ShaderInfo shader_info(&shader, ShaderType::kCompute);
   Pipeline pipeline(PipelineType::kCompute);
   std::tie(r, binary) = sc.Compile(&pipeline, &shader_info, map);
   ASSERT_FALSE(r.IsSuccess());
@@ -347,15 +347,15 @@ kernel void TestShader(global int* in, global int* out, int m, int b) {
   *out = *in * m + b;
 }
 )";
-  Shader shader(kShaderTypeCompute);
+  Shader shader(ShaderType::kCompute);
   shader.SetName("TestShader");
-  shader.SetFormat(kShaderFormatOpenCLC);
+  shader.SetFormat(ShaderFormat::kOpenCLC);
   shader.SetData(data);
 
   ShaderCompiler sc;
   Result r;
   std::vector<uint32_t> binary;
-  Pipeline::ShaderInfo shader_info1(&shader, kShaderTypeCompute);
+  Pipeline::ShaderInfo shader_info1(&shader, ShaderType::kCompute);
   shader_info1.SetCompileOptions({"-cluster-pod-kernel-args=0"});
   Pipeline pipeline(PipelineType::kCompute);
   std::tie(r, binary) = sc.Compile(&pipeline, &shader_info1, ShaderMap());
@@ -375,7 +375,7 @@ kernel void TestShader(global int* in, global int* out, int m, int b) {
   EXPECT_TRUE(has_pod_ubo);
 
   binary.clear();
-  Pipeline::ShaderInfo shader_info2(&shader, kShaderTypeCompute);
+  Pipeline::ShaderInfo shader_info2(&shader, ShaderType::kCompute);
   shader_info2.SetCompileOptions({"-cluster-pod-kernel-args", "-pod-ubo"});
   std::tie(r, binary) = sc.Compile(&pipeline, &shader_info2, ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
@@ -403,15 +403,15 @@ kernel void TestShader(read_only image2d_t ro_image, write_only image2d_t wo_ima
 }
 )";
 
-  Shader shader(kShaderTypeCompute);
+  Shader shader(ShaderType::kCompute);
   shader.SetName("TestShader");
-  shader.SetFormat(kShaderFormatOpenCLC);
+  shader.SetFormat(ShaderFormat::kOpenCLC);
   shader.SetData(data);
 
   ShaderCompiler sc;
   Result r;
   std::vector<uint32_t> binary;
-  Pipeline::ShaderInfo shader_info1(&shader, kShaderTypeCompute);
+  Pipeline::ShaderInfo shader_info1(&shader, ShaderType::kCompute);
   Pipeline pipeline(PipelineType::kCompute);
   std::tie(r, binary) = sc.Compile(&pipeline, &shader_info1, ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
@@ -447,15 +447,15 @@ kernel void foo(read_only image2d_t im, global float4* out) {
 
   Pipeline pipeline(PipelineType::kCompute);
   pipeline.SetName("pipe");
-  Shader shader(kShaderTypeCompute);
+  Shader shader(ShaderType::kCompute);
   shader.SetName("foo");
-  shader.SetFormat(kShaderFormatOpenCLC);
+  shader.SetFormat(ShaderFormat::kOpenCLC);
   shader.SetData(data);
 
   ShaderCompiler sc;
   Result r;
   std::vector<uint32_t> binary;
-  Pipeline::ShaderInfo shader_info1(&shader, kShaderTypeCompute);
+  Pipeline::ShaderInfo shader_info1(&shader, ShaderType::kCompute);
   std::tie(r, binary) = sc.Compile(&pipeline, &shader_info1, ShaderMap());
   ASSERT_TRUE(r.IsSuccess());
   EXPECT_FALSE(binary.empty());

--- a/src/vkscript/command_parser.cc
+++ b/src/vkscript/command_parser.cc
@@ -33,22 +33,22 @@ namespace {
 
 ShaderType ShaderNameToType(const std::string& name) {
   if (name == "fragment") {
-    return kShaderTypeFragment;
+    return ShaderType::kFragment;
   }
   if (name == "compute") {
-    return kShaderTypeCompute;
+    return ShaderType::kCompute;
   }
   if (name == "geometry") {
-    return kShaderTypeGeometry;
+    return ShaderType::kGeometry;
   }
   if (name == "tessellation evaluation") {
-    return kShaderTypeTessellationEvaluation;
+    return ShaderType::kTessellationEvaluation;
   }
   if (name == "tessellation control") {
-    return kShaderTypeTessellationControl;
+    return ShaderType::kTessellationControl;
   }
 
-  return kShaderTypeVertex;
+  return ShaderType::kVertex;
 }
 
 }  // namespace

--- a/src/vkscript/command_parser_test.cc
+++ b/src/vkscript/command_parser_test.cc
@@ -707,12 +707,12 @@ struct EntryInfo {
   ShaderType type;
 };
 static const EntryInfo kEntryPoints[] = {
-    {"vertex", kShaderTypeVertex},
-    {"fragment", kShaderTypeFragment},
-    {"geometry", kShaderTypeGeometry},
-    {"compute", kShaderTypeCompute},
-    {"tessellation evaluation", kShaderTypeTessellationEvaluation},
-    {"tessellation control", kShaderTypeTessellationControl},
+    {"vertex", ShaderType::kVertex},
+    {"fragment", ShaderType::kFragment},
+    {"geometry", ShaderType::kGeometry},
+    {"compute", ShaderType::kCompute},
+    {"tessellation evaluation", ShaderType::kTessellationEvaluation},
+    {"tessellation control", ShaderType::kTessellationControl},
 };
 
 TEST_F(CommandParserTest, EntryPoint) {

--- a/src/vkscript/parser.cc
+++ b/src/vkscript/parser.cc
@@ -84,7 +84,7 @@ Result Parser::GenerateDefaultPipeline(const SectionParser& section_parser) {
       continue;
     }
 
-    if (section.shader_type != kShaderTypeCompute) {
+    if (section.shader_type != ShaderType::kCompute) {
       pipeline_type = PipelineType::kGraphics;
       break;
     }

--- a/src/vkscript/section_parser.cc
+++ b/src/vkscript/section_parser.cc
@@ -50,17 +50,17 @@ Result SectionParser::NameToNodeType(const std::string& data,
   assert(shader_type);
   assert(fmt);
 
-  *fmt = kShaderFormatText;
+  *fmt = ShaderFormat::kText;
 
   std::string name;
   size_t pos = data.rfind(" spirv hex");
   if (pos != std::string::npos) {
-    *fmt = kShaderFormatSpirvHex;
+    *fmt = ShaderFormat::kSpirvHex;
     name = data.substr(0, pos);
   } else {
     pos = data.rfind(" spirv");
     if (pos != std::string::npos) {
-      *fmt = kShaderFormatSpirvAsm;
+      *fmt = ShaderFormat::kSpirvAsm;
       name = data.substr(0, pos);
     } else {
       name = data;
@@ -69,7 +69,7 @@ Result SectionParser::NameToNodeType(const std::string& data,
 
   pos = data.rfind(" passthrough");
   if (pos != std::string::npos) {
-    *fmt = kShaderFormatDefault;
+    *fmt = ShaderFormat::kDefault;
     name = data.substr(0, pos);
   }
 
@@ -85,47 +85,47 @@ Result SectionParser::NameToNodeType(const std::string& data,
     *section_type = NodeType::kVertexData;
   } else if (name == "compute shader") {
     *section_type = NodeType::kShader;
-    *shader_type = kShaderTypeCompute;
-    if (*fmt == kShaderFormatText) {
-      *fmt = kShaderFormatGlsl;
+    *shader_type = ShaderType::kCompute;
+    if (*fmt == ShaderFormat::kText) {
+      *fmt = ShaderFormat::kGlsl;
     }
   } else if (name == "fragment shader") {
     *section_type = NodeType::kShader;
-    *shader_type = kShaderTypeFragment;
-    if (*fmt == kShaderFormatText) {
-      *fmt = kShaderFormatGlsl;
+    *shader_type = ShaderType::kFragment;
+    if (*fmt == ShaderFormat::kText) {
+      *fmt = ShaderFormat::kGlsl;
     }
   } else if (name == "geometry shader") {
     *section_type = NodeType::kShader;
-    *shader_type = kShaderTypeGeometry;
-    if (*fmt == kShaderFormatText) {
-      *fmt = kShaderFormatGlsl;
+    *shader_type = ShaderType::kGeometry;
+    if (*fmt == ShaderFormat::kText) {
+      *fmt = ShaderFormat::kGlsl;
     }
   } else if (name == "tessellation control shader") {
     *section_type = NodeType::kShader;
-    *shader_type = kShaderTypeTessellationControl;
-    if (*fmt == kShaderFormatText) {
-      *fmt = kShaderFormatGlsl;
+    *shader_type = ShaderType::kTessellationControl;
+    if (*fmt == ShaderFormat::kText) {
+      *fmt = ShaderFormat::kGlsl;
     }
   } else if (name == "tessellation evaluation shader") {
     *section_type = NodeType::kShader;
-    *shader_type = kShaderTypeTessellationEvaluation;
-    if (*fmt == kShaderFormatText) {
-      *fmt = kShaderFormatGlsl;
+    *shader_type = ShaderType::kTessellationEvaluation;
+    if (*fmt == ShaderFormat::kText) {
+      *fmt = ShaderFormat::kGlsl;
     }
   } else if (name == "vertex shader") {
     *section_type = NodeType::kShader;
-    *shader_type = kShaderTypeVertex;
-    if (*fmt == kShaderFormatText) {
-      *fmt = kShaderFormatGlsl;
+    *shader_type = ShaderType::kVertex;
+    if (*fmt == ShaderFormat::kText) {
+      *fmt = ShaderFormat::kGlsl;
     }
   } else {
     return Result("Invalid name: " + data);
   }
 
   if (!SectionParser::HasShader(*section_type) &&
-      (*fmt == kShaderFormatGlsl || *fmt == kShaderFormatSpirvAsm ||
-       *fmt == kShaderFormatSpirvHex)) {
+      (*fmt == ShaderFormat::kGlsl || *fmt == ShaderFormat::kSpirvAsm ||
+       *fmt == ShaderFormat::kSpirvHex)) {
     return Result("Invalid source format: " + data);
   }
 
@@ -141,8 +141,8 @@ void SectionParser::AddSection(NodeType section_type,
     return;
   }
 
-  if (fmt == kShaderFormatDefault) {
-    sections_.push_back({section_type, shader_type, kShaderFormatSpirvAsm,
+  if (fmt == ShaderFormat::kDefault) {
+    sections_.push_back({section_type, shader_type, ShaderFormat::kSpirvAsm,
                          line_count, kPassThroughShader});
     return;
   }
@@ -167,8 +167,8 @@ Result SectionParser::SplitSections(const std::string& data) {
   bool in_section = false;
 
   NodeType current_type = NodeType::kComment;
-  ShaderType current_shader = kShaderTypeVertex;
-  ShaderFormat current_fmt = kShaderFormatText;
+  ShaderType current_shader = ShaderType::kVertex;
+  ShaderFormat current_fmt = ShaderFormat::kText;
   std::string section_contents;
 
   for (std::string line; std::getline(ss, line);) {

--- a/src/vkscript/section_parser_test.cc
+++ b/src/vkscript/section_parser_test.cc
@@ -46,8 +46,8 @@ void main() {
   auto sections = p.Sections();
   ASSERT_EQ(1U, sections.size());
   EXPECT_EQ(NodeType::kShader, sections[0].section_type);
-  EXPECT_EQ(kShaderTypeVertex, sections[0].shader_type);
-  EXPECT_EQ(kShaderFormatGlsl, sections[0].format);
+  EXPECT_EQ(ShaderType::kVertex, sections[0].shader_type);
+  EXPECT_EQ(ShaderFormat::kGlsl, sections[0].format);
   EXPECT_EQ(shader, sections[0].contents);
 }
 
@@ -61,8 +61,8 @@ TEST_F(SectionParserTest, ParseShaderGlslVertexPassthrough) {
   auto sections = p.Sections();
   ASSERT_EQ(1U, sections.size());
   EXPECT_EQ(NodeType::kShader, sections[0].section_type);
-  EXPECT_EQ(kShaderTypeVertex, sections[0].shader_type);
-  EXPECT_EQ(kShaderFormatSpirvAsm, sections[0].format);
+  EXPECT_EQ(ShaderType::kVertex, sections[0].shader_type);
+  EXPECT_EQ(ShaderFormat::kSpirvAsm, sections[0].format);
   EXPECT_EQ(kPassThroughShader, sections[0].contents);
 }
 
@@ -98,30 +98,30 @@ test body.)";
 
   // Passthrough vertext shader
   EXPECT_EQ(NodeType::kShader, sections[0].section_type);
-  EXPECT_EQ(kShaderTypeVertex, sections[0].shader_type);
-  EXPECT_EQ(kShaderFormatSpirvAsm, sections[0].format);
+  EXPECT_EQ(ShaderType::kVertex, sections[0].shader_type);
+  EXPECT_EQ(ShaderFormat::kSpirvAsm, sections[0].format);
   EXPECT_EQ(kPassThroughShader, sections[0].contents);
 
   // fragment shader
   EXPECT_EQ(NodeType::kShader, sections[1].section_type);
-  EXPECT_EQ(kShaderTypeFragment, sections[1].shader_type);
-  EXPECT_EQ(kShaderFormatGlsl, sections[1].format);
+  EXPECT_EQ(ShaderType::kFragment, sections[1].shader_type);
+  EXPECT_EQ(ShaderFormat::kGlsl, sections[1].format);
   EXPECT_EQ("#version 430\nvoid main() {}", sections[1].contents);
 
   // geometry shader
   EXPECT_EQ(NodeType::kShader, sections[2].section_type);
-  EXPECT_EQ(kShaderTypeGeometry, sections[2].shader_type);
-  EXPECT_EQ(kShaderFormatGlsl, sections[2].format);
+  EXPECT_EQ(ShaderType::kGeometry, sections[2].shader_type);
+  EXPECT_EQ(ShaderFormat::kGlsl, sections[2].format);
   EXPECT_EQ("float4 main() {}", sections[2].contents);
 
   // indices
   EXPECT_EQ(NodeType::kIndices, sections[3].section_type);
-  EXPECT_EQ(kShaderFormatText, sections[3].format);
+  EXPECT_EQ(ShaderFormat::kText, sections[3].format);
   EXPECT_EQ("1 2 3 4\n5 6 7 8", sections[3].contents);
 
   // test
   EXPECT_EQ(NodeType::kTest, sections[4].section_type);
-  EXPECT_EQ(kShaderFormatText, sections[4].format);
+  EXPECT_EQ(ShaderFormat::kText, sections[4].format);
   EXPECT_EQ("test body.", sections[4].contents);
 }
 
@@ -135,8 +135,8 @@ TEST_F(SectionParserTest, SkipCommentLinesOutsideSections) {
   auto sections = p.Sections();
   ASSERT_EQ(1U, sections.size());
   EXPECT_EQ(NodeType::kShader, sections[0].section_type);
-  EXPECT_EQ(kShaderTypeVertex, sections[0].shader_type);
-  EXPECT_EQ(kShaderFormatGlsl, sections[0].format);
+  EXPECT_EQ(ShaderType::kVertex, sections[0].shader_type);
+  EXPECT_EQ(ShaderFormat::kGlsl, sections[0].format);
   EXPECT_EQ("", sections[0].contents);
 }
 
@@ -150,8 +150,8 @@ TEST_F(SectionParserTest, SkipBlankLinesOutsideSections) {
   auto sections = p.Sections();
   ASSERT_EQ(1U, sections.size());
   EXPECT_EQ(NodeType::kShader, sections[0].section_type);
-  EXPECT_EQ(kShaderTypeVertex, sections[0].shader_type);
-  EXPECT_EQ(kShaderFormatGlsl, sections[0].format);
+  EXPECT_EQ(ShaderType::kVertex, sections[0].shader_type);
+  EXPECT_EQ(ShaderFormat::kGlsl, sections[0].format);
   EXPECT_EQ("", sections[0].contents);
 }
 
@@ -189,56 +189,56 @@ TEST_F(SectionParserTest, NameToNodeType) {
     ShaderType shader_type;
     ShaderFormat fmt;
   } name_cases[] = {
-      {"comment", NodeType::kComment, kShaderTypeVertex, kShaderFormatText},
-      {"indices", NodeType::kIndices, kShaderTypeVertex, kShaderFormatText},
-      {"require", NodeType::kRequire, kShaderTypeVertex, kShaderFormatText},
-      {"test", NodeType::kTest, kShaderTypeVertex, kShaderFormatText},
-      {"vertex data", NodeType::kVertexData, kShaderTypeVertex,
-       kShaderFormatText},
+      {"comment", NodeType::kComment, ShaderType::kVertex, ShaderFormat::kText},
+      {"indices", NodeType::kIndices, ShaderType::kVertex, ShaderFormat::kText},
+      {"require", NodeType::kRequire, ShaderType::kVertex, ShaderFormat::kText},
+      {"test", NodeType::kTest, ShaderType::kVertex, ShaderFormat::kText},
+      {"vertex data", NodeType::kVertexData, ShaderType::kVertex,
+       ShaderFormat::kText},
 
-      {"compute shader", NodeType::kShader, kShaderTypeCompute,
-       kShaderFormatGlsl},
-      {"fragment shader", NodeType::kShader, kShaderTypeFragment,
-       kShaderFormatGlsl},
-      {"geometry shader", NodeType::kShader, kShaderTypeGeometry,
-       kShaderFormatGlsl},
+      {"compute shader", NodeType::kShader, ShaderType::kCompute,
+       ShaderFormat::kGlsl},
+      {"fragment shader", NodeType::kShader, ShaderType::kFragment,
+       ShaderFormat::kGlsl},
+      {"geometry shader", NodeType::kShader, ShaderType::kGeometry,
+       ShaderFormat::kGlsl},
       {"tessellation control shader", NodeType::kShader,
-       kShaderTypeTessellationControl, kShaderFormatGlsl},
+       ShaderType::kTessellationControl, ShaderFormat::kGlsl},
       {"tessellation evaluation shader", NodeType::kShader,
-       kShaderTypeTessellationEvaluation, kShaderFormatGlsl},
-      {"vertex shader", NodeType::kShader, kShaderTypeVertex,
-       kShaderFormatGlsl},
-      {"compute shader spirv", NodeType::kShader, kShaderTypeCompute,
-       kShaderFormatSpirvAsm},
-      {"fragment shader spirv", NodeType::kShader, kShaderTypeFragment,
-       kShaderFormatSpirvAsm},
-      {"geometry shader spirv", NodeType::kShader, kShaderTypeGeometry,
-       kShaderFormatSpirvAsm},
+       ShaderType::kTessellationEvaluation, ShaderFormat::kGlsl},
+      {"vertex shader", NodeType::kShader, ShaderType::kVertex,
+       ShaderFormat::kGlsl},
+      {"compute shader spirv", NodeType::kShader, ShaderType::kCompute,
+       ShaderFormat::kSpirvAsm},
+      {"fragment shader spirv", NodeType::kShader, ShaderType::kFragment,
+       ShaderFormat::kSpirvAsm},
+      {"geometry shader spirv", NodeType::kShader, ShaderType::kGeometry,
+       ShaderFormat::kSpirvAsm},
       {"tessellation control shader spirv", NodeType::kShader,
-       kShaderTypeTessellationControl, kShaderFormatSpirvAsm},
+       ShaderType::kTessellationControl, ShaderFormat::kSpirvAsm},
       {"tessellation evaluation shader spirv", NodeType::kShader,
-       kShaderTypeTessellationEvaluation, kShaderFormatSpirvAsm},
-      {"vertex shader spirv", NodeType::kShader, kShaderTypeVertex,
-       kShaderFormatSpirvAsm},
-      {"compute shader spirv hex", NodeType::kShader, kShaderTypeCompute,
-       kShaderFormatSpirvHex},
-      {"fragment shader spirv hex", NodeType::kShader, kShaderTypeFragment,
-       kShaderFormatSpirvHex},
-      {"geometry shader spirv hex", NodeType::kShader, kShaderTypeGeometry,
-       kShaderFormatSpirvHex},
+       ShaderType::kTessellationEvaluation, ShaderFormat::kSpirvAsm},
+      {"vertex shader spirv", NodeType::kShader, ShaderType::kVertex,
+       ShaderFormat::kSpirvAsm},
+      {"compute shader spirv hex", NodeType::kShader, ShaderType::kCompute,
+       ShaderFormat::kSpirvHex},
+      {"fragment shader spirv hex", NodeType::kShader, ShaderType::kFragment,
+       ShaderFormat::kSpirvHex},
+      {"geometry shader spirv hex", NodeType::kShader, ShaderType::kGeometry,
+       ShaderFormat::kSpirvHex},
       {"tessellation control shader spirv hex", NodeType::kShader,
-       kShaderTypeTessellationControl, kShaderFormatSpirvHex},
+       ShaderType::kTessellationControl, ShaderFormat::kSpirvHex},
       {"tessellation evaluation shader spirv hex", NodeType::kShader,
-       kShaderTypeTessellationEvaluation, kShaderFormatSpirvHex},
-      {"vertex shader spirv hex", NodeType::kShader, kShaderTypeVertex,
-       kShaderFormatSpirvHex},
-      {"vertex shader passthrough", NodeType::kShader, kShaderTypeVertex,
-       kShaderFormatDefault}};
+       ShaderType::kTessellationEvaluation, ShaderFormat::kSpirvHex},
+      {"vertex shader spirv hex", NodeType::kShader, ShaderType::kVertex,
+       ShaderFormat::kSpirvHex},
+      {"vertex shader passthrough", NodeType::kShader, ShaderType::kVertex,
+       ShaderFormat::kDefault}};
 
   for (auto name_case : name_cases) {
     NodeType section_type = NodeType::kTest;
-    ShaderType shader_type = kShaderTypeVertex;
-    ShaderFormat fmt = kShaderFormatText;
+    ShaderType shader_type = ShaderType::kVertex;
+    ShaderFormat fmt = ShaderFormat::kText;
     SectionParser p;
     Result r = p.NameToNodeTypeForTesting(name_case.name, &section_type,
                                           &shader_type, &fmt);
@@ -252,8 +252,8 @@ TEST_F(SectionParserTest, NameToNodeType) {
 
 TEST_F(SectionParserTest, NameToNodeTypeInvalidName) {
   NodeType section_type = NodeType::kTest;
-  ShaderType shader_type = kShaderTypeVertex;
-  ShaderFormat fmt = kShaderFormatText;
+  ShaderType shader_type = ShaderType::kVertex;
+  ShaderFormat fmt = ShaderFormat::kText;
   SectionParser p;
   Result r = p.NameToNodeTypeForTesting("InvalidName", &section_type,
                                         &shader_type, &fmt);
@@ -272,8 +272,8 @@ TEST_F(SectionParserTest, NameToSectionInvalidSuffix) {
 
   for (auto name_case : cases) {
     NodeType section_type = NodeType::kTest;
-    ShaderType shader_type = kShaderTypeVertex;
-    ShaderFormat fmt = kShaderFormatText;
+    ShaderType shader_type = ShaderType::kVertex;
+    ShaderFormat fmt = ShaderFormat::kText;
     SectionParser p;
 
     Result r = p.NameToNodeTypeForTesting(name_case.name, &section_type,

--- a/src/vulkan/device.cc
+++ b/src/vulkan/device.cc
@@ -1635,22 +1635,22 @@ bool Device::IsRequiredSubgroupSizeSupported(
     const uint32_t required_subgroup_size) const {
   VkShaderStageFlagBits stage = {};
   switch (type) {
-    case kShaderTypeGeometry:
+    case ShaderType::kGeometry:
       stage = VK_SHADER_STAGE_GEOMETRY_BIT;
       break;
-    case kShaderTypeFragment:
+    case ShaderType::kFragment:
       stage = VK_SHADER_STAGE_FRAGMENT_BIT;
       break;
-    case kShaderTypeVertex:
+    case ShaderType::kVertex:
       stage = VK_SHADER_STAGE_VERTEX_BIT;
       break;
-    case kShaderTypeTessellationControl:
+    case ShaderType::kTessellationControl:
       stage = VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
       break;
-    case kShaderTypeTessellationEvaluation:
+    case ShaderType::kTessellationEvaluation:
       stage = VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
       break;
-    case kShaderTypeCompute:
+    case ShaderType::kCompute:
       stage = VK_SHADER_STAGE_COMPUTE_BIT;
       break;
     default:

--- a/src/vulkan/engine_vulkan.cc
+++ b/src/vulkan/engine_vulkan.cc
@@ -35,43 +35,43 @@ const uint32_t kVerticesPerTriangle = 3;
 
 Result ToVkShaderStage(ShaderType type, VkShaderStageFlagBits* ret) {
   switch (type) {
-    case kShaderTypeGeometry:
+    case ShaderType::kGeometry:
       *ret = VK_SHADER_STAGE_GEOMETRY_BIT;
       break;
-    case kShaderTypeFragment:
+    case ShaderType::kFragment:
       *ret = VK_SHADER_STAGE_FRAGMENT_BIT;
       break;
-    case kShaderTypeVertex:
+    case ShaderType::kVertex:
       *ret = VK_SHADER_STAGE_VERTEX_BIT;
       break;
-    case kShaderTypeTessellationControl:
+    case ShaderType::kTessellationControl:
       *ret = VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
       break;
-    case kShaderTypeTessellationEvaluation:
+    case ShaderType::kTessellationEvaluation:
       *ret = VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
       break;
-    case kShaderTypeRayGeneration:
+    case ShaderType::kRayGeneration:
       *ret = VK_SHADER_STAGE_RAYGEN_BIT_KHR;
       break;
-    case kShaderTypeAnyHit:
+    case ShaderType::kAnyHit:
       *ret = VK_SHADER_STAGE_ANY_HIT_BIT_KHR;
       break;
-    case kShaderTypeClosestHit:
+    case ShaderType::kClosestHit:
       *ret = VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR;
       break;
-    case kShaderTypeMiss:
+    case ShaderType::kMiss:
       *ret = VK_SHADER_STAGE_MISS_BIT_KHR;
       break;
-    case kShaderTypeIntersection:
+    case ShaderType::kIntersection:
       *ret = VK_SHADER_STAGE_INTERSECTION_BIT_KHR;
       break;
-    case kShaderTypeCall:
+    case ShaderType::kCall:
       *ret = VK_SHADER_STAGE_CALLABLE_BIT_KHR;
       break;
-    case kShaderTypeCompute:
+    case ShaderType::kCompute:
       *ret = VK_SHADER_STAGE_COMPUTE_BIT;
       break;
-    case kShaderTypeMulti:
+    case ShaderType::kMulti:
       *ret = VK_SHADER_STAGE_FRAGMENT_BIT;
       return Result("Vulkan::Unknown shader stage");
   }
@@ -525,7 +525,7 @@ Result EngineVulkan::GetVkShaderStageInfo(
         return r;
       }
 
-      if (it.first == kShaderTypeCompute &&
+      if (it.first == ShaderType::kCompute &&
           it.second.required_subgroup_size > 0) {
         VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT* pSubgroupSize =
             new VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT();


### PR DESCRIPTION
This CL changes the `enum` for both `ShaderFormat` and `ShaderType` into an `enum class` with a specific size of `uint8_t`. This makes the code a bit nicer to read, and allows checks for switch coverage.