### PR TITLE
Check depthClampZeroOne feature bit.

### DIFF
--- a/samples/config_helper_vulkan.cc
+++ b/samples/config_helper_vulkan.cc
@@ -1024,6 +1024,10 @@ amber::Result ConfigHelperVulkan::CheckVulkanPhysicalDeviceRequirements(
       supports_.ray_tracing_pipeline =
           ray_tracing_pipeline_features.rayTracingPipeline;
     }
+    if (supports_.depth_clamp_zero_one) {
+      supports_.depth_clamp_zero_one =
+          depth_clamp_zero_one_features.depthClampZeroOne;
+    }
 
     std::vector<std::string> required_features1;
     for (const auto& feature : required_features) {


### PR DESCRIPTION
The presence of the DepthClampZeroOne extension isn't enough to verify it's usable, the `depthClampZeroOne` feature flag also needs to be checked in the features structure.

Change-Id: Ic75a2375604d91251f19a10c539e3a5cb180f850