### PR TITLE
Fix naive memory barrier pipeline stages

### DIFF
--- a/src/vulkan/resource.cc
+++ b/src/vulkan/resource.cc
@@ -215,9 +215,10 @@ void Resource::MemoryBarrier(CommandBuffer* command_buffer) {
   // ReadOnly Descriptors          host w         shader r
   //                           transfer w       transfer r
   device_->GetPtrs()->vkCmdPipelineBarrier(
-      command_buffer->GetVkCommandBuffer(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-      VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 1, &kMemoryBarrierForAll, 0,
-      nullptr, 0, nullptr);
+      command_buffer->GetVkCommandBuffer(),
+      VK_PIPELINE_STAGE_ALL_COMMANDS_BIT | VK_PIPELINE_STAGE_HOST_BIT,
+      VK_PIPELINE_STAGE_ALL_COMMANDS_BIT | VK_PIPELINE_STAGE_HOST_BIT, 0, 1,
+      &kMemoryBarrierForAll, 0, nullptr, 0, nullptr);
 }
 
 }  // namespace vulkan


### PR DESCRIPTION
Host access masks are used, but VK_PIPELINE_STAGE_HOST_BIT is not provided. 

VK_PIPELINE_STAGE_ALL_COMMANDS_BIT  does not include VK_PIPELINE_STAGE_HOST_BIT