### PR TITLE
kokoro: linux uses clang-18

### DIFF
--- a/kokoro/linux-clang-debug/build.sh
+++ b/kokoro/linux-clang-debug/build.sh
@@ -17,5 +17,5 @@ set -e  # fail on error
 set -x  # display commands
 
 SCRIPT_DIR=`dirname "$BASH_SOURCE"`
-source $SCRIPT_DIR/../scripts/linux/build.sh DEBUG "clang-13.0.1" \
+source $SCRIPT_DIR/../scripts/linux/build.sh DEBUG "clang-18" \
     -DAMBER_ENABLE_SWIFTSHADER=TRUE

--- a/kokoro/linux-clang-release/build.sh
+++ b/kokoro/linux-clang-release/build.sh
@@ -17,6 +17,6 @@ set -e  # fail on error
 set -x  # display commands
 
 SCRIPT_DIR=`dirname "$BASH_SOURCE"`
-source $SCRIPT_DIR/../scripts/linux/build.sh RELEASE "clang-13.0.1" \
+source $SCRIPT_DIR/../scripts/linux/build.sh RELEASE "clang-18" \
     -DAMBER_ENABLE_SWIFTSHADER=TRUE \
     -DAMBER_USE_DXC=TRUE


### PR DESCRIPTION
Google-internal bug 393437270