### PR TITLE
Fix missing #include <cstdint> causing build failures

### DIFF
--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -16,6 +16,7 @@
 #define SRC_TOKENIZER_H_
 
 #include <cstdlib>
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/src/type.h
+++ b/src/type.h
@@ -16,6 +16,7 @@
 #define SRC_TYPE_H_
 
 #include <cassert>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Tested on Fedora 42 with clang.

Fixes #1091